### PR TITLE
Test revoked refresh token cannot be exchanged (closes #382)

### DIFF
--- a/packages/keryx/__tests__/initializers/oauth.test.ts
+++ b/packages/keryx/__tests__/initializers/oauth.test.ts
@@ -794,6 +794,34 @@ describe("oauth initializer", () => {
         await api.redis.redis.get(`oauth:refresh:${refreshToken}`),
       ).not.toBeNull();
     });
+
+    test("revoked refresh token cannot be exchanged via refresh_token grant", async () => {
+      const { refreshToken } = await seedTokenPair("test-client");
+
+      const revokeRes = await oauthRequest("/oauth/revoke", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: refreshToken,
+          token_type_hint: "refresh_token",
+          client_id: "test-client",
+        }).toString(),
+      });
+      expect(revokeRes!.status).toBe(200);
+
+      const exchangeRes = await oauthRequest("/oauth/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: refreshToken,
+          client_id: "test-client",
+        }).toString(),
+      });
+      expect(exchangeRes!.status).toBe(400);
+      const body = (await exchangeRes!.json()) as { error: string };
+      expect(body.error).toBe("invalid_grant");
+    });
   });
 
   describe("/oauth/introspect", () => {

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Closes #382. Four of the five scope items from the issue were already covered by prior PRs (#398, #402); this PR fills the one remaining gap with a single focused test.

| Issue scope item | Status |
|---|---|
| Expired access token → 401 with clear error | Covered (#398) — `verifyAccessToken` returns null; MCP layer maps to 401 |
| Expired authorization code rejected at token endpoint | Covered (#398) |
| Replay of used authorization code rejected | Covered (#398) |
| Token introspection returns correct active/inactive state | Covered (#402) |
| **Revoked refresh token cannot be exchanged** | **Added here** |

The gap was that revocation was proven *transitively* (revoke deletes keys; unknown refresh tokens return `invalid_grant`), never as a single revoke→exchange flow — the exact attacker scenario the issue calls out.

The new test lives in `__tests__/initializers/oauth.test.ts` alongside the other `/oauth/revoke` and refresh-grant tests (reusing the in-scope `seedTokenPair` helper). The issue suggested `__tests__/util/oauth.test.ts`, but that path is stale post-refactor — `util/oauth.ts` now holds only pure helpers (`validateRedirectUri`, `base64UrlEncode`, …).

## Test plan

- [x] `bun test __tests__/initializers/oauth.test.ts` — 41/41 pass (new test plus existing 40)
- [x] `bun lint` clean across all workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)