### PR TITLE
Extract useTestServer() helper to keryx/testing and adopt across tests

### DIFF
--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -8,25 +8,15 @@ We don't mock the server. That's a deliberate choice — if you're testing an AP
 
 ## Test Structure
 
-Each test file boots and stops the full server in `beforeAll`/`afterAll`. Tests use dynamic port binding (`WEB_SERVER_PORT=0`) so each file gets a random available port — no conflicts when running multiple test files:
+Each test file boots and stops the full server in `beforeAll`/`afterAll`. Tests use dynamic port binding (`WEB_SERVER_PORT=0`) so each file gets a random available port — no conflicts when running multiple test files. Use the `useTestServer()` helper to register these hooks in one line:
 
 ```ts
-import { api } from "keryx";
-import { serverUrl, HOOK_TIMEOUT } from "../setup";
+import { useTestServer } from "keryx/testing";
 
-let url: string;
-
-beforeAll(async () => {
-  await api.start();
-  url = serverUrl();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+const getUrl = useTestServer();
 
 test("status endpoint returns server info", async () => {
-  const res = await fetch(url + "/api/status");
+  const res = await fetch(getUrl() + "/api/status");
   const body = (await res.json()) as ActionResponse<Status>;
 
   expect(res.status).toBe(200);
@@ -39,10 +29,20 @@ Yes, this means each test file starts the entire server — database connections
 
 ## Test Helpers
 
-The `backend/__tests__/setup.ts` file provides helpers used across the test suite:
+The `keryx/testing` subpath exports helpers that cover the common test lifecycle:
 
-- **`serverUrl()`** — Returns the actual URL the web server bound to (with resolved port). Call after `api.start()`.
-- **`HOOK_TIMEOUT`** — A generous timeout (15s) for `beforeAll`/`afterAll` hooks, since they connect to Redis, Postgres, run migrations, etc. Pass as the second argument to `beforeAll`/`afterAll`.
+- **`useTestServer(opts?)`** — Registers `beforeAll` / `afterAll` hooks that call `api.start()` and `api.stop()`. Returns a getter that resolves the server URL (the URL isn't known until the port is bound, so it's a function, not a string). Options:
+  - `clearDatabase` (default `false`) — truncate all tables in `beforeAll` (requires the `db` initializer).
+  - `clearRedis` (default `false`) — `FLUSHDB` on the current Redis database in `beforeAll` (requires the `redis` initializer). Opt in for tests that exercise pub/sub so messages from prior tests don't leak in.
+
+  ```ts
+  const getUrl = useTestServer({ clearDatabase: true, clearRedis: true });
+  ```
+
+  Need additional setup like inserting a seed user? Bun supports multiple `beforeAll` blocks per file — add another one after `useTestServer()` that runs once `api.start()` has completed.
+
+- **`serverUrl()`** — Returns the actual URL the web server bound to (with resolved port). Call after `api.start()`. `useTestServer()` wraps this internally; reach for it directly only when you need manual lifecycle control.
+- **`HOOK_TIMEOUT`** — A generous timeout (15s) for `beforeAll`/`afterAll` hooks, since they connect to Redis, Postgres, run migrations, etc. Pass as the second argument to `beforeAll`/`afterAll` when writing your own lifecycle hooks.
 - **`waitFor(condition, { interval, timeout })`** — Polls a condition function until it returns `true`, or throws after a timeout. Use this instead of fixed `Bun.sleep()` calls when waiting for async side effects like background tasks:
 
 ```ts
@@ -78,7 +78,7 @@ Just use `fetch`. Here's a typical test for creating a user:
 
 ```ts
 test("create a user", async () => {
-  const res = await fetch(url + "/api/user", {
+  const res = await fetch(getUrl() + "/api/user", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -98,13 +98,10 @@ Nothing special — it's the same `fetch` you'd use in a browser or a Bun script
 
 ## Database Setup
 
-Tests typically clear the database before running to ensure a clean slate:
+Tests typically clear the database before running to ensure a clean slate — pass `clearDatabase: true` to `useTestServer()`:
 
 ```ts
