### PR TITLE
Replace O(n) per-request action routing with compiled Router (#348)

### DIFF
--- a/packages/keryx/__tests__/classes/Router.test.ts
+++ b/packages/keryx/__tests__/classes/Router.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, test } from "bun:test";
+import { type Action, HTTP_METHOD } from "../../classes/Action";
+import { Router } from "../../classes/Router";
+
+// Minimal shape the Router actually reads. Casting avoids standing up full Action
+// instances (and their abstract `run()`) for data-structure tests.
+function action(
+  name: string,
+  route: string | RegExp,
+  method: HTTP_METHOD = HTTP_METHOD.GET,
+): Action {
+  return { name, web: { route, method } } as unknown as Action;
+}
+
+describe("Router", () => {
+  describe("static routes", () => {
+    test("matches an exact string path", () => {
+      const router = new Router();
+      router.compile([action("status", "/status")]);
+
+      expect(router.match("/status", HTTP_METHOD.GET)).toEqual({
+        actionName: "status",
+      });
+    });
+
+    test("returns null on method mismatch", () => {
+      const router = new Router();
+      router.compile([action("status", "/status", HTTP_METHOD.GET)]);
+
+      expect(router.match("/status", HTTP_METHOD.POST)).toBeNull();
+    });
+
+    test("different methods on the same path route independently", () => {
+      const router = new Router();
+      router.compile([
+        action("user:list", "/users", HTTP_METHOD.GET),
+        action("user:create", "/users", HTTP_METHOD.POST),
+      ]);
+
+      expect(router.match("/users", HTTP_METHOD.GET)).toEqual({
+        actionName: "user:list",
+      });
+      expect(router.match("/users", HTTP_METHOD.POST)).toEqual({
+        actionName: "user:create",
+      });
+      expect(router.match("/users", HTTP_METHOD.DELETE)).toBeNull();
+    });
+
+    test("treats regex metacharacters as literal", () => {
+      const router = new Router();
+      router.compile([action("version", "/v1.0/status")]);
+
+      expect(router.match("/v1.0/status", HTTP_METHOD.GET)).toEqual({
+        actionName: "version",
+      });
+      // The `.` must not match an arbitrary character.
+      expect(router.match("/v1X0/status", HTTP_METHOD.GET)).toBeNull();
+    });
+
+    test("trailing slash is strict (no implicit normalization)", () => {
+      const router = new Router();
+      router.compile([action("status", "/status")]);
+
+      expect(router.match("/status", HTTP_METHOD.GET)).toEqual({
+        actionName: "status",
+      });
+      expect(router.match("/status/", HTTP_METHOD.GET)).toBeNull();
+    });
+
+    test("root path matches", () => {
+      const router = new Router();
+      router.compile([action("home", "/")]);
+
+      expect(router.match("/", HTTP_METHOD.GET)).toEqual({
+        actionName: "home",
+      });
+    });
+  });
+
+  describe("parameterized routes", () => {
+    test("extracts a single :param", () => {
+      const router = new Router();
+      router.compile([action("user:get", "/users/:id")]);
+
+      expect(router.match("/users/42", HTTP_METHOD.GET)).toEqual({
+        actionName: "user:get",
+        pathParams: { id: "42" },
+      });
+    });
+
+    test("extracts multiple :params in order", () => {
+      const router = new Router();
+      router.compile([action("msg:get", "/channels/:channelId/messages/:id")]);
+
+      expect(
+        router.match("/channels/general/messages/99", HTTP_METHOD.GET),
+      ).toEqual({
+        actionName: "msg:get",
+        pathParams: { channelId: "general", id: "99" },
+      });
+    });
+
+    test(":param accepts URL-safe characters (dashes, dots, alphanumeric)", () => {
+      const router = new Router();
+      router.compile([action("user:get", "/users/:id")]);
+
+      const match = router.match(
+        "/users/7f9c3b2e-1d5a-4f8b-9e7c-0a1b2c3d4e5f.v2",
+        HTTP_METHOD.GET,
+      );
+      expect(match?.pathParams?.id).toBe(
+        "7f9c3b2e-1d5a-4f8b-9e7c-0a1b2c3d4e5f.v2",
+      );
+    });
+
+    test(":param is bounded by slashes — does not cross segments", () => {
+      const router = new Router();
+      router.compile([action("user:get", "/users/:id")]);
+
+      // An extra segment after :id must not match.
+      expect(router.match("/users/42/extra", HTTP_METHOD.GET)).toBeNull();
+    });
+
+    test("empty param value does not match", () => {
+      const router = new Router();
+      router.compile([action("user:get", "/users/:id")]);
+
+      expect(router.match("/users/", HTTP_METHOD.GET)).toBeNull();
+    });
+
+    test("param on the same path routes differently per method", () => {
+      const router = new Router();
+      router.compile([
+        action("user:get", "/users/:id", HTTP_METHOD.GET),
+        action("user:update", "/users/:id", HTTP_METHOD.PATCH),
+      ]);
+
+      expect(router.match("/users/1", HTTP_METHOD.GET)?.actionName).toBe(
+        "user:get",
+      );
+      expect(router.match("/users/1", HTTP_METHOD.PATCH)?.actionName).toBe(
+        "user:update",
+      );
+      expect(router.match("/users/1", HTTP_METHOD.DELETE)).toBeNull();
+    });
+  });
+
+  describe("RegExp routes", () => {
+    test("matches without returning pathParams", () => {
+      const router = new Router();
+      router.compile([action("admin:any", /^\/admin\/.+$/)]);
+
+      expect(router.match("/admin/settings", HTTP_METHOD.GET)).toEqual({
+        actionName: "admin:any",
+      });
+    });
+
+    test("honors the RegExp's own boundaries", () => {
+      const router = new Router();
+      router.compile([action("admin:any", /^\/admin\/.+$/)]);
+
+      expect(router.match("/admin/", HTTP_METHOD.GET)).toBeNull();
+      expect(router.match("/admins/x", HTTP_METHOD.GET)).toBeNull();
+    });
+  });
+
+  describe("precedence and tie-breaks", () => {
+    test("static route beats a dynamic route that could also match (regardless of registration order)", () => {
+      // Dynamic registered first — the old live-loop would have matched it.
+      // The router deliberately prefers the static index.
+      const routerDynamicFirst = new Router();
+      routerDynamicFirst.compile([
+        action("user:get", "/users/:id"),
+        action("user:all", "/users/all"),
+      ]);
+      expect(routerDynamicFirst.match("/users/all", HTTP_METHOD.GET)).toEqual({
+        actionName: "user:all",
+      });
+
+      // And the reverse order.
+      const routerStaticFirst = new Router();
+      routerStaticFirst.compile([
+        action("user:all", "/users/all"),
+        action("user:get", "/users/:id"),
+      ]);
+      expect(routerStaticFirst.match("/users/all", HTTP_METHOD.GET)).toEqual({
+        actionName: "user:all",
+      });
+    });
+
+    test("first-registered wins among dynamic routes that both match", () => {
+      const router = new Router();
+      router.compile([
+        action("first", "/things/:id"),
+        action("second", "/things/:slug"),
+      ]);
+
+      expect(router.match("/things/abc", HTTP_METHOD.GET)).toEqual({
+        actionName: "first",
+        pathParams: { id: "abc" },
+      });
+    });
+
+    test("duplicate static route keeps the first registration", () => {
+      const router = new Router();
+      router.compile([action("first", "/ping"), action("second", "/ping")]);
+
+      expect(router.match("/ping", HTTP_METHOD.GET)?.actionName).toBe("first");
+    });
+  });
+
+  describe("empty / missing input", () => {
+    test("empty action list yields no matches", () => {
+      const router = new Router();
+      router.compile([]);
+
+      expect(router.match("/anything", HTTP_METHOD.GET)).toBeNull();
+    });
+
+    test("ignores actions with no web.route", () => {
+      const taskOnly = { name: "bg:work" } as unknown as Action;
+      const router = new Router();
+      router.compile([taskOnly, action("status", "/status")]);
+
+      expect(router.match("/status", HTTP_METHOD.GET)).toEqual({
+        actionName: "status",
+      });
+    });
+
+    test("unknown path returns null", () => {
+      const router = new Router();
+      router.compile([action("status", "/status")]);
+
+      expect(router.match("/nope", HTTP_METHOD.GET)).toBeNull();
+    });
+  });
+
+  describe("rebuild correctness", () => {
+    test("compile() replaces prior state — no leftover static or dynamic routes", () => {
+      const router = new Router();
+      router.compile([
+        action("old:static", "/old"),
+        action("old:dynamic", "/old/:id"),
+      ]);
+      router.compile([action("new:static", "/new")]);
+
+      expect(router.match("/old", HTTP_METHOD.GET)).toBeNull();
+      expect(router.match("/old/1", HTTP_METHOD.GET)).toBeNull();
+      expect(router.match("/new", HTTP_METHOD.GET)?.actionName).toBe(
+        "new:static",
+      );
+    });
+
+    test("rebuilds on in-place mutation (push/splice)", () => {
+      const actions: Action[] = [action("status", "/status")];
+      const router = new Router();
+      router.compile(actions);
+
+      expect(router.match("/late", HTTP_METHOD.GET)).toBeNull();
+
+      actions.push(action("late:get", "/late"));
+      expect(router.match("/late", HTTP_METHOD.GET)?.actionName).toBe(
+        "late:get",
+      );
+
+      actions.splice(0, actions.length);
+      expect(router.match("/status", HTTP_METHOD.GET)).toBeNull();
+      expect(router.match("/late", HTTP_METHOD.GET)).toBeNull();
+    });
+
+    test("rebuilds when the source getter returns a fresh array reference", () => {
+      const container = { actions: [action("status", "/status")] as Action[] };
+      const router = new Router();
+      router.compile(() => container.actions);
+
+      expect(router.match("/status", HTTP_METHOD.GET)?.actionName).toBe(
+        "status",
+      );
+
+      // Wholesale swap — mirrors `api.actions.actions = api.actions.actions.filter(...)`.
+      container.actions = [action("swapped", "/swapped")];
+
+      expect(router.match("/status", HTTP_METHOD.GET)).toBeNull();
+      expect(router.match("/swapped", HTTP_METHOD.GET)?.actionName).toBe(
+        "swapped",
+      );
+    });
+
+    test("rebuilds on same-length reference swap (identity, not length, drives drift detection)", () => {
+      const container = {
+        actions: [
+          action("alpha", "/alpha"),
+          action("beta", "/beta"),
+        ] as Action[],
+      };
+      const router = new Router();
+      router.compile(() => container.actions);
+
+      expect(router.match("/alpha", HTTP_METHOD.GET)?.actionName).toBe("alpha");
+
+      // Replace with a new array of the SAME length. Length-only drift checks
+      // would miss this; the router must also compare references.
+      container.actions = [
+        action("gamma", "/gamma"),
+        action("delta", "/delta"),
+      ];
+
+      expect(router.match("/alpha", HTTP_METHOD.GET)).toBeNull();
+      expect(router.match("/beta", HTTP_METHOD.GET)).toBeNull();
+      expect(router.match("/gamma", HTTP_METHOD.GET)?.actionName).toBe("gamma");
+      expect(router.match("/delta", HTTP_METHOD.GET)?.actionName).toBe("delta");
+    });
+
+    test("defers rebuild when the getter is not yet ready", () => {
+      const container: { actions?: Action[] } = {};
+      const router = new Router();
+
+      // Mirrors the initializer-time case where `api.actions` isn't assigned yet.
+      router.compile(() => {
+        if (!container.actions) throw new Error("not ready");
+        return container.actions;
+      });
+
+      container.actions = [action("late:status", "/status")];
+
+      expect(router.match("/status", HTTP_METHOD.GET)?.actionName).toBe(
+        "late:status",
+      );
+    });
+
+    test("does not rebuild when neither reference nor length changed", () => {
+      // Arrange a getter that counts invocations. After the first rebuild,
+      // subsequent matches must only call the getter (to check drift), not
+      // walk all actions again. We verify this indirectly by mutating an
+      // action's `name` after compile — if we were rebuilding every time, the
+      // new name would show up; since we cache, it should not.
+      const a = action("original", "/thing");
+      const actions: Action[] = [a];
+      const router = new Router();
+      router.compile(actions);
+
+      expect(router.match("/thing", HTTP_METHOD.GET)?.actionName).toBe(
+        "original",
+      );
+
+      (a as { name: string }).name = "mutated-in-place";
+
+      // No length change, no reference change — cached index still returns
+      // the pre-mutation value.
+      expect(router.match("/thing", HTTP_METHOD.GET)?.actionName).toBe(
+        "original",
+      );
+    });
+  });
+
+  describe("scale smoke test", () => {
+    test("routes correctly with many mixed static and dynamic actions", () => {
+      const many: Action[] = [];
+      for (let i = 0; i < 500; i++) many.push(action(`s:${i}`, `/static/${i}`));
+      for (let i = 0; i < 500; i++) {
+        many.push(action(`d:${i}`, `/dynamic/${i}/:id`));
+      }
+
+      const router = new Router();
+      router.compile(many);
+
+      expect(router.match("/static/0", HTTP_METHOD.GET)?.actionName).toBe(
+        "s:0",
+      );
+      expect(router.match("/static/499", HTTP_METHOD.GET)?.actionName).toBe(
+        "s:499",
+      );
+      expect(router.match("/static/500", HTTP_METHOD.GET)).toBeNull();
+
+      expect(router.match("/dynamic/42/abc", HTTP_METHOD.GET)).toEqual({
+        actionName: "d:42",
+        pathParams: { id: "abc" },
+      });
+    });
+  });
+});

