### PR TITLE
Move flapPreventer from module scope onto API instance (closes #355)

### DIFF
--- a/packages/keryx/__tests__/classes/API.test.ts
+++ b/packages/keryx/__tests__/classes/API.test.ts
@@ -181,6 +181,56 @@ describe("API.start validation", () => {
   });
 });
 
+describe("API.restart flap preventer", () => {
+  test("is isolated per instance", async () => {
+    const a = buildTestAPI();
+    const b = buildTestAPI();
+
+    // Simulate a restart already in-flight on `a`.
+    (a as unknown as { flapPreventer: boolean }).flapPreventer = true;
+
+    let bStopped = 0;
+    let bStarted = 0;
+    (b as unknown as { stop: () => Promise<void> }).stop = async () => {
+      bStopped++;
+    };
+    (b as unknown as { start: () => Promise<void> }).start = async () => {
+      bStarted++;
+    };
+
+    // `a`'s flag must not block `b`.
+    await b.restart();
+
+    expect(bStopped).toBe(1);
+    expect(bStarted).toBe(1);
+    expect((a as unknown as { flapPreventer: boolean }).flapPreventer).toBe(
+      true,
+    );
+    expect((b as unknown as { flapPreventer: boolean }).flapPreventer).toBe(
+      false,
+    );
+  });
+
+  test("short-circuits a concurrent restart on the same instance", async () => {
+    const testApi = buildTestAPI();
+
+    let stops = 0;
+    let starts = 0;
+    (testApi as unknown as { stop: () => Promise<void> }).stop = async () => {
+      stops++;
+    };
+    (testApi as unknown as { start: () => Promise<void> }).start = async () => {
+      starts++;
+    };
+
+    (testApi as unknown as { flapPreventer: boolean }).flapPreventer = true;
+    await testApi.restart();
+
+    expect(stops).toBe(0);
+    expect(starts).toBe(0);
+  });
+});
+
 describe("API.validateInitializerProperties (direct)", () => {
   test("start phase skips initializers excluded from the active runMode", () => {
     const testApi = buildTestAPI([

--- a/packages/keryx/classes/API.ts
+++ b/packages/keryx/classes/API.ts
@@ -18,8 +18,6 @@ export enum RUN_MODE {
   SERVER = "server",
 }
 
-let flapPreventer = false;
-
 /**
  * The global singleton that manages the full framework lifecycle: initialize → start → stop.
  * All initializers attach their namespaces to this object (e.g., `api.db`, `api.actions`, `api.redis`).
@@ -44,6 +42,8 @@ export class API {
   runMode!: RUN_MODE;
   /** All discovered initializer instances, topologically sorted by `dependsOn` after discovery. */
   initializers: Initializer[];
+  /** Guards `restart()` against concurrent re-entry so rapid stop/start cycles get coalesced. */
+  private flapPreventer = false;
 
   // allow arbitrary properties to be set on the API, to be added and typed later
   [key: string]: any;
@@ -184,12 +184,12 @@ export class API {
    * concurrent restart calls to avoid rapid stop/start cycles.
    */
   async restart() {
-    if (flapPreventer) return;
+    if (this.flapPreventer) return;
 
-    flapPreventer = true;
+    this.flapPreventer = true;
     await this.stop();
     await this.start();
-    flapPreventer = false;
+    this.flapPreventer = false;
   }
 
   private async loadLocalConfig() {

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Moves the `flapPreventer` restart guard from module scope onto a private `API` instance field so two `API` instances in the same process no longer share a single flag.
- Adds two unit tests in `API.test.ts`: one verifies restart-guard isolation between instances; the other confirms same-instance re-entry still short-circuits.
- Bumps `keryx` from `0.24.0` → `0.24.1`.

## Test plan
- [x] `bun test` in `packages/keryx/` — 645 pass, 0 fail
- [x] `bun lint` (tsc + biome across all workspaces) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)