### PR TITLE
Reject symlinks escaping staticDir; test path traversal (#381)

### DIFF
--- a/packages/keryx/__tests__/servers/web.test.ts
+++ b/packages/keryx/__tests__/servers/web.test.ts
@@ -269,16 +269,10 @@ describe("static files", () => {
     expect(await res.text()).toBe("hello static");
   });
 
-  test("blocks path traversal with ../", async () => {
-    const res = await fetch(getUrl() + "/../package.json");
-    // Should not serve a file outside staticDir — falls through to action routing → 404
-    expect(res.status).toBe(404);
-  });
-
-  test("blocks encoded path traversal with %2e%2e", async () => {
-    const res = await fetch(getUrl() + "/%2e%2e/package.json");
-    expect(res.status).toBe(404);
-  });
+  // Path traversal rejection tests live in __tests__/util/webStaticFiles.test.ts.
+  // Traversal sequences like `../` and `%2e%2e` are normalized by the WHATWG
+  // URL parser (and Bun.serve) before reaching the handler, so testing requires
+  // raw HTTP sockets — see that file.
 
   test("includes ETag and Last-Modified headers", async () => {
     const res = await fetch(getUrl() + "/test.txt");

--- a/packages/keryx/__tests__/util/webStaticFiles.test.ts
+++ b/packages/keryx/__tests__/util/webStaticFiles.test.ts
@@ -1,0 +1,168 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { config } from "../../api";
+import { useTestServer } from "./../setup";
+
+const getUrl = useTestServer();
+
+const staticDir = config.server.web.staticFiles.directory;
+const SECRET = `TRAVERSAL_SECRET_${crypto.randomUUID()}`;
+let secretDir: string;
+
+beforeAll(() => {
+  secretDir = fs.mkdtempSync(path.join(os.tmpdir(), "keryx-trav-"));
+  fs.writeFileSync(path.join(secretDir, "secret.txt"), SECRET);
+
+  if (!fs.existsSync(staticDir)) fs.mkdirSync(staticDir, { recursive: true });
+  fs.writeFileSync(path.join(staticDir, "ok.txt"), "legitimate content");
+  fs.mkdirSync(path.join(staticDir, "nested"), { recursive: true });
+  fs.writeFileSync(
+    path.join(staticDir, "nested", "file.txt"),
+    "nested content",
+  );
+  fs.symlinkSync(
+    path.join(secretDir, "secret.txt"),
+    path.join(staticDir, "evil-link.txt"),
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(path.join(staticDir, "ok.txt"), { force: true });
+  fs.rmSync(path.join(staticDir, "nested"), { recursive: true, force: true });
+  fs.rmSync(path.join(staticDir, "evil-link.txt"), { force: true });
+  fs.rmSync(secretDir, { recursive: true, force: true });
+});
+
+// Sends a raw HTTP/1.1 GET, bypassing the WHATWG URL normalization that
+// `fetch` applies client-side. This is the only way to deliver literal
+// `../`, `%2e%2e`, encoded slashes, and similar to the server un-normalized
+// (though note: Bun.serve itself also normalizes some of these before the
+// request reaches the fetch handler — see per-test comments).
+async function rawGet(
+  rawPath: string,
+): Promise<{ status: number; body: string }> {
+  const { hostname, port } = new URL(getUrl());
+  const portNum = Number(port);
+  let buf = "";
+  let resolve: () => void;
+  const done = new Promise<void>((r) => {
+    resolve = r;
+  });
+  await Bun.connect({
+    hostname,
+    port: portNum,
+    socket: {
+      data(_socket, chunk) {
+        buf += chunk.toString("latin1");
+      },
+      close() {
+        resolve();
+      },
+      error() {
+        resolve();
+      },
+      open(socket) {
+        socket.write(
+          `GET ${rawPath} HTTP/1.1\r\nHost: ${hostname}:${port}\r\nConnection: close\r\n\r\n`,
+        );
+      },
+    },
+  });
+  await done;
+  const [head, ...rest] = buf.split("\r\n\r\n");
+  const statusLine = head?.split("\r\n")[0] ?? "";
+  const status = parseInt(statusLine.split(" ")[1] ?? "0", 10);
+  return { status, body: rest.join("\r\n\r\n") };
+}
+
+describe("static file path traversal", () => {
+  test("positive control: legitimate file serves", async () => {
+    const res = await fetch(getUrl() + "/ok.txt");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("legitimate content");
+  });
+
+  test("positive control: nested file serves", async () => {
+    const res = await fetch(getUrl() + "/nested/file.txt");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("nested content");
+  });
+
+  test("rejects literal ../ (raw socket)", async () => {
+    const { status, body } = await rawGet("/../package.json");
+    expect(status).toBe(404);
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain('"name": "keryx"');
+  });
+
+  test("rejects URL-encoded %2e%2e traversal (raw socket)", async () => {
+    const { status, body } = await rawGet("/%2e%2e/package.json");
+    expect(status).toBe(404);
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain('"name": "keryx"');
+  });
+
+  test("rejects mixed-encoding ..%2f traversal (raw socket)", async () => {
+    const { status, body } = await rawGet("/..%2fpackage.json");
+    expect(status).toBe(404);
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain('"name": "keryx"');
+  });
+
+  test("rejects double-encoded %252e%252e traversal", async () => {
+    const res = await fetch(getUrl() + "/%252e%252e/package.json");
+    const body = await res.text();
+    expect(res.status).toBe(404);
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain('"name": "keryx"');
+  });
+
+  test("rejects encoded slash %2F..%2F traversal (raw socket)", async () => {
+    const { status, body } = await rawGet("/%2F..%2Fpackage.json");
+    expect(status).toBe(404);
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain('"name": "keryx"');
+  });
+
+  test("rejects absolute path /etc/passwd (raw socket)", async () => {
+    const { status, body } = await rawGet("/etc/passwd");
+    expect(status).toBe(404);
+    expect(body).not.toContain("root:");
+  });
+
+  test("rejects double-slash //etc/passwd (raw socket)", async () => {
+    const { status, body } = await rawGet("//etc/passwd");
+    expect(status).toBe(404);
+    expect(body).not.toContain("root:");
+  });
+
+  test("rejects Windows-style backslash ..\\..\\ traversal (raw socket)", async () => {
+    const { status, body } = await rawGet("/..\\..\\package.json");
+    expect(status).toBe(404);
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain('"name": "keryx"');
+  });
+
+  test("rejects null byte injection (raw socket)", async () => {
+    const { status, body } = await rawGet("/ok.txt%00/../../package.json");
+    // Even if a naive handler truncated at %00, it must not serve traversal.
+    expect(body).not.toContain('"name": "keryx"');
+    expect(body).not.toContain(SECRET);
+    // Status depends on how %00 is handled; 200 serving ok.txt is acceptable,
+    // but serving package.json or the secret file is not.
+    expect([200, 400, 404]).toContain(status);
+    if (status === 200) {
+      expect(body).toContain("legitimate content");
+    }
+  });
+
+  test("rejects symlink pointing outside staticDir", async () => {
+    const res = await fetch(getUrl() + "/evil-link.txt");
+    const body = await res.text();
+    expect(res.status).toBe(404);
+    expect(body).not.toContain(SECRET);
+  });
+});

--- a/packages/keryx/util/webStaticFiles.ts
+++ b/packages/keryx/util/webStaticFiles.ts
@@ -1,8 +1,33 @@
+import { realpath } from "node:fs/promises";
 import path from "node:path";
 import type { parse } from "node:url";
 import { logger } from "../api";
 import { config } from "../config";
 import { getSecurityHeaders } from "./webResponse";
+
+/**
+ * Verify that the resolved on-disk path, with symlinks followed, stays
+ * inside the static root. Returns the real base path + target path if
+ * safe, or `null` if the target escapes (via symlink or otherwise).
+ */
+async function resolveWithinStaticRoot(
+  targetPath: string,
+  basePath: string,
+): Promise<string | null> {
+  try {
+    const realBase = await realpath(basePath);
+    const realTarget = await realpath(targetPath);
+    if (
+      realTarget !== realBase &&
+      !realTarget.startsWith(realBase + path.sep)
+    ) {
+      return null;
+    }
+    return realTarget;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Attempt to serve a static file for the given request. Returns a `Response`
@@ -54,6 +79,9 @@ export async function handleStaticFile(
         const indexFile = Bun.file(indexPath);
         const indexExists = await indexFile.exists();
         if (indexExists) {
+          if ((await resolveWithinStaticRoot(indexPath, basePath)) === null) {
+            return null;
+          }
           return buildStaticFileResponse(
             req,
             indexFile,
@@ -62,6 +90,12 @@ export async function handleStaticFile(
         }
       }
       return null; // File not found, let other handlers deal with it
+    }
+
+    // Follow symlinks and confirm the real path stays inside staticDir —
+    // prevents symlinks inside staticDir from serving files outside it.
+    if ((await resolveWithinStaticRoot(fullPath, basePath)) === null) {
+      return null;
     }
 
     return buildStaticFileResponse(req, file, finalPath);


### PR DESCRIPTION
## Summary

Closes https://github.com/actionhero/keryx/issues/381

Adds `packages/keryx/__tests__/util/webStaticFiles.test.ts` covering the full scope of issue #381:

- Literal `../` traversal
- URL-encoded `%2e%2e` traversal
- Double-encoded `%252e%252e` traversal
- Mixed-encoding `..%2f` traversal
- Encoded slash `%2F..%2F` traversal
- Absolute paths (`/etc/passwd`, `//etc/passwd`)
- Windows-style `..\\..\\` backslash traversal
- Null-byte injection (`%00`)
- Symlinks pointing outside `staticDir`

Uses a raw `Bun.connect` socket helper to bypass the WHATWG URL normalization that `fetch` (and `Bun.serve`) apply — without it, these paths get rewritten to `/package.json` on the wire and never reach the handler.

## Fix: symlink escape

The symlink test exposed a real gap. `path.resolve` does not follow symlinks, so a symlink inside `staticDir` pointing to an external file previously passed the `startsWith(basePath + sep)` check and was served. Fixed by adding `resolveWithinStaticRoot()` using `fs.realpath`, which verifies the on-disk target (with symlinks followed) stays within the real static root. Applied at both the file and directory-fallback `index.html` branches.

## Removed: misleading tests

Deleted two tests in `__tests__/servers/web.test.ts` that claimed to test path traversal via `fetch`. They were no-ops — the WHATWG URL parser rewrites `../` and `%2e%2e` to normalized forms client-side, so the server was only ever seeing `/package.json` (which doesn't exist in `assets/`) and returning 404 for a normal file miss. The real traversal guard was never exercised. Added a pointer comment to the new file.

## Test plan

- [x] `bun test __tests__/util/webStaticFiles.test.ts` → 12/12 pass
- [x] `bun test __tests__/servers/web.test.ts` → unaffected tests still pass
- [x] `bun test` (full framework suite, `packages/keryx/`) → 456/456 pass
- [x] `bun lint` → clean
- [x] Symlink test fails without the `webStaticFiles.ts` fix (confirmed gap is real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)