--- a/packages/keryx/__tests__/util/webRouting.test.ts
+++ b/packages/keryx/__tests__/util/webRouting.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { api } from "../../api";
+import { type Action, HTTP_METHOD } from "../../classes/Action";
+import { Router } from "../../classes/Router";
 import { ErrorType } from "../../classes/TypedError";
-import { parseRequestParams } from "../../util/webRouting";
+import { config } from "../../config";
+import { determineActionName, parseRequestParams } from "../../util/webRouting";
+import { HOOK_TIMEOUT } from "../setup";
 
 // Helpers to build minimal Request objects for testing
 function jsonRequest(body: Record<string, unknown>, method = "POST"): Request {
@@ -208,5 +213,76 @@ describe("parseRequestParams", () => {
       expect(params.name).toBe("from-body");
       expect(params.extra).toBe("query-val");
     });
+  });
+});
+
+function makeAction(
+  name: string,
+  route: string | RegExp,
+  method: HTTP_METHOD = HTTP_METHOD.GET,
+): Action {
+  return { name, web: { route, method } } as unknown as Action;
+}
+
+function routerUrl(pathWithQuery: string) {
+  const { parse } = require("node:url");
+  return parse(`http://localhost${pathWithQuery}`, true);
+}
+
+describe("determineActionName", () => {
+  const originalActions = (api as { actions?: unknown }).actions;
+
+  beforeAll(() => {
+    const router = new Router();
+    const actions = [
+      makeAction("status", "/status"),
+      makeAction("user:get", "/users/:id"),
+      makeAction("user:create", "/users", HTTP_METHOD.POST),
+    ];
+    router.compile(actions);
+    (api as { actions: unknown }).actions = { actions, router };
+  }, HOOK_TIMEOUT);
+
+  afterAll(() => {
+    (api as { actions: unknown }).actions = originalActions;
+  }, HOOK_TIMEOUT);
+
+  test("strips the configured apiRoute prefix before matching", async () => {
+    const result = await determineActionName(
+      routerUrl(`${config.server.web.apiRoute}/status`),
+      HTTP_METHOD.GET,
+    );
+    expect(result).toEqual({ actionName: "status", pathParams: undefined });
+  });
+
+  test("extracts path params through the transport layer", async () => {
+    const result = await determineActionName(
+      routerUrl(`${config.server.web.apiRoute}/users/42`),
+      HTTP_METHOD.GET,
+    );
+    expect(result.actionName).toBe("user:get");
+    expect(result.pathParams).toEqual({ id: "42" });
+  });
+
+  test("dispatches GET and POST on the same path to different actions", async () => {
+    const getResult = await determineActionName(
+      routerUrl(`${config.server.web.apiRoute}/users`),
+      HTTP_METHOD.POST,
+    );
+    expect(getResult.actionName).toBe("user:create");
+
+    const missing = await determineActionName(
+      routerUrl(`${config.server.web.apiRoute}/users`),
+      HTTP_METHOD.DELETE,
+    );
+    expect(missing.actionName).toBeNull();
+  });
+
+  test("returns null for an unknown path", async () => {
+    const result = await determineActionName(
+      routerUrl(`${config.server.web.apiRoute}/nope`),
+      HTTP_METHOD.GET,
+    );
+    expect(result).toEqual({ actionName: null, pathParams: null });
   });
 });

