### PR TITLE
Add runtime validation for initializer module augmentation

### DIFF
--- a/packages/keryx/__tests__/classes/API.test.ts
+++ b/packages/keryx/__tests__/classes/API.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { API, RUN_MODE } from "../../classes/API";
+import { Initializer } from "../../classes/Initializer";
+import { ErrorType, TypedError } from "../../classes/TypedError";
+
+class FakeInitializer extends Initializer {
+  returnValue: unknown;
+  startFn?: (api: API) => void | Promise<void>;
+
+  constructor(
+    name: string,
+    opts: {
+      returnValue?: unknown;
+      startFn?: (api: API) => void | Promise<void>;
+      declaresAPIProperty?: boolean;
+      runModes?: RUN_MODE[];
+    } = {},
+  ) {
+    super(name);
+    this.returnValue = opts.returnValue;
+    this.startFn = opts.startFn;
+    if (opts.declaresAPIProperty !== undefined) {
+      this.declaresAPIProperty = opts.declaresAPIProperty;
+    }
+    if (opts.runModes) this.runModes = opts.runModes;
+  }
+
+  async initialize() {
+    return this.returnValue;
+  }
+
+  async start() {
+    if (this.startFn) await this.startFn(api);
+  }
+}
+
+let api: API;
+
+/**
+ * Build an API instance whose `findInitializers` is replaced with a no-op, so
+ * tests have full control over which initializers participate in the lifecycle.
+ */
+function buildTestAPI(initializers: Initializer[] = []): API {
+  const testApi = new API();
+  (
+    testApi as unknown as { findInitializers: () => Promise<void> }
+  ).findInitializers = async () => {};
+  testApi.initializers = initializers;
+  return testApi;
+}
+
+describe("API.initialize validation", () => {
+  beforeEach(() => {
+    api = buildTestAPI();
+  });
+
+  test("passes when every initializer attaches its namespace", async () => {
+    api = buildTestAPI([
+      new FakeInitializer("alpha", { returnValue: { ok: true } }),
+      new FakeInitializer("beta", { returnValue: { ok: true } }),
+    ]);
+
+    await api.initialize();
+
+    expect(api.initialized).toBe(true);
+    expect(api.alpha).toEqual({ ok: true });
+    expect(api.beta).toEqual({ ok: true });
+  });
+
+  test("fails when an initializer returns undefined", async () => {
+    api = buildTestAPI([
+      new FakeInitializer("alpha", { returnValue: { ok: true } }),
+      new FakeInitializer("broken", { returnValue: undefined }),
+    ]);
+
+    let caught: unknown;
+    try {
+      await api.initialize();
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(TypedError);
+    const err = caught as TypedError;
+    expect(err.type).toBe(ErrorType.INITIALIZER_VALIDATION);
+    expect(err.message).toContain("broken");
+    expect(err.message).toContain("initialize phase");
+    expect(api.initialized).toBe(false);
+  });
+
+  test("fails when an initializer returns null", async () => {
+    api = buildTestAPI([new FakeInitializer("nully", { returnValue: null })]);
+
+    let caught: unknown;
+    try {
+      await api.initialize();
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(TypedError);
+    expect((caught as TypedError).type).toBe(ErrorType.INITIALIZER_VALIDATION);
+    expect((caught as TypedError).message).toContain("nully");
+  });
+
+  test("lists every missing initializer in a single error", async () => {
+    api = buildTestAPI([
+      new FakeInitializer("ok", { returnValue: { v: 1 } }),
+      new FakeInitializer("miss-a", { returnValue: undefined }),
+      new FakeInitializer("miss-b", { returnValue: undefined }),
+    ]);
+
+    let caught: unknown;
+    try {
+      await api.initialize();
+    } catch (e) {
+      caught = e;
+    }
+
+    const err = caught as TypedError;
+    expect(err.type).toBe(ErrorType.INITIALIZER_VALIDATION);
+    expect(err.message).toContain("miss-a");
+    expect(err.message).toContain("miss-b");
+  });
+
+  test("declaresAPIProperty = false skips validation", async () => {
+    api = buildTestAPI([
+      new FakeInitializer("skip-me", {
+        returnValue: undefined,
+        declaresAPIProperty: false,
+      }),
+    ]);
+
+    await api.initialize();
+
+    expect(api.initialized).toBe(true);
+    expect(api["skip-me"]).toBeUndefined();
+  });
+});
+
+describe("API.start validation", () => {
+  test("fails when start() leaves the namespace null", async () => {
+    api = buildTestAPI([
+      new FakeInitializer("late", {
+        returnValue: { placeholder: true },
+        startFn: (a) => {
+          a.late = null;
+        },
+      }),
+    ]);
+
+    let caught: unknown;
+    try {
+      await api.start();
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(TypedError);
+    const err = caught as TypedError;
+    expect(err.type).toBe(ErrorType.INITIALIZER_VALIDATION);
+    expect(err.message).toContain("late");
+    expect(err.message).toContain("start phase");
+    expect(api.started).toBe(false);
+  });
+
+  test("passes when start() populates a previously-empty container", async () => {
+    api = buildTestAPI([
+      new FakeInitializer("late", {
+        returnValue: {},
+        startFn: (a) => {
+          a.late = { connected: true };
+        },
+      }),
+    ]);
+
+    await api.start();
+
+    expect(api.started).toBe(true);
+    expect(api.late).toEqual({ connected: true });
+  });
+});
+
+describe("API.validateInitializerProperties (direct)", () => {
+  test("start phase skips initializers excluded from the active runMode", () => {
+    const testApi = buildTestAPI([
+      new FakeInitializer("cli-only", {
+        returnValue: undefined,
+        runModes: [RUN_MODE.CLI],
+      }),
+    ]);
+    testApi.runMode = RUN_MODE.SERVER;
+
+    // `api["cli-only"]` is undefined; without the runMode skip this would throw.
+    expect(() =>
+      // @ts-expect-error - accessing private method for unit testing
+      testApi.validateInitializerProperties("start"),
+    ).not.toThrow();
+  });
+
+  test("initialize phase validates ALL initializers regardless of runMode", () => {
+    const testApi = buildTestAPI([
+      new FakeInitializer("cli-only", {
+        returnValue: undefined,
+        runModes: [RUN_MODE.CLI],
+      }),
+    ]);
+    testApi.runMode = RUN_MODE.SERVER;
+
+    expect(() =>
+      // @ts-expect-error - accessing private method for unit testing
+      testApi.validateInitializerProperties("initialize"),
+    ).toThrowError(TypedError);
+  });
+});

--- a/packages/keryx/classes/API.ts
+++ b/packages/keryx/classes/API.ts
@@ -92,6 +92,8 @@ export class API {
       }
     }
 
+    this.validateInitializerProperties("initialize");
+
     this.initialized = true;
     this.logger.warn("--- 🔄  Initializing complete ---");
   }
@@ -137,6 +139,8 @@ export class API {
         });
       }
     }