-beforeAll(async () => {
-  await api.start();
-  await api.db.clearDatabase();
-});
+const getUrl = useTestServer({ clearDatabase: true });
 ```
 
 `clearDatabase()` truncates all tables with `RESTART IDENTITY CASCADE`. It refuses to run when `NODE_ENV=production`, so you can't accidentally nuke your production data.
@@ -126,7 +123,7 @@ import { config } from "keryx";
 
 test("authenticated request", async () => {
   // Create a user
-  await fetch(url + "/api/user", {
+  await fetch(getUrl() + "/api/user", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -137,7 +134,7 @@ test("authenticated request", async () => {
   });
 
   // Log in
-  const sessionRes = await fetch(url + "/api/session", {
+  const sessionRes = await fetch(getUrl() + "/api/session", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -150,7 +147,7 @@ test("authenticated request", async () => {
   const sessionId = sessionBody.session.id;
 
   // Make an authenticated request
-  const res = await fetch(url + "/api/user", {
+  const res = await fetch(getUrl() + "/api/user", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -171,7 +168,7 @@ WebSocket tests connect to the same server and send JSON messages:
 
 ```ts
 test("websocket action", async () => {
-  const wsUrl = url.replace("http", "ws");
+  const wsUrl = getUrl().replace("http", "ws");
   const ws = new WebSocket(wsUrl);
 
   await new Promise<void>((resolve) => {

--- a/example/backend/__tests__/actions/channel.test.ts
+++ b/example/backend/__tests__/actions/channel.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from "bun:test";
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { type ActionResponse, api, Channel } from "keryx";
 import type { ChannelMembers } from "../../actions/channel";
 import type { SessionCreate } from "../../actions/session";
@@ -15,26 +8,15 @@ import {
   createUser,
   subscribeToChannel,
 } from "./../servers/websocket-helpers";
-import { HOOK_TIMEOUT, serverUrl } from "./../setup";
+import { useTestServer } from "./../setup";
 
-let url: string;
-
-beforeAll(async () => {
-  await api.start();
-  url = serverUrl();
-  await api.db.clearDatabase();
-  await api.redis.redis.flushdb();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+const getUrl = useTestServer({ clearDatabase: true, clearRedis: true });
 
 describe("channel:members", () => {
   let session: ActionResponse<SessionCreate>["session"];
 
   beforeAll(async () => {
-    await fetch(url + "/api/user", {
+    await fetch(getUrl() + "/api/user", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -44,7 +26,7 @@ describe("channel:members", () => {
       }),
     });
 
-    const sessionRes = await fetch(url + "/api/session", {
+    const sessionRes = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -64,7 +46,10 @@ describe("channel:members", () => {
 
   test("rejects invalid channel name", async () => {
     const res = await fetch(
-      url + "/api/channel/" + encodeURIComponent("bad channel!@#") + "/members",
+      getUrl() +
+        "/api/channel/" +
+        encodeURIComponent("bad channel!@#") +
+        "/members",
       {
         method: "GET",
         headers: {
@@ -78,7 +63,7 @@ describe("channel:members", () => {
   });
 
   test("fails without a session", async () => {
-    const res = await fetch(url + "/api/channel/messages/members", {
+    const res = await fetch(getUrl() + "/api/channel/messages/members", {
       method: "GET",
     });
     expect(res.status).toBe(401);
@@ -87,12 +72,15 @@ describe("channel:members", () => {
   });
 
   test("returns empty members for a channel with no subscribers", async () => {
-    const res = await fetch(url + "/api/channel/some-empty-channel/members", {
-      method: "GET",
-      headers: {
-        Cookie: `${session.cookieName}=${session.id}`,
+    const res = await fetch(
+      getUrl() + "/api/channel/some-empty-channel/members",
+      {
+        method: "GET",
+        headers: {
+          Cookie: `${session.cookieName}=${session.id}`,
+        },
       },
-    });
+    );
     expect(res.status).toBe(200);
     const response = (await res.json()) as ActionResponse<ChannelMembers>;
     expect(response.members).toEqual([]);
@@ -111,7 +99,7 @@ describe("channel:members", () => {
     await createSession(socket, messages, "luigi@example.com", "mushroom1");
     await subscribeToChannel(socket, messages, "messages");
 
-    const res = await fetch(url + "/api/channel/messages/members", {
+    const res = await fetch(getUrl() + "/api/channel/messages/members", {
       method: "GET",
       headers: {
         Cookie: `${session.cookieName}=${session.id}`,
@@ -149,7 +137,7 @@ describe("channel:members", () => {
       await subscribeToChannel(socket, messages, "test-channel");
 
       // Verify member is present
-      let res = await fetch(url + "/api/channel/test-channel/members", {
+      let res = await fetch(getUrl() + "/api/channel/test-channel/members", {
         method: "GET",
         headers: {
           Cookie: `${session.cookieName}=${session.id}`,
@@ -163,7 +151,7 @@ describe("channel:members", () => {
       await Bun.sleep(100);
 
       // Verify member is removed
-      res = await fetch(url + "/api/channel/test-channel/members", {
+      res = await fetch(getUrl() + "/api/channel/test-channel/members", {
         method: "GET",
         headers: {
           Cookie: `${session.cookieName}=${session.id}`,

--- a/example/backend/__tests__/actions/files.test.ts
+++ b/example/backend/__tests__/actions/files.test.ts
@@ -1,19 +1,10 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { type ActionResponse, api } from "keryx";
+import { describe, expect, test } from "bun:test";
+import { type ActionResponse } from "keryx";
 import path from "path";
 import type { FileUpload } from "../../actions/files";
-import { HOOK_TIMEOUT, serverUrl } from "./../setup";
+import { useTestServer } from "./../setup";
 
-let url: string;
-
-beforeAll(async () => {
-  await api.start();
-  url = serverUrl();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+const getUrl = useTestServer();
 
 describe("status", () => {
   test("the web server can handle a request to an action", async () => {
@@ -32,7 +23,7 @@ describe("status", () => {
 
     const f = Bun.file(filePath);
     formData.append("file", f);
-    const res = await fetch(url + "/api/file", {
+    const res = await fetch(getUrl() + "/api/file", {
       method: "POST",
       body: formData,
     });

--- a/example/backend/__tests__/actions/message.test.ts
+++ b/example/backend/__tests__/actions/message.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { type ActionResponse, api } from "keryx";
 import type {
   MessageCrete,
@@ -7,27 +7,16 @@ import type {
 } from "../../actions/message";
 import type { SessionCreate } from "../../actions/session";
 import { messages } from "../../schema/messages";
-import { HOOK_TIMEOUT, serverUrl } from "./../setup";
+import { useTestServer } from "./../setup";
 
-let url: string;
-
-beforeAll(async () => {
-  await api.start();
-  url = serverUrl();
-  await api.db.clearDatabase();
-  await api.redis.redis.flushdb();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+const getUrl = useTestServer({ clearDatabase: true, clearRedis: true });
 
 describe("message:create", () => {
   let user: ActionResponse<SessionCreate>["user"];
   let session: ActionResponse<SessionCreate>["session"];
 
   beforeAll(async () => {
-    await fetch(url + "/api/user", {
+    await fetch(getUrl() + "/api/user", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -37,7 +26,7 @@ describe("message:create", () => {
       }),
     });
 
-    const sessionRes = await fetch(url + "/api/session", {
+    const sessionRes = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -52,7 +41,7 @@ describe("message:create", () => {
   });
 
   test("fails without a session", async () => {
-    const res = await fetch(url + "/api/message", {
+    const res = await fetch(getUrl() + "/api/message", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ body: "Hello, world!" }),
@@ -63,7 +52,7 @@ describe("message:create", () => {
   });
 
   test("fails without a valid session", async () => {
-    const res = await fetch(url + "/api/message", {
+    const res = await fetch(getUrl() + "/api/message", {
       method: "PUT",
       headers: {
         Cookie: `${session.cookieName}=123`,
@@ -77,7 +66,7 @@ describe("message:create", () => {
   });
 
   test("messages can be created", async () => {
-    const res = await fetch(url + "/api/message", {
+    const res = await fetch(getUrl() + "/api/message", {
       method: "PUT",
       headers: {
         Cookie: `${session.cookieName}=${session.id}`,
@@ -112,7 +101,7 @@ describe("message:create", () => {
     });
 
     test("messages can be listed in the proper (reverse) order", async () => {
-      const res = await fetch(url + "/api/messages/list", {
+      const res = await fetch(getUrl() + "/api/messages/list", {
         method: "GET",
         headers: {
           Cookie: `${session.cookieName}=${session.id}`,
@@ -128,7 +117,7 @@ describe("message:create", () => {
     });
 
     test("returns pagination metadata", async () => {
-      const res = await fetch(url + "/api/messages/list", {
+      const res = await fetch(getUrl() + "/api/messages/list", {
         method: "GET",
         headers: {
           Cookie: `${session.cookieName}=${session.id}`,
@@ -146,7 +135,7 @@ describe("message:create", () => {
     });
 
     test("limit and page can be used", async () => {
-      const res = await fetch(url + "/api/messages/list?limit=2&page=2", {
+      const res = await fetch(getUrl() + "/api/messages/list?limit=2&page=2", {
         method: "GET",
         headers: {
           Cookie: `${session.cookieName}=${session.id}`,
@@ -181,7 +170,7 @@ describe("message:create", () => {
     });
 
     test("fails without a session", async () => {
-      const res = await fetch(url + `/api/message/${messageId}`, {
+      const res = await fetch(getUrl() + `/api/message/${messageId}`, {
         method: "GET",
         headers: { "Content-Type": "application/json" },
       });
@@ -191,7 +180,7 @@ describe("message:create", () => {
     });
 
     test("can view a message by ID", async () => {
-      const res = await fetch(url + `/api/message/${messageId}`, {
+      const res = await fetch(getUrl() + `/api/message/${messageId}`, {
         method: "GET",
         headers: {
           Cookie: `${session.cookieName}=${session.id}`,
@@ -208,7 +197,7 @@ describe("message:create", () => {
     });
 
     test("includes user_name in response", async () => {
-      const res = await fetch(url + `/api/message/${messageId}`, {
+      const res = await fetch(getUrl() + `/api/message/${messageId}`, {
         method: "GET",
         headers: {
           Cookie: `${session.cookieName}=${session.id}`,
@@ -223,7 +212,7 @@ describe("message:create", () => {
     });
 
     test("fails with invalid message id format", async () => {
-      const res = await fetch(url + `/api/message/invalid`, {
+      const res = await fetch(getUrl() + `/api/message/invalid`, {
         method: "GET",
         headers: {
           Cookie: `${session.cookieName}=${session.id}`,
@@ -236,7 +225,7 @@ describe("message:create", () => {
     });
 
     test("fails when message not found", async () => {
-      const res = await fetch(url + `/api/message/99999`, {
+      const res = await fetch(getUrl() + `/api/message/99999`, {
         method: "GET",
         headers: {
           Cookie: `${session.cookieName}=${session.id}`,

--- a/example/backend/__tests__/actions/session.test.ts
+++ b/example/backend/__tests__/actions/session.test.ts
@@ -1,30 +1,23 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { type ActionResponse, api } from "keryx";
 import type { SessionCreate } from "../../actions/session";
 import { hashPassword } from "../../ops/UserOps";
 import { users } from "../../schema/users";
-import { HOOK_TIMEOUT, serverUrl } from "./../setup";
+import { useTestServer } from "./../setup";
 
-let url: string;
+const getUrl = useTestServer({ clearDatabase: true });
 
 beforeAll(async () => {
-  await api.start();
-  url = serverUrl();
-  await api.db.clearDatabase();
   await api.db.db.insert(users).values({
     name: "Mario Mario",
     email: "mario@example.com",
     password_hash: await hashPassword("mushroom1"),
   });
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+});
 
 describe("session:create", () => {
   test("returns user when matched", async () => {
-    const res = await fetch(url + "/api/session", {
+    const res = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -42,7 +35,7 @@ describe("session:create", () => {
   });
 
   test("fails validation", async () => {
-    const res = await fetch(url + "/api/session", {
+    const res = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -56,7 +49,7 @@ describe("session:create", () => {
   });
 
   test("fails when user is not found with generic error", async () => {
-    const res = await fetch(url + "/api/session", {
+    const res = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -70,7 +63,7 @@ describe("session:create", () => {
   });
 
   test("fails when passwords do not match with same generic error", async () => {
-    const res = await fetch(url + "/api/session", {
+    const res = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -88,7 +81,7 @@ describe("session:destroy", () => {
   let session: ActionResponse<SessionCreate>["session"];
 
   beforeAll(async () => {
-    const sessionRes = await fetch(url + "/api/session", {
+    const sessionRes = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -102,7 +95,7 @@ describe("session:destroy", () => {
   });
 
   test("successfully destroys a session", async () => {
-    const res = await fetch(url + "/api/session", {
+    const res = await fetch(getUrl() + "/api/session", {
       method: "DELETE",
       headers: {
         Cookie: `${session.cookieName}=${session.id}`,
@@ -115,7 +108,7 @@ describe("session:destroy", () => {
     expect(response.success).toBe(true);
 
     // Verify session is actually destroyed by trying to access a protected endpoint
-    const userRes = await fetch(url + "/api/user/1", {
+    const userRes = await fetch(getUrl() + "/api/user/1", {
       method: "GET",
       headers: {
         Cookie: `${session.cookieName}=${session.id}`,
@@ -126,7 +119,7 @@ describe("session:destroy", () => {
   });
 
   test("fails without a session", async () => {
-    const res = await fetch(url + "/api/session", {
+    const res = await fetch(getUrl() + "/api/session", {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
       body: "{}",

--- a/example/backend/__tests__/actions/swagger.test.ts
+++ b/example/backend/__tests__/actions/swagger.test.ts
@@ -1,22 +1,13 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { type Action, type ActionResponse, api } from "keryx";
 import type { Swagger } from "../../actions/swagger";
-import { HOOK_TIMEOUT, serverUrl } from "./../setup";
+import { useTestServer } from "./../setup";
 
-let url: string;
-
-beforeAll(async () => {
-  await api.start();
-  url = serverUrl();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+const getUrl = useTestServer();
 
 describe("swagger", () => {
   test("the swagger endpoint returns valid OpenAPI 3.0 metadata", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     expect(res.status).toBe(200);
     const response = (await res.json()) as ActionResponse<Swagger>;
 
@@ -41,7 +32,7 @@ describe("swagger", () => {
   };
 
   test("swagger documents all web actions", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     // Count web actions (actions with both route and method)
@@ -75,7 +66,7 @@ describe("swagger", () => {
   });
 
   test("swagger documents request bodies for actions with inputs", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     // Find actions with Zod inputs
@@ -108,7 +99,7 @@ describe("swagger", () => {
   });
 
   test("swagger documents standard response codes", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     // Check a specific endpoint (swagger itself)
@@ -130,7 +121,7 @@ describe("swagger", () => {
   });
 
   test("swagger groups actions by tags", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     // Check that actions are tagged by their namespace
@@ -150,7 +141,7 @@ describe("swagger", () => {
   });
 
   test("swagger documents query parameters for GET actions", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     // messages:list is GET /messages/list with page and limit inputs
@@ -174,7 +165,7 @@ describe("swagger", () => {
   });
 
   test("swagger does not duplicate path params as query params", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     // user:view is GET /user/:user — "user" is a path param and a Zod input
@@ -190,7 +181,7 @@ describe("swagger", () => {
   });
 
   test("swagger includes securitySchemes for session cookie", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     expect(response.components.securitySchemes).toBeDefined();
@@ -202,7 +193,7 @@ describe("swagger", () => {
   });
 
   test("swagger includes document-level security requirement", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     expect(response.security).toBeDefined();
@@ -210,7 +201,7 @@ describe("swagger", () => {
   });
 
   test("swagger endpoint itself is documented", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     expect(response.paths["/swagger"]).toBeDefined();
@@ -221,7 +212,7 @@ describe("swagger", () => {
   });
 
   test("swagger properly enumerates UserCreate action parameters", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     // Check the UserCreate action (PUT /user)
@@ -256,7 +247,7 @@ describe("swagger", () => {
   });
 
   test("swagger documents response types from TypeScript return types", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     // Check the status action response schema
@@ -305,7 +296,7 @@ describe("swagger", () => {
   });
 
   test("swagger documents response types for UserCreate action", async () => {
-    const res = await fetch(url + "/api/swagger");
+    const res = await fetch(getUrl() + "/api/swagger");
     const response = (await res.json()) as ActionResponse<Swagger>;
 
     // Check the user:create action response schema

--- a/example/backend/__tests__/actions/user.test.ts
+++ b/example/backend/__tests__/actions/user.test.ts
@@ -1,24 +1,14 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { type ActionResponse, api, config, logger } from "keryx";
+import { describe, expect, test } from "bun:test";
+import { type ActionResponse, config, logger } from "keryx";
 import type { SessionCreate } from "../../actions/session";
 import type { UserCreate, UserEdit, UserView } from "../../actions/user";
-import { HOOK_TIMEOUT, serverUrl } from "./../setup";
+import { useTestServer } from "./../setup";
 
-let url: string;
-
-beforeAll(async () => {
-  await api.start();
-  url = serverUrl();
-  await api.db.clearDatabase();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+const getUrl = useTestServer({ clearDatabase: true });
 
 describe("user:create", () => {
   test("user can be created", async () => {
-    const res = await fetch(url + "/api/user", {
+    const res = await fetch(getUrl() + "/api/user", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -35,7 +25,7 @@ describe("user:create", () => {
   });
 
   test("email must be unique", async () => {
-    const res = await fetch(url + "/api/user", {
+    const res = await fetch(getUrl() + "/api/user", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -52,7 +42,7 @@ describe("user:create", () => {
   });
 
   test("validation failures return the proper key", async () => {
-    const res = await fetch(url + "/api/user", {
+    const res = await fetch(getUrl() + "/api/user", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -84,7 +74,7 @@ describe("user:create", () => {
       formData.append("email", "test@example.com");
       formData.append("password", "secretpassword123");
 
-      await fetch(url + "/api/user", {
+      await fetch(getUrl() + "/api/user", {
         method: "PUT",
         body: formData,
       });
@@ -108,7 +98,7 @@ describe("user:create", () => {
 
 describe("user:edit", () => {
   test("it fails without a session", async () => {
-    const res = await fetch(url + "/api/user", {
+    const res = await fetch(getUrl() + "/api/user", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "new name" }),
@@ -119,7 +109,7 @@ describe("user:edit", () => {
   });
 
   test("the user can be updated", async () => {
-    const sessionRes = await fetch(url + "/api/session", {
+    const sessionRes = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -132,7 +122,7 @@ describe("user:edit", () => {
     expect(sessionRes.status).toBe(200);
     const sessionId = sessionResponse.session.id;
 
-    const res = await fetch(url + "/api/user", {
+    const res = await fetch(getUrl() + "/api/user", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -152,7 +142,7 @@ describe("user:edit", () => {
 
 describe("user:view", () => {
   test("it fails without a session", async () => {
-    const res = await fetch(url + "/api/user/1", {
+    const res = await fetch(getUrl() + "/api/user/1", {
       method: "GET",
       headers: { "Content-Type": "application/json" },
     });
@@ -163,7 +153,7 @@ describe("user:view", () => {
 
   test("user can view themselves", async () => {
     // Create a user first
-    await fetch(url + "/api/user", {
+    await fetch(getUrl() + "/api/user", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -174,7 +164,7 @@ describe("user:view", () => {
     });
 
     // Create a session
-    const sessionRes = await fetch(url + "/api/session", {
+    const sessionRes = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -189,7 +179,7 @@ describe("user:view", () => {
     const userId = sessionResponse.user.id;
 
     // View the user
-    const res = await fetch(url + `/api/user/${userId}`, {
+    const res = await fetch(getUrl() + `/api/user/${userId}`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -206,7 +196,7 @@ describe("user:view", () => {
 
   test("user can view another user (public information only)", async () => {
     // Create two users
-    await fetch(url + "/api/user", {
+    await fetch(getUrl() + "/api/user", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -217,7 +207,7 @@ describe("user:view", () => {
     });
 
     // Create a session for Peach
-    const sessionRes = await fetch(url + "/api/session", {
+    const sessionRes = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -231,7 +221,7 @@ describe("user:view", () => {
     const sessionId = sessionResponse.session.id;
 
     // View a different user (id 1, which should exist from earlier tests)
-    const res = await fetch(url + "/api/user/1", {
+    const res = await fetch(getUrl() + "/api/user/1", {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -249,7 +239,7 @@ describe("user:view", () => {
 
   test("fails with invalid user id format", async () => {
     // Create a session
-    const sessionRes = await fetch(url + "/api/session", {
+    const sessionRes = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -263,7 +253,7 @@ describe("user:view", () => {
     const sessionId = sessionResponse.session.id;
 
     // Try to view with invalid id
-    const res = await fetch(url + "/api/user/invalid", {
+    const res = await fetch(getUrl() + "/api/user/invalid", {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -277,7 +267,7 @@ describe("user:view", () => {
 
   test("fails when user not found", async () => {
     // Create a session
-    const sessionRes = await fetch(url + "/api/session", {
+    const sessionRes = await fetch(getUrl() + "/api/session", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -291,7 +281,7 @@ describe("user:view", () => {
     const sessionId = sessionResponse.session.id;
 
     // Try to view non-existent user
-    const res = await fetch(url + "/api/user/99999", {
+    const res = await fetch(getUrl() + "/api/user/99999", {
       method: "GET",
       headers: {
         "Content-Type": "application/json",

--- a/example/backend/__tests__/setup.ts
+++ b/example/backend/__tests__/setup.ts
@@ -1,43 +1,12 @@
 import { setMaxListeners } from "events";
 // Import from local index first to set api.rootDir before any framework code runs
-import { api, type WebServer } from "keryx";
 import "../index";
+
+export { HOOK_TIMEOUT, serverUrl, useTestServer, waitFor } from "keryx/testing";
 
 // Set max listeners to prevent warnings in CI environments
 // TODO: Github Actions needs this, but not locally. Why?
 setMaxListeners(999);
-
-// CI environments are slower; hooks need enough time for api.start()/api.stop()
-// which connect to Redis, Postgres, run migrations, etc.
-// bun:test's setDefaultTimeout and bunfig.toml [test].timeout only apply to
-// test() blocks, not lifecycle hooks — so we export this for explicit use.
-export const HOOK_TIMEOUT = 15_000;
-
-/**
- * Return the actual URL the web server bound to (resolved port).
- * Call after api.start() so the server has bound its port.
- */
-export function serverUrl(): string {
-  const web = api.servers.servers.find(
-    (s: { name: string }) => s.name === "web",
-  ) as WebServer | undefined;
-  return web?.url || "";
-}
-
-/**
- * Poll a condition until it returns true, or throw after a timeout.
- * Use this instead of fixed Bun.sleep() calls when waiting for async side effects.
- */
-export async function waitFor(
-  condition: () => Promise<boolean> | boolean,
-  { interval = 50, timeout = 5000 } = {},
-): Promise<void> {
-  const start = Date.now();
-  while (!(await condition())) {
-    if (Date.now() - start > timeout) throw new Error("waitFor timed out");
-    await Bun.sleep(interval);
-  }
-}
 
 // ioredis flushes its command queue on connection close, rejecting pending
 // commands with "Connection is closed." These rejections are unhandled because

--- a/packages/keryx/__tests__/actions/status.test.ts
+++ b/packages/keryx/__tests__/actions/status.test.ts
@@ -1,22 +1,13 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { Status } from "../../actions/status";
-import { type ActionResponse, api } from "../../api";
-import { HOOK_TIMEOUT, serverUrl } from "./../setup";
+import type { ActionResponse } from "../../api";
+import { useTestServer } from "./../setup";
 
-let url: string;
-
-beforeAll(async () => {
-  await api.start();
-  url = serverUrl();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+const getUrl = useTestServer();
 
 describe("status", () => {
   test("the web server can handle a request to an action", async () => {
-    const res = await fetch(url + "/api/status");
+    const res = await fetch(getUrl() + "/api/status");
     expect(res.status).toBe(200);
     const response = (await res.json()) as ActionResponse<Status>;
 
@@ -26,7 +17,7 @@ describe("status", () => {
   });
 
   test("returns health checks for database and redis", async () => {
-    const res = await fetch(url + "/api/status");
+    const res = await fetch(getUrl() + "/api/status");
     expect(res.status).toBe(200);
     const response = (await res.json()) as ActionResponse<Status>;
 

--- a/packages/keryx/__tests__/classes/Connection.test.ts
+++ b/packages/keryx/__tests__/classes/Connection.test.ts
@@ -5,7 +5,7 @@ import { Action, type ActionMiddleware } from "../../classes/Action";
 import { LogFormat, LogLevel } from "../../classes/Logger";
 import { ErrorType, TypedError } from "../../classes/TypedError";
 import { config } from "../../config";
-import { HOOK_TIMEOUT } from "./../setup";
+import { useTestServer } from "./../setup";
 
 class SlowAction extends Action {
   constructor(timeout?: number) {
@@ -31,15 +31,7 @@ class SlowAction extends Action {
   }
 }
 
-beforeAll(async () => {
-  await api.start();
-  await api.db.clearDatabase();
-  await api.redis.redis.flushdb();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+useTestServer({ clearDatabase: true, clearRedis: true });
 
 describe("Connection class", () => {
   test("constructor creates connection with unique ID", () => {

--- a/packages/keryx/__tests__/initializers/channels.test.ts
+++ b/packages/keryx/__tests__/initializers/channels.test.ts
@@ -1,14 +1,7 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  test,
-} from "bun:test";
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { api, Connection } from "../../api";
 import type { PubSubMessage } from "../../initializers/pubsub";
-import { HOOK_TIMEOUT, waitFor } from "./../setup";
+import { useTestServer, waitFor } from "./../setup";
 
 /** A test connection that captures broadcast messages. */
 class TestConnection extends Connection {
@@ -19,14 +12,11 @@ class TestConnection extends Connection {
   }
 }
 
-beforeAll(async () => {
-  await api.start();
-  await api.channels.clearPresence();
-}, HOOK_TIMEOUT);
+useTestServer();
 
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+beforeAll(async () => {
+  await api.channels.clearPresence();
+});
 
 afterEach(async () => {
   api.connections.connections.clear();

--- a/packages/keryx/__tests__/initializers/oauth.test.ts
+++ b/packages/keryx/__tests__/initializers/oauth.test.ts
@@ -1,23 +1,9 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  test,
-} from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { api } from "../../api";
 import { config } from "../../config";
-import { HOOK_TIMEOUT } from "./../setup";
+import { useTestServer } from "./../setup";
 
-beforeAll(async () => {
-  await api.start();
-  await api.redis.redis.flushdb();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+useTestServer({ clearRedis: true });
 
 afterEach(async () => {
   // Clear rate limit keys to avoid 429s between tests

--- a/packages/keryx/__tests__/initializers/pubsub.test.ts
+++ b/packages/keryx/__tests__/initializers/pubsub.test.ts
@@ -1,14 +1,7 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  test,
-} from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { api, Connection } from "../../api";
 import type { PubSubMessage } from "../../initializers/pubsub";
-import { HOOK_TIMEOUT, waitFor } from "./../setup";
+import { useTestServer, waitFor } from "./../setup";
 
 /** A test connection that captures broadcast messages instead of throwing. */
 class TestConnection extends Connection {
@@ -24,13 +17,7 @@ class TestConnection extends Connection {
   }
 }
 
-beforeAll(async () => {
-  await api.start();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+useTestServer();
 
 afterEach(() => {
   api.connections.connections.clear();

--- a/packages/keryx/__tests__/initializers/session.test.ts
+++ b/packages/keryx/__tests__/initializers/session.test.ts
@@ -1,16 +1,9 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { api, Connection } from "../../api";
 import { config } from "../../config";
-import { HOOK_TIMEOUT } from "./../setup";
+import { useTestServer } from "./../setup";
 
-beforeAll(async () => {
-  await api.start();
-  await api.redis.redis.flushdb();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+useTestServer({ clearRedis: true });
 
 describe("session initializer", () => {
   test("session object is initialized", () => {

--- a/packages/keryx/__tests__/initializers/swagger.test.ts
+++ b/packages/keryx/__tests__/initializers/swagger.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { rm } from "fs/promises";
 import path from "path";
 import { api } from "../../api";
@@ -7,15 +7,9 @@ import {
   loadCachedSchemas,
   writeSchemasCache,
 } from "../../util/swaggerSchemaGenerator";
-import { HOOK_TIMEOUT } from "./../setup";
+import { useTestServer } from "./../setup";
 
-beforeAll(async () => {
-  await api.start();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+useTestServer();
 
 describe("swagger initializer", () => {
   test("swagger namespace is initialized", () => {

--- a/packages/keryx/__tests__/servers/streaming.test.ts
+++ b/packages/keryx/__tests__/servers/streaming.test.ts
@@ -1,16 +1,13 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { z } from "zod";
 import { api } from "../../api";
 import { type Action, HTTP_METHOD } from "../../classes/Action";
 import { StreamingResponse } from "../../classes/StreamingResponse";
-import { HOOK_TIMEOUT, serverUrl } from "../setup";
+import { useTestServer } from "../setup";
 
-let url: string;
+const getUrl = useTestServer();
 
-beforeAll(async () => {
-  await api.start();
-  url = serverUrl();
-
+beforeAll(() => {
   // SSE action that sends a configurable number of counter events
   const sseAction = {
     name: "test:sse",
@@ -70,11 +67,7 @@ beforeAll(async () => {
   } as unknown as Action;
 
   api.actions.actions.push(sseAction, streamAction, sseErrorAction);
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+});
 
 /**
  * Parse raw SSE text into an array of event objects.
@@ -107,7 +100,7 @@ function parseSSE(
 
 describe("SSE streaming", () => {
   test("returns correct SSE headers", async () => {
-    const res = await fetch(url + "/api/test/sse");
+    const res = await fetch(getUrl() + "/api/test/sse");
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("text/event-stream");
     expect(res.headers.get("Cache-Control")).toBe("no-cache");
@@ -116,14 +109,14 @@ describe("SSE streaming", () => {
   });
 
   test("includes standard keryx headers (CORS, security, session)", async () => {
-    const res = await fetch(url + "/api/test/sse");
+    const res = await fetch(getUrl() + "/api/test/sse");
     expect(res.headers.get("X-SERVER-NAME")).toBeTruthy();
     expect(res.headers.get("Set-Cookie")).toBeTruthy();
     await res.text();
   });
 
   test("streams counter events with correct SSE format", async () => {
-    const res = await fetch(url + "/api/test/sse?count=3");
+    const res = await fetch(getUrl() + "/api/test/sse?count=3");
     const text = await res.text();
     const events = parseSSE(text);
 
@@ -136,7 +129,7 @@ describe("SSE streaming", () => {
   });
 
   test("does not compress SSE responses", async () => {
-    const res = await fetch(url + "/api/test/sse?count=5", {
+    const res = await fetch(getUrl() + "/api/test/sse?count=5", {
       headers: { "Accept-Encoding": "gzip, br" },
     });
     expect(res.headers.get("Content-Encoding")).toBeNull();
@@ -144,7 +137,7 @@ describe("SSE streaming", () => {
   });
 
   test("SSE error event sends error and closes stream", async () => {
-    const res = await fetch(url + "/api/test/sse-error");
+    const res = await fetch(getUrl() + "/api/test/sse-error");
     const text = await res.text();
     const events = parseSSE(text);
 
@@ -157,7 +150,7 @@ describe("SSE streaming", () => {
 
 describe("raw streaming", () => {
   test("streams binary chunks with correct content type", async () => {
-    const res = await fetch(url + "/api/test/stream");
+    const res = await fetch(getUrl() + "/api/test/stream");
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
     const text = await res.text();

--- a/packages/keryx/__tests__/servers/web.test.ts
+++ b/packages/keryx/__tests__/servers/web.test.ts
@@ -5,18 +5,13 @@ import { z } from "zod";
 import type { Status } from "../../actions/status";
 import { type ActionResponse, api, config } from "../../api";
 import { type Action, HTTP_METHOD } from "../../classes/Action";
-import { HOOK_TIMEOUT, serverUrl } from "./../setup";
+import { useTestServer } from "./../setup";
 
-let url: string;
-
-beforeAll(async () => {
-  await api.start();
-  url = serverUrl();
-}, HOOK_TIMEOUT);
+const getUrl = useTestServer();
 
 const staticDir = config.server.web.staticFiles.directory;
 
-beforeAll(async () => {
+beforeAll(() => {
   // Ensure the static assets directory exists with test files
   if (!existsSync(staticDir)) mkdirSync(staticDir, { recursive: true });
   writeFileSync(path.join(staticDir, "test.txt"), "hello static");
@@ -30,30 +25,29 @@ beforeAll(async () => {
   writeFileSync(path.join(subDir, "index.html"), "<h1>subdir index</h1>");
 });
 
-afterAll(async () => {
-  await api.stop();
+afterAll(() => {
   // Clean up test files
   rmSync(path.join(staticDir, "test.txt"), { force: true });
   rmSync(path.join(staticDir, "index.html"), { force: true });
   rmSync(path.join(staticDir, "subdir"), { recursive: true, force: true });
-}, HOOK_TIMEOUT);
+});
 
 describe("booting", () => {
   test("the web server will boot on a test port", async () => {
-    expect(url).toMatch(/^http:\/\/localhost:\d+$/);
+    expect(getUrl()).toMatch(/^http:\/\/localhost:\d+$/);
   });
 });
 
 describe("actions", () => {
   test("the web server can handle a request to an action", async () => {
-    const res = await fetch(url + "/api/status");
+    const res = await fetch(getUrl() + "/api/status");
     expect(res.status).toBe(200);
     const response = (await res.json()) as ActionResponse<Status>;
     expect(response.name).toInclude("test-server");
   });
 
   test("trying for a non-existent action returns a 404", async () => {
-    const res = await fetch(url + "/api/non-existent-action");
+    const res = await fetch(getUrl() + "/api/non-existent-action");
     expect(res.status).toBe(404);
     const response = (await res.json()) as ActionResponse<Status>;
     expect(response.error?.message).toContain("Action not found");
@@ -64,7 +58,7 @@ describe("actions", () => {
     const original = config.server.web.includeStackInErrors;
     config.server.web.includeStackInErrors = false;
     try {
-      const res = await fetch(url + "/api/non-existent-action");
+      const res = await fetch(getUrl() + "/api/non-existent-action");
       expect(res.status).toBe(404);
       const response = (await res.json()) as ActionResponse<Status>;
       expect(response.error?.message).toContain("Action not found");
@@ -77,7 +71,7 @@ describe("actions", () => {
 
 describe("security headers", () => {
   test("API responses include security headers", async () => {
-    const res = await fetch(url + "/api/status");
+    const res = await fetch(getUrl() + "/api/status");
     expect(res.headers.get("Content-Security-Policy")).toBe(
       "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net data:; img-src 'self' data: blob:; connect-src 'self'; worker-src blob:",
     );
@@ -92,7 +86,7 @@ describe("security headers", () => {
   });
 
   test("static file responses include security headers", async () => {
-    const res = await fetch(url + "/test.txt");
+    const res = await fetch(getUrl() + "/test.txt");
     expect(res.headers.get("Content-Security-Policy")).toBe(
       "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net data:; img-src 'self' data: blob:; connect-src 'self'; worker-src blob:",
     );
@@ -112,7 +106,7 @@ describe("CORS headers", () => {
     const original = config.server.web.allowedOrigins;
     (config.server.web as any).allowedOrigins = "*";
     try {
-      const res = await fetch(url + "/api/status");
+      const res = await fetch(getUrl() + "/api/status");
       expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
       expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
     } finally {
@@ -124,7 +118,7 @@ describe("CORS headers", () => {
     const original = config.server.web.allowedOrigins;
     (config.server.web as any).allowedOrigins = "*";
     try {
-      const res = await fetch(url + "/api/status", {
+      const res = await fetch(getUrl() + "/api/status", {
         headers: { Origin: "http://example.com" },
       });
       expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
@@ -141,7 +135,7 @@ describe("CORS headers", () => {
     const original = config.server.web.allowedOrigins;
     (config.server.web as any).allowedOrigins = "http://allowed.example.com";
     try {
-      const res = await fetch(url + "/api/status", {
+      const res = await fetch(getUrl() + "/api/status", {
         headers: { Origin: "http://allowed.example.com" },
       });
       expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
@@ -158,7 +152,7 @@ describe("CORS headers", () => {
     const original = config.server.web.allowedOrigins;
     (config.server.web as any).allowedOrigins = "http://allowed.example.com";
     try {
-      const res = await fetch(url + "/api/status", {
+      const res = await fetch(getUrl() + "/api/status", {
         headers: { Origin: "http://evil.example.com" },
       });
       expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
@@ -169,6 +163,7 @@ describe("CORS headers", () => {
 
   test("OPTIONS preflight with Origin reflects origin", async () => {
     const original = config.server.web.allowedOrigins;
+    const url = getUrl();
     (config.server.web as any).allowedOrigins = url;
     try {
       const res = await fetch(url + "/api/status", {
@@ -186,19 +181,19 @@ describe("CORS headers", () => {
 
 describe("cookies", () => {
   test("session cookie uses SameSite=Strict", async () => {
-    const res = await fetch(url + "/api/status");
+    const res = await fetch(getUrl() + "/api/status");
     const setCookie = res.headers.get("set-cookie") ?? "";
     expect(setCookie).toContain("SameSite=Strict");
   });
 
   test("session cookie includes HttpOnly", async () => {
-    const res = await fetch(url + "/api/status");
+    const res = await fetch(getUrl() + "/api/status");
     const setCookie = res.headers.get("set-cookie") ?? "";
     expect(setCookie).toContain("HttpOnly");
   });
 
   test("session cookie includes expected name", async () => {
-    const res = await fetch(url + "/api/status");
+    const res = await fetch(getUrl() + "/api/status");
     const setCookie = res.headers.get("set-cookie") ?? "";
     expect(setCookie).toContain(`${config.session.cookieName}=`);
   });
@@ -206,7 +201,7 @@ describe("cookies", () => {
 
 describe("correlation IDs", () => {
   test("no X-Request-Id header by default (trustProxy is false)", async () => {
-    const res = await fetch(url + "/api/status");
+    const res = await fetch(getUrl() + "/api/status");
     expect(res.headers.get("X-Request-Id")).toBeNull();
   });
 
@@ -215,7 +210,7 @@ describe("correlation IDs", () => {
     (config.server.web.correlationId as any).trustProxy = true;
     try {
       const incomingId = crypto.randomUUID();
-      const res = await fetch(url + "/api/status", {
+      const res = await fetch(getUrl() + "/api/status", {
         headers: { "X-Request-Id": incomingId },
       });
       expect(res.headers.get("X-Request-Id")).toBe(incomingId);
@@ -228,7 +223,7 @@ describe("correlation IDs", () => {
     const original = config.server.web.correlationId.trustProxy;
     (config.server.web.correlationId as any).trustProxy = true;
     try {
-      const res = await fetch(url + "/api/status");
+      const res = await fetch(getUrl() + "/api/status");
       expect(res.headers.get("X-Request-Id")).toBeNull();
     } finally {
       (config.server.web.correlationId as any).trustProxy = original;
@@ -241,7 +236,7 @@ describe("correlation IDs", () => {
     (config.server.web.correlationId as any).header = "";
     (config.server.web.correlationId as any).trustProxy = true;
     try {
-      const res = await fetch(url + "/api/status", {
+      const res = await fetch(getUrl() + "/api/status", {
         headers: { "X-Request-Id": crypto.randomUUID() },
       });
       expect(res.headers.get("X-Request-Id")).toBeNull();
@@ -256,7 +251,7 @@ describe("correlation IDs", () => {
     (config.server.web.correlationId as any).trustProxy = true;
     try {
       const incomingId = crypto.randomUUID();
-      const res = await fetch(url + "/api/non-existent-action", {
+      const res = await fetch(getUrl() + "/api/non-existent-action", {
         headers: { "X-Request-Id": incomingId },
       });
       expect(res.status).toBe(404);
@@ -269,48 +264,48 @@ describe("correlation IDs", () => {
 
 describe("static files", () => {
   test("serves a file from the static directory", async () => {
-    const res = await fetch(url + "/test.txt");
+    const res = await fetch(getUrl() + "/test.txt");
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("hello static");
   });
 
   test("blocks path traversal with ../", async () => {
-    const res = await fetch(url + "/../package.json");
+    const res = await fetch(getUrl() + "/../package.json");
     // Should not serve a file outside staticDir — falls through to action routing → 404
     expect(res.status).toBe(404);
   });
 
   test("blocks encoded path traversal with %2e%2e", async () => {
-    const res = await fetch(url + "/%2e%2e/package.json");
+    const res = await fetch(getUrl() + "/%2e%2e/package.json");
     expect(res.status).toBe(404);
   });
 
   test("includes ETag and Last-Modified headers", async () => {
-    const res = await fetch(url + "/test.txt");
+    const res = await fetch(getUrl() + "/test.txt");
     expect(res.status).toBe(200);
     expect(res.headers.get("etag")).toMatch(/^".+"$/);
     expect(res.headers.get("last-modified")).toBeTruthy();
   });
 
   test("includes Cache-Control header", async () => {
-    const res = await fetch(url + "/test.txt");
+    const res = await fetch(getUrl() + "/test.txt");
     expect(res.status).toBe(200);
     expect(res.headers.get("cache-control")).toBe("public, max-age=3600");
   });
 
   test("returns 304 for matching If-None-Match", async () => {
-    const res1 = await fetch(url + "/test.txt");
+    const res1 = await fetch(getUrl() + "/test.txt");
     const etag = res1.headers.get("etag")!;
     expect(etag).toBeTruthy();
 
-    const res2 = await fetch(url + "/test.txt", {
+    const res2 = await fetch(getUrl() + "/test.txt", {
       headers: { "If-None-Match": etag },
     });
     expect(res2.status).toBe(304);
   });
 
   test("returns 200 for non-matching If-None-Match", async () => {
-    const res = await fetch(url + "/test.txt", {
+    const res = await fetch(getUrl() + "/test.txt", {
       headers: { "If-None-Match": '"bogus"' },
     });
     expect(res.status).toBe(200);
@@ -318,18 +313,18 @@ describe("static files", () => {
   });
 
   test("returns 304 for If-Modified-Since when file is not newer", async () => {
-    const res1 = await fetch(url + "/test.txt");
+    const res1 = await fetch(getUrl() + "/test.txt");
     const lastModified = res1.headers.get("last-modified")!;
     expect(lastModified).toBeTruthy();
 
-    const res2 = await fetch(url + "/test.txt", {
+    const res2 = await fetch(getUrl() + "/test.txt", {
       headers: { "If-Modified-Since": lastModified },
     });
     expect(res2.status).toBe(304);
   });
 
   test("returns 200 for If-Modified-Since in the distant past", async () => {
-    const res = await fetch(url + "/test.txt", {
+    const res = await fetch(getUrl() + "/test.txt", {
       headers: { "If-Modified-Since": "Thu, 01 Jan 1970 00:00:00 GMT" },
     });
     expect(res.status).toBe(200);
@@ -340,7 +335,7 @@ describe("static files", () => {
     const original = config.server.web.staticFiles.etag;
     (config.server.web.staticFiles as any).etag = false;
     try {
-      const res = await fetch(url + "/test.txt");
+      const res = await fetch(getUrl() + "/test.txt");
       expect(res.status).toBe(200);
       expect(res.headers.get("etag")).toBeNull();
       expect(res.headers.get("last-modified")).toBeNull();
@@ -351,19 +346,19 @@ describe("static files", () => {
 
   test("serves index.html for root static route", async () => {
     const staticRoute = config.server.web.staticFiles.route;
-    const res = await fetch(url + staticRoute);
+    const res = await fetch(getUrl() + staticRoute);
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("root index");
   });
 
   test("serves index.html for subdirectory path", async () => {
-    const res = await fetch(url + "/subdir/");
+    const res = await fetch(getUrl() + "/subdir/");
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("subdir index");
   });
 
   test("serves index.html for subdirectory path without trailing slash", async () => {
-    const res = await fetch(url + "/subdir");
+    const res = await fetch(getUrl() + "/subdir");
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("subdir index");
   });
@@ -452,14 +447,14 @@ describe("raw Response passthrough", () => {
   });
 
   test("returns the raw Response body and Content-Type", async () => {
-    const res = await fetch(url + "/api/test/raw-response");
+    const res = await fetch(getUrl() + "/api/test/raw-response");
     expect(res.status).toBe(200);
     expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
     expect(await res.text()).toBe("raw binary data");
   });
 
   test("does not include Keryx standard headers", async () => {
-    const res = await fetch(url + "/api/test/raw-response");
+    const res = await fetch(getUrl() + "/api/test/raw-response");
     expect(res.headers.get("Set-Cookie")).toBeNull();
     expect(res.headers.get("X-SERVER-NAME")).toBeNull();
     expect(res.headers.get("X-Content-Type-Options")).toBeNull();
@@ -467,7 +462,7 @@ describe("raw Response passthrough", () => {
   });
 
   test("preserves custom status codes", async () => {
-    const res = await fetch(url + "/api/test/raw-response-201", {
+    const res = await fetch(getUrl() + "/api/test/raw-response-201", {
       method: "POST",
     });
     expect(res.status).toBe(201);
@@ -476,7 +471,7 @@ describe("raw Response passthrough", () => {
   });
 
   test("handles empty body with 204 status", async () => {
-    const res = await fetch(url + "/api/test/raw-response-204", {
+    const res = await fetch(getUrl() + "/api/test/raw-response-204", {
       method: "DELETE",
     });
     expect(res.status).toBe(204);
@@ -487,7 +482,7 @@ describe("raw Response passthrough", () => {
 describe("compression", () => {
   // The /api/swagger endpoint returns a large OpenAPI spec (well above 1024 bytes)
   test("returns gzip-compressed response when Accept-Encoding: gzip", async () => {
-    const res = await fetch(url + "/api/swagger", {
+    const res = await fetch(getUrl() + "/api/swagger", {
       headers: { "Accept-Encoding": "gzip" },
       decompress: false,
     });
@@ -504,7 +499,7 @@ describe("compression", () => {
   });
 
   test("returns brotli-compressed response when Accept-Encoding: br", async () => {
-    const res = await fetch(url + "/api/swagger", {
+    const res = await fetch(getUrl() + "/api/swagger", {
       headers: { "Accept-Encoding": "br" },
       decompress: false,
     });
@@ -519,7 +514,7 @@ describe("compression", () => {
   });
 
   test("prefers brotli over gzip when both are accepted", async () => {
-    const res = await fetch(url + "/api/swagger", {
+    const res = await fetch(getUrl() + "/api/swagger", {
       headers: { "Accept-Encoding": "gzip, br" },
       decompress: false,
     });
@@ -528,7 +523,7 @@ describe("compression", () => {
   });
 
   test("does not compress when Accept-Encoding is absent", async () => {
-    const res = await fetch(url + "/api/swagger", {
+    const res = await fetch(getUrl() + "/api/swagger", {
       headers: { "Accept-Encoding": "" },
       decompress: false,
     });
@@ -538,7 +533,7 @@ describe("compression", () => {
 
   test("does not compress responses below the threshold", async () => {
     // /api/status returns a small JSON object (~200 bytes), below the 1024 byte threshold
-    const res = await fetch(url + "/api/status", {
+    const res = await fetch(getUrl() + "/api/status", {
       headers: { "Accept-Encoding": "gzip" },
       decompress: false,
     });
@@ -547,7 +542,7 @@ describe("compression", () => {
   });
 
   test("does not compress null-body responses", async () => {
-    const res = await fetch(url + "/.well-known/test", {
+    const res = await fetch(getUrl() + "/.well-known/test", {
       headers: { "Accept-Encoding": "gzip" },
       decompress: false,
     });
@@ -560,7 +555,7 @@ describe("compression", () => {
     writeFileSync(path.join(staticDir, "large.txt"), largeContent);
 
     try {
-      const res = await fetch(url + "/large.txt", {
+      const res = await fetch(getUrl() + "/large.txt", {
         headers: { "Accept-Encoding": "gzip" },
         decompress: false,
       });

--- a/packages/keryx/__tests__/servers/websocket.test.ts
+++ b/packages/keryx/__tests__/servers/websocket.test.ts
@@ -1,18 +1,11 @@
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { api } from "../../api";
 import { Channel } from "../../classes/Channel";
 import { config } from "../../config";
-import { HOOK_TIMEOUT, serverUrl } from "./../setup";
+import { serverUrl, useTestServer } from "./../setup";
 import { buildWebSocket } from "./websocket-helpers";
 
-beforeAll(async () => {
-  await api.start();
-  await api.db.clearDatabase();
-}, HOOK_TIMEOUT);
-
-afterAll(async () => {
-  await api.stop();
-}, HOOK_TIMEOUT);
+useTestServer({ clearDatabase: true });
 
 test("request to an action", async () => {
   const { socket, messages } = await buildWebSocket();

--- a/packages/keryx/__tests__/setup.ts
+++ b/packages/keryx/__tests__/setup.ts
@@ -1,42 +1,10 @@
 import { setMaxListeners } from "events";
-import { api } from "../api";
-import type { WebServer } from "../servers/web";
+
+export { HOOK_TIMEOUT, serverUrl, useTestServer, waitFor } from "../testing";
 
 // Set max listeners to prevent warnings in CI environments
 // TODO: Github Actions needs this, but not locally. Why?
 setMaxListeners(999);
-
-// CI environments are slower; hooks need enough time for api.start()/api.stop()
-// which connect to Redis, Postgres, run migrations, etc.
-// bun:test's setDefaultTimeout and bunfig.toml [test].timeout only apply to
-// test() blocks, not lifecycle hooks — so we export this for explicit use.
-export const HOOK_TIMEOUT = 15_000;
-
-/**
- * Return the actual URL the web server bound to (resolved port).
- * Call after api.start() so the server has bound its port.
- */
-export function serverUrl(): string {
-  const web = api.servers.servers.find((s) => s.name === "web") as
-    | WebServer
-    | undefined;
-  return web?.url || "";
-}
-
-/**
- * Poll a condition until it returns true, or throw after a timeout.
- * Use this instead of fixed Bun.sleep() calls when waiting for async side effects.
- */
-export async function waitFor(
-  condition: () => Promise<boolean> | boolean,
-  { interval = 50, timeout = 5000 } = {},
-): Promise<void> {
-  const start = Date.now();
-  while (!(await condition())) {
-    if (Date.now() - start > timeout) throw new Error("waitFor timed out");
-    await Bun.sleep(interval);
-  }
-}
 
 // ioredis flushes its command queue on connection close, rejecting pending
 // commands with "Connection is closed." These rejections are unhandled because

--- a/packages/keryx/__tests__/util/mcpServer.test.ts
+++ b/packages/keryx/__tests__/util/mcpServer.test.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import { api } from "../../api";
 import { Action, HTTP_METHOD } from "../../classes/Action";
 import { config } from "../../config";
-import { HOOK_TIMEOUT, serverUrl } from "../setup";
+import { serverUrl, useTestServer } from "../setup";
 
 const mcpUrl = () => `${serverUrl()}${config.server.mcp.route}`;
 
@@ -83,10 +83,13 @@ class TestPrompt extends Action {
 describe("mcpServer utilities (integration)", () => {
   const testActions: Action[] = [];
 
-  beforeAll(async () => {
+  beforeAll(() => {
     config.server.mcp.enabled = true;
-    await api.start();
+  });
 
+  useTestServer();
+
+  beforeAll(() => {
     // Inject test actions after start (api.actions is now populated).
     // MCP servers are created per-session, so these will be picked up
     // when the test client connects.
@@ -94,10 +97,9 @@ describe("mcpServer utilities (integration)", () => {
     const prompt = new TestPrompt();
     testActions.push(templateResource, prompt);
     api.actions.actions.push(...testActions);
-  }, HOOK_TIMEOUT);
+  });
 
-  afterAll(async () => {
-    await api.stop();
+  afterAll(() => {
     config.server.mcp.enabled = false;
 
     // Remove injected test actions
@@ -105,7 +107,7 @@ describe("mcpServer utilities (integration)", () => {
       const idx = api.actions.actions.indexOf(action);
       if (idx !== -1) api.actions.actions.splice(idx, 1);
     }
-  }, HOOK_TIMEOUT);
+  });
 
   describe("URI template resources", () => {
     // MCP requires auth — get a token via the OAuth initializer

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.21.6",
+  "version": "0.21.9",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",
@@ -49,6 +49,7 @@
     "middleware/",
     "servers/",
     "templates/",
+    "testing/",
     "util/",
     "api.ts",
     "index.ts",
@@ -69,7 +70,8 @@
     "./util/*": "./util/*",
     "./config": "./config/index.ts",
     "./config/*": "./config/*",
-    "./servers/*": "./servers/*"
+    "./servers/*": "./servers/*",
+    "./testing": "./testing/index.ts"
   },
   "scripts": {
     "start": "bun keryx.ts start",

--- a/packages/keryx/testing/index.ts
+++ b/packages/keryx/testing/index.ts
@@ -1,0 +1,105 @@
+import { afterAll, beforeAll } from "bun:test";
+import { api } from "../api";
+import type { WebServer } from "../servers/web";
+
+/**
+ * Generous lifecycle hook timeout (15s) for `beforeAll` / `afterAll`.
+ *
+ * `api.start()` and `api.stop()` connect to Redis, Postgres, run migrations,
+ * etc. — slower than a unit test, especially in CI. Pass this as the second
+ * argument to `beforeAll` / `afterAll` so hooks don't time out.
+ *
+ * Note: `bun:test`'s `setDefaultTimeout` and `bunfig.toml [test].timeout` only
+ * apply to `test()` blocks, not lifecycle hooks.
+ */
+export const HOOK_TIMEOUT = 15_000;
+
+/**
+ * Return the actual URL the web server bound to (with resolved port).
+ * Returns an empty string if the web server isn't running.
+ *
+ * Call after `api.start()` so the server has bound its port. Useful when
+ * `WEB_SERVER_PORT=0` is set so each test file gets a random available port.
+ */
+export function serverUrl(): string {
+  const web = api.servers.servers.find(
+    (s: { name: string }) => s.name === "web",
+  ) as WebServer | undefined;
+  return web?.url || "";
+}
+
+/**
+ * Register `beforeAll` / `afterAll` hooks that start and stop the API around
+ * a test file. Returns a getter for the bound server URL — the URL isn't known
+ * until after `api.start()` binds the port, so it can't be returned directly.
+ *
+ * **Hook ordering gotcha.** `bun:test` runs `beforeAll` and `afterAll` hooks in
+ * registration order (not LIFO). So whichever hook is registered first runs
+ * first — in both phases. This matters in two ways:
+ *
+ * 1. **Config overrides that must happen before `api.start()`** — register a
+ *    separate `beforeAll` that sets the config *before* calling `useTestServer()`,
+ *    so it runs first.
+ * 2. **Teardown cleanup that needs Redis/DB access** — the helper's `afterAll`
+ *    calls `api.stop()`, which closes the Redis and Postgres connections. Any
+ *    cleanup that touches those must run *before* `api.stop()`. Since `afterAll`
+ *    also runs in registration order, the helper's `api.stop()` runs first. Put
+ *    connection-dependent cleanup in the same `afterAll` block as the original
+ *    start/stop pair rather than splitting it, or handle cleanup in `afterEach`.
+ *
+ * @param opts.clearDatabase - Truncate all tables in `beforeAll`. Default `false`.
+ *   Requires the `db` initializer to be active. Opt in for tests that mutate
+ *   persistent state.
+ * @param opts.clearRedis - Flush the current Redis DB in `beforeAll`. Default
+ *   `false`. Requires the `redis` initializer to be active. Opt in for tests
+ *   that exercise pub/sub so messages from prior tests don't leak in.
+ * @returns A getter function that returns the server URL once `api.start()` has
+ *   bound its port. Call the getter at each fetch site: `fetch(getUrl() + "/api/...")`.
+ *
+ * @example
+ * const getUrl = useTestServer({ clearDatabase: true });
+ *
+ * test("creates a user", async () => {
+ *   const res = await fetch(getUrl() + "/api/user", { method: "PUT", ... });
+ *   expect(res.status).toBe(200);
+ * });
+ */
+export function useTestServer(
+  opts: { clearDatabase?: boolean; clearRedis?: boolean } = {},
+): () => string {
+  const { clearDatabase = false, clearRedis = false } = opts;
+  let url = "";
+  beforeAll(async () => {
+    await api.start();
+    url = serverUrl();
+    if (clearDatabase) await api.db.clearDatabase();
+    if (clearRedis) await api.redis.redis.flushdb();
+  }, HOOK_TIMEOUT);
+  afterAll(async () => {
+    await api.stop();
+  }, HOOK_TIMEOUT);
+  return () => url;
+}
+
+/**
+ * Poll a condition until it returns true, or throw after a timeout.
+ *
+ * Use this instead of fixed `Bun.sleep()` calls when waiting for async side
+ * effects like background tasks, pub/sub delivery, or presence updates.
+ *
+ * @param condition - Function returning a boolean (or Promise of one). Polled
+ *   repeatedly until it returns truthy.
+ * @param opts.interval - Milliseconds between polls. Default 50.
+ * @param opts.timeout - Milliseconds before giving up. Default 5000.
+ * @throws {Error} If the condition doesn't become truthy before the timeout.
+ */
+export async function waitFor(
+  condition: () => Promise<boolean> | boolean,
+  { interval = 50, timeout = 5000 } = {},
+): Promise<void> {
+  const start = Date.now();
+  while (!(await condition())) {
+    if (Date.now() - start > timeout) throw new Error("waitFor timed out");
+    await Bun.sleep(interval);
+  }
+}


### PR DESCRIPTION
## Summary

- New public `keryx/testing` subpath export with `useTestServer()`, `serverUrl()`, `HOOK_TIMEOUT`, and `waitFor()` — resolves [#359](https://github.com/actionhero/keryx/issues/359) and gives app authors a supported test utility.
- 18 test files migrated (6 example backend + 12 framework), cutting 430 lines of `beforeAll`/`afterAll` boilerplate. Both workspaces' local `setup.ts` files slimmed to env-specific bits (max listeners, ioredis rejection filter) and re-export from `keryx/testing`.
- `useTestServer()` defaults both `clearDatabase` and `clearRedis` to `false` — callers opt in. JSDoc explicitly flags the `bun:test` hook-ordering gotcha (hooks run in registration order, so Redis/DB cleanup must precede the helper's `api.stop()`).
- Docs (`docs/guide/testing.md`) rewritten around the helper. Version bumped 0.21.6 → 0.21.9.

## Test plan

- [x] `bun lint` clean across all 4 workspaces
- [x] Framework tests: 405/405 pass
- [x] Example backend tests: 215/215 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)