--- a/packages/keryx/classes/Router.ts
+++ b/packages/keryx/classes/Router.ts
@@ -1,0 +1,157 @@
+import type { Action, HTTP_METHOD } from "./Action";
+
+/**
+ * Result of a successful route match.
+ */
+export type RouterMatch = {
+  actionName: string;
+  pathParams?: Record<string, string>;
+};
+
+type DynamicRoute = {
+  matcher: RegExp;
+  paramNames: string[];
+  actionName: string;
+};
+
+/**
+ * Fast path-to-action lookup.
+ *
+ * `compile()` builds two lookup structures from a list of actions:
+ *   - a static index keyed by method + exact path for plain-string routes with no `:param` segments
+ *   - a dynamic list (per method) of pre-compiled regexes for `:param` and `RegExp` routes
+ *
+ * `match()` performs an O(1) static lookup first, then falls back to an O(k) scan of
+ * dynamic routes for that method (where k is the number of dynamic routes per method).
+ *
+ * The router preserves the registration order of dynamic routes, so when two dynamic
+ * patterns can both match a path, the first one registered wins — matching the
+ * behavior of the pre-router iteration loop.
+ *
+ * The router reads the action list through a source function supplied to
+ * `compile()`. On each `match()` call it checks whether the returned array
+ * reference or length has changed since the last build, and rebuilds on drift.
+ * This preserves the live-iteration semantics of the previous loop-based matcher
+ * — including tolerating tests that both push new actions onto
+ * `api.actions.actions` and that swap the array wholesale via
+ * `api.actions.actions = api.actions.actions.filter(...)`.
+ */
+export class Router {
+  private staticIndex: Map<HTTP_METHOD, Map<string, string>> = new Map();
+  private dynamicList: Map<HTTP_METHOD, DynamicRoute[]> = new Map();
+  private source: () => Action[] = () => [];
+  private lastSeen: Action[] | null = null;
+  private lastLength = -1;
+
+  /**
+   * Bind the router to an action source and eagerly build the lookup structures.
+   *
+   * The `source` argument may be the action array directly, or a getter function
+   * that returns the current array. A getter is the recommended form for
+   * long-lived routers (e.g. the one on `api.actions`) because some callers
+   * swap the underlying array reference rather than mutating in place.
+   *
+   * Safe to call multiple times — each call fully replaces the previous state.
+   * When in-process hot-reload for actions is added, callers must re-invoke this
+   * method; the currently relied-on dev restart via `bun --watch` is a full
+   * process restart, so `initialize()` naturally re-runs this.
+   *
+   * @param source - Either the actions array or a function returning it. Actions without a `web.route` are skipped.
+   */
+  compile(source: Action[] | (() => Action[])): void {
+    this.source =
+      typeof source === "function" ? source : () => source as Action[];
+
+    // Eagerly build if the source is ready. If the getter throws (e.g. called
+    // inside `initialize()` before `api.actions` is assigned), defer to the
+    // first `match()` call.
+    try {
+      const actions = this.source();
+      this.rebuild(actions);
+    } catch {
+      this.lastSeen = null;
+      this.lastLength = -1;
+    }
+  }
+
+  private rebuild(actions: Action[]): void {
+    this.staticIndex = new Map();
+    this.dynamicList = new Map();
+
+    for (const action of actions) {
+      if (!action?.web?.route) continue;
+      const { route, method } = action.web;
+
+      const isRegExp = route instanceof RegExp;
+      const hasParams = !isRegExp && /:\w+/.test(route as string);
+
+      if (!isRegExp && !hasParams) {
+        let byPath = this.staticIndex.get(method);
+        if (!byPath) {
+          byPath = new Map();
+          this.staticIndex.set(method, byPath);
+        }
+        if (!byPath.has(route as string)) {
+          byPath.set(route as string, action.name);
+        }
+        continue;
+      }
+
+      const matcher = isRegExp
+        ? (route as RegExp)
+        : new RegExp(`^${(route as string).replace(/:\w+/g, "([^/]+)")}$`);
+      const paramNames = isRegExp
+        ? []
+        : ((route as string).match(/:\w+/g) ?? []).map((n) => n.slice(1));
+
+      let list = this.dynamicList.get(method);
+      if (!list) {
+        list = [];
+        this.dynamicList.set(method, list);
+      }
+      list.push({ matcher, paramNames, actionName: action.name });
+    }
+
+    this.lastSeen = actions;
+    this.lastLength = actions.length;
+  }
+
+  /**
+   * Match a path + method against the compiled routes.
+   *
+   * @param path - The request path (already stripped of any API prefix).
+   * @param method - Uppercase HTTP method.
+   * @returns The matched action name plus any extracted path parameters, or `null` if no route matched.
+   */
+  match(path: string, method: HTTP_METHOD): RouterMatch | null {
+    const actions = this.source();
+    if (actions !== this.lastSeen || actions.length !== this.lastLength) {
+      this.rebuild(actions);
+    }
+
+    const staticHit = this.staticIndex.get(method)?.get(path);
+    if (staticHit) return { actionName: staticHit };
+
+    const candidates = this.dynamicList.get(method);
+    if (!candidates) return null;
+
+    for (const { matcher, paramNames, actionName } of candidates) {
+      const result = matcher.exec(path);
+      if (!result) continue;
+
+      if (paramNames.length === 0) return { actionName };
+
+      const pathParams: Record<string, string> = {};
+      for (let i = 0; i < paramNames.length; i++) {
+        const value = result[i + 1];
+        if (value !== undefined) pathParams[paramNames[i]] = value;
+      }
+      return {
+        actionName,
+        pathParams: Object.keys(pathParams).length > 0 ? pathParams : undefined,
+      };
+    }
+
+    return null;
+  }
+}

