### PR TITLE
Require connection on Action.run and inline task connection in resque worker

### DIFF
--- a/example/backend/actions/message.ts
+++ b/example/backend/actions/message.ts
@@ -35,7 +35,7 @@ export class MessageCrete implements Action {
     params: ActionParams<MessageCrete>,
     connection: Connection<SessionImpl>,
   ) {
-    const userId = connection!.session!.data.userId!;
+    const userId = connection.session!.data.userId!;
 
     const [message] = await api.db.db
       .insert(messages)

--- a/example/backend/actions/user.ts
+++ b/example/backend/actions/user.ts
@@ -100,7 +100,7 @@ export class UserEdit implements Action {
     const [user] = await api.db.db
       .update(users)
       .set(updates)
-      .where(eq(users.id, connection.session?.data.userId))
+      .where(eq(users.id, connection.session!.data.userId))
       .returning();
 
     return { user: serializeUser(user) };

--- a/example/backend/assets/index.html
+++ b/example/backend/assets/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
       .scalar-api-references-footer {
-              display: none !important;
-            }
+                                                                    display: none !important;
+                                                                  }
     </style>
   </head>
   <body>

--- a/example/backend/middleware/channel.ts
+++ b/example/backend/middleware/channel.ts
@@ -27,7 +27,7 @@ export const SessionChannelMiddleware: ChannelMiddleware = {
     _channel: string,
     connection: Connection<SessionImpl>,
   ): Promise<void> => {
-    if (!connection.session || !connection.session.data.userId) {
+    if (!connection.session?.data.userId) {
       throw new TypedError({
         message: "Authentication required to join this channel",
         type: ErrorType.CONNECTION_CHANNEL_AUTHORIZATION,

--- a/example/backend/middleware/session.ts
+++ b/example/backend/middleware/session.ts
@@ -8,7 +8,7 @@ import type { SessionImpl } from "../actions/session";
 
 export const SessionMiddleware: ActionMiddleware = {
   runBefore: async (_params, connection: Connection<SessionImpl>) => {
-    if (!connection.session || !connection.session.data.userId) {
+    if (!connection.session?.data.userId) {
       throw new TypedError({
         message: "Session not found",
         type: ErrorType.CONNECTION_SESSION_NOT_FOUND,

--- a/packages/keryx/__tests__/initializers/resque.test.ts
+++ b/packages/keryx/__tests__/initializers/resque.test.ts
@@ -8,7 +8,7 @@ import {
   test,
 } from "bun:test";
 import { z } from "zod";
-import { Action, api } from "../../api";
+import { Action, api, Connection } from "../../api";
 import { DEFAULT_QUEUE } from "../../classes/Action";
 import { HOOK_TIMEOUT, waitFor } from "./../setup";
 
@@ -147,5 +147,37 @@ describe("with workers and scheduler", () => {
     await api.resque.startScheduler();
     await waitFor(() => runs.length > 1);
     expect(runs.length).toBeGreaterThan(1);
+  });
+
+  test("task actions receive a task-typed connection with an empty session (fresh start)", async () => {
+    let sessionData: Record<string, any> | undefined;
+    let connectionType: string | undefined;
+
+    class BareAction implements Action {
+      name = "bare_action";
+      inputs = z.object({});
+      run = async (
+        _params: Record<string, unknown>,
+        connection: Connection,
+      ): Promise<void> => {
+        sessionData = connection.session?.data;
+        connectionType = connection.type;
+      };
+    }
+    const instance = new BareAction();
+    api.actions.actions.push(instance);
+    api.resque.jobs[instance.name] = api.resque.wrapActionAsJob(instance);
+
+    await api.actions.enqueue("bare_action");
+    await api.resque.startWorkers();
+    await waitFor(() => sessionData !== undefined);
+
+    expect(sessionData).toEqual({});
+    expect(connectionType).toBe("task");
+
+    api.actions.actions = api.actions.actions.filter(
+      (a) => a.name !== "bare_action",
+    );
+    delete api.resque.jobs.bare_action;
   });
 });

--- a/packages/keryx/classes/Action.ts
+++ b/packages/keryx/classes/Action.ts
@@ -181,10 +181,12 @@ export abstract class Action {
    *   action's `inputs` Zod schema (falls back to `Record<string, unknown>` when no schema is
    *   defined). By the time `run` is called, all middleware `runBefore` hooks have already
    *   executed and may have mutated the params.
-   * @param connection - The connection that initiated this action. Provides access to the
-   *   caller's session (`connection.session`), subscription state, and raw transport handle.
-   *   It is `undefined` when the action is invoked outside an HTTP/WebSocket request context
-   *   (e.g., as a background task via the Resque worker or via `api.actions.run()`).
+   * @param connection - The connection that initiated this action. Always defined. Provides
+   *   access to the caller's session (`connection.session`), subscription state, and raw
+   *   transport handle. For background tasks (resque worker), `connection.type === "task"`
+   *   and `connection.session.data` is empty — tasks are fresh starts, so actions that
+   *   need user context should receive it as an input parameter rather than reading from
+   *   the session.
    * @param abortSignal - An `AbortSignal` tied to the action's timeout. The signal is aborted
    *   when the per-action `timeout` (or the global `config.actions.timeout`, default 300 000 ms)
    *   elapses. Long-running actions should check `abortSignal.aborted` or pass the signal to
@@ -194,7 +196,7 @@ export abstract class Action {
    */
   abstract run(
     params: ActionParams<Action>,
-    connection?: Connection,
+    connection: Connection,
     abortSignal?: AbortSignal,
   ): Promise<any>;
 }

--- a/packages/keryx/initializers/resque.ts
+++ b/packages/keryx/initializers/resque.ts
@@ -279,9 +279,11 @@ export class Resque extends Initializer {
   };
 
   /**
-   * Wrap an action as a node-resque job. Creates a temporary `Connection` with type `"resque"`,
-   * converts inputs to a plain object, and runs the action via `connection.act()`. Handles
-   * fan-out result/error collection and recurring task re-enqueue.
+   * Wrap an action as a node-resque job. Creates a fresh `Connection` of type `"task"`
+   * with an empty in-memory session stub (tasks are fresh starts — no Redis read/write
+   * for session), converts inputs to a plain object, and runs the action via
+   * `connection.act()`. Handles fan-out result/error collection and recurring task
+   * re-enqueue.
    */
   wrapActionAsJob = (
     action: Action,
@@ -291,18 +293,6 @@ export class Resque extends Initializer {
       pluginOptions: {},
 
       perform: async function (params: ActionParams<typeof action>) {
-        const connection = new Connection(
-          "resque",
-          `job:${api.process.name}:${SERVER_JOB_COUNTER++}}`,
-        );
-
-        const propagatedCorrelationId = params._correlationId as
-          | string
-          | undefined;
-        if (propagatedCorrelationId) {
-          connection.correlationId = propagatedCorrelationId;
-        }
-
         const plainParams: Record<string, unknown> =
           typeof params === "object" && params !== null
             ? Object.fromEntries(
@@ -311,6 +301,27 @@ export class Resque extends Initializer {
                   : Object.entries(params),
               )
             : {};
+
+        const propagatedCorrelationId = plainParams._correlationId as
+          | string
+          | undefined;
+
+        const connection = new Connection(
+          "task",
+          `job:${api.process.name}:${SERVER_JOB_COUNTER++}`,
+        );
+        if (propagatedCorrelationId) {
+          connection.correlationId = propagatedCorrelationId;
+        }
+        // Synthesize an empty session in-memory — tasks are fresh starts; needed data
+        // must come through action params, not session state.
+        connection.session = {
+          id: `task:${connection.id}`,
+          cookieName: config.session.cookieName,
+          createdAt: Date.now(),
+          data: {},
+        };
+        connection.sessionLoaded = true;
 
         const fanOutId = plainParams._fanOutId as string | undefined;
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.21.6",
+  "version": "0.22.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/templates/scaffold/middleware-session.ts.mustache
+++ b/packages/keryx/templates/scaffold/middleware-session.ts.mustache
@@ -3,7 +3,7 @@ import type { ActionMiddleware } from "keryx/classes/Action.ts";
 
 export const SessionMiddleware: ActionMiddleware = {
   runBefore: async (_params, connection: Connection<{ userId?: number }>) => {
-    if (!connection.session || !connection.session.data.userId) {
+    if (!connection.session?.data.userId) {
       throw new TypedError({
         message: "Session not found",
         type: ErrorType.CONNECTION_SESSION_NOT_FOUND,


### PR DESCRIPTION
## Summary

Fixes #350. `Action.run(params, connection?: Connection)` had `connection` as optional — HTTP-only actions compiled fine when dereferencing `connection.session.data.userId`, then crashed at runtime when the same action ran as a background task. At runtime, the resque worker already constructed a Connection and passed it through — the `?` was misleading, and each task wrote an orphan empty-session record to Redis.

This PR drops the `?` on Action.run so the type matches reality, and inlines a plain Connection (`type: \"task\"`) in the resque worker with a pre-populated empty in-memory session — no Redis round-trip. Task actions are fresh starts: `connection.session.data` is `{}`, and any user/tenant context must arrive as action params, not through session state. The example backend's middleware and scaffold templates are simplified to the equivalent `connection.session?.data.userId` form, and keryx bumps to 0.22.0.

## Test plan
- [x] `bun lint` clean
- [x] `packages/keryx`: 406 pass / 0 fail
- [x] `example/backend`: 215 pass / 0 fail
- [x] New test in `resque.test.ts`: task actions receive a `type: \"task\"` connection with an empty session

🤖 Generated with [Claude Code](https://claude.com/claude-code)