+
+    this.validateInitializerProperties("start");
 
     this.started = true;
     this.logger.warn("--- 🔼  Starting complete ---");
@@ -271,5 +275,38 @@ export class API {
 
   private sortInitializers(key: InitializerSortKeys) {
     this.initializers.sort((a, b) => a[key] - b[key]);
+  }
+
+  /**
+   * Assert that every initializer which claims an API namespace (via
+   * `declaresAPIProperty`) has actually attached `api[initializer.name]`.
+   * Closes the silent-drift gap between TypeScript module augmentation
+   * and runtime property assignment — a missing namespace becomes a fast,
+   * loud startup failure instead of a confusing `Cannot read property of
+   * undefined` deep inside a request handler.
+   *
+   * Initializers excluded from the current `runMode` are skipped during the
+   * `start` phase since their `start()` method never ran.
+   */
+  private validateInitializerProperties(phase: "initialize" | "start") {
+    const missing: string[] = [];
+    for (const initializer of this.initializers) {
+      if (initializer.declaresAPIProperty === false) continue;
+      if (phase === "start" && !initializer.runModes.includes(this.runMode)) {
+        continue;
+      }
+      if (this[initializer.name] == null) {
+        missing.push(initializer.name);
+      }
+    }
+    if (missing.length > 0) {
+      throw new TypedError({
+        type: ErrorType.INITIALIZER_VALIDATION,
+        message:
+          `Initializers did not attach their namespace to api after the ${phase} phase: ` +
+          `${missing.join(", ")}. Each initializer must either return a namespace object ` +
+          `from initialize() (and/or populate it in start()), or set declaresAPIProperty = false.`,
+      });
+    }
   }
 }

--- a/packages/keryx/classes/Initializer.ts
+++ b/packages/keryx/classes/Initializer.ts
@@ -17,6 +17,13 @@ export abstract class Initializer {
   stopPriority: number;
   /** Which run modes this initializer participates in. Defaults to both SERVER and CLI. */
   runModes: RUN_MODE[];
+  /**
+   * Whether this initializer attaches a property named `this.name` on the `api` singleton.
+   * Runtime validation in `API.initialize()` and `API.start()` will fail if the declared
+   * property is missing. Default: `true`. Set to `false` for initializers that intentionally
+   * don't augment the `API` interface.
+   */
+  declaresAPIProperty: boolean;
 
   constructor(name: string) {
     this.name = name;
@@ -24,6 +31,7 @@ export abstract class Initializer {
     this.startPriority = 1000;
     this.stopPriority = 1000;
     this.runModes = [RUN_MODE.SERVER, RUN_MODE.CLI];
+    this.declaresAPIProperty = true;
   }
 
   /**

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Closes #346.

Initializers declare properties on `api` via TypeScript module augmentation, but nothing verified they were actually attached at runtime. A silently-missing namespace would surface later as `Cannot read property of undefined` inside a request handler — now it's a fast, loud `INITIALIZER_VALIDATION` failure at startup naming the offending initializer. A new `validateInitializerProperties` check runs after both the `initialize` and `start` phases; `runMode`-excluded initializers are skipped during `start`. Initializers that intentionally don't augment `api` can opt out via `declaresAPIProperty = false` on the `Initializer` base class. Version bumped `0.21.6 → 0.21.7`.

## Test plan

- [x] New unit tests in `packages/keryx/__tests__/classes/API.test.ts` (9 tests) cover happy path, `undefined`/`null` returns, multi-miss aggregation, opt-out, `start()`-phase null, and runMode-skip behavior
- [x] Full keryx framework test suite passes (414/414)
- [x] `bun lint` clean across all workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)