--- a/packages/keryx/initializers/actionts.ts
+++ b/packages/keryx/initializers/actionts.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { api, logger } from "../api";
 import { type Action, DEFAULT_QUEUE } from "../classes/Action";
 import { Initializer } from "../classes/Initializer";
+import { Router } from "../classes/Router";
 import { ErrorType, TypedError } from "../classes/TypedError";
 import { config } from "../config";
 import { formatLoadedMessage } from "../util/config";
@@ -672,8 +673,16 @@ export class Actions extends Initializer {
       }),
     );
 
+    // Keep the router compile co-located with action assembly — if in-process
+    // hot-reload is ever added, this is the single seam that must re-fire.
+    // The getter lets the router track wholesale array replacement (e.g. tests
+    // that do `api.actions.actions = api.actions.actions.filter(...)`).
+    const router = new Router();
+    router.compile(() => api.actions.actions);
+
     return {
       actions,
+      router,
 
       enqueue: this.enqueue,
       fanOut: this.fanOut,

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/webRouting.ts
+++ b/packages/keryx/util/webRouting.ts
@@ -7,6 +7,10 @@ import { config } from "../config";
 /**
  * Match a URL path + HTTP method against registered action routes.
  * Returns the action name and any extracted path parameters, or `null` if no match.
+ *
+ * Delegates to the pre-compiled `api.actions.router` for O(1) static-route lookup
+ * and an ordered scan of parameterized routes. This function only handles the
+ * transport concern of stripping the configured API prefix before routing.
  */
 export async function determineActionName(
   url: ReturnType<typeof parse>,
@@ -20,46 +24,14 @@ export async function determineActionName(
     "",
   );
 
-  for (const action of api.actions.actions) {
-    if (!action?.web?.route) continue;
+  if (!pathToMatch) return { actionName: null, pathParams: null };
 
-    // Convert route with path parameters to regex
-    const routeWithParams = `${action.web.route}`.replace(/:\w+/g, "([^/]+)");
-    const matcher =
-      action.web.route instanceof RegExp
-        ? action.web.route
-        : new RegExp(`^${routeWithParams}$`);
-
-    if (
-      pathToMatch &&
-      pathToMatch.match(matcher) &&
-      method.toUpperCase() === action.web.method
-    ) {
-      // Extract path parameters if the route has them
-      const pathParams: Record<string, string> = {};
-      const paramNames = (`${action.web.route}`.match(/:\w+/g) || []).map(
-        (name) => name.slice(1),
-      );
-      const match = pathToMatch.match(matcher);
-
-      if (match && paramNames.length > 0) {
-        // Skip the first match (full string) and use the captured groups
-        for (let i = 0; i < paramNames.length; i++) {
-          const value = match[i + 1];
-          if (value !== undefined) {
-            pathParams[paramNames[i]] = value;
-          }
-        }
-      }
-
-      return {
-        actionName: action.name,
-        pathParams: Object.keys(pathParams).length > 0 ? pathParams : undefined,
-      };
-    }
-  }
-
-  return { actionName: null, pathParams: null };
+  const match = api.actions.router.match(
+    pathToMatch,
+    method.toUpperCase() as HTTP_METHOD,
+  );
+  if (!match) return { actionName: null, pathParams: null };
+  return { actionName: match.actionName, pathParams: match.pathParams };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Introduce a `Router` class (`packages/keryx/classes/Router.ts`) that compiles an action list into a per-method **static index** (O(1) exact-path lookup) plus an ordered per-method list of pre-compiled regexes for `:param` and `RegExp` routes. `determineActionName` now delegates to `api.actions.router.match()` instead of iterating every action and rebuilding regex per request.
- The router is bound via a getter (`() => api.actions.actions`) so it survives both in-place push/splice and wholesale reassignment (`api.actions.actions = filter(...)`); drift is detected by reference + length comparison and triggers a lazy rebuild.
- Semantic note: static routes now beat dynamic routes on overlapping paths regardless of registration order — the intended design per #348, and a subtle change from the old live-loop behavior.

## Test plan

- [x] `bun test` in `packages/keryx` — 436 pass, 0 fail (includes 27 new `Router` unit tests + 4 new `determineActionName` integration tests)
- [x] `bun test` in `example/backend` — 215 pass, 0 fail
- [x] `bun lint` clean
- [x] Package patch-bumped to `0.21.7`

Closes #348.