### PR TITLE
Extract throwConnectionError() helper for db/redis initializers (closes #363)

### DIFF
--- a/packages/keryx/initializers/db.ts
+++ b/packages/keryx/initializers/db.ts
@@ -11,7 +11,10 @@ import { api, logger } from "../api";
 import { Initializer } from "../classes/Initializer";
 import { ErrorType, TypedError } from "../classes/TypedError";
 import { config } from "../config";
-import { formatConnectionStringForLogging } from "../util/connectionString";
+import {
+  formatConnectionStringForLogging,
+  throwConnectionError,
+} from "../util/connectionString";
 
 const namespace = "db";
 
@@ -59,10 +62,7 @@ export class DB extends Initializer {
     try {
       await api.db.db.execute(sql`SELECT NOW()`);
     } catch (e) {
-      throw new TypedError({
-        type: ErrorType.SERVER_INITIALIZATION,
-        message: `Cannot connect to database (${formatConnectionStringForLogging(config.database.connectionString)}): ${e}`,
-      });
+      throwConnectionError("database", config.database.connectionString, e);
     }
 
     if (config.database.autoMigrate) {

--- a/packages/keryx/initializers/redis.ts
+++ b/packages/keryx/initializers/redis.ts
@@ -1,9 +1,11 @@
 import { Redis as RedisClient } from "ioredis";
 import { api, logger } from "../api";
 import { Initializer } from "../classes/Initializer";
-import { ErrorType, TypedError } from "../classes/TypedError";
 import { config } from "../config";
-import { formatConnectionStringForLogging } from "../util/connectionString";
+import {
+  formatConnectionStringForLogging,
+  throwConnectionError,
+} from "../util/connectionString";
 
 const namespace = "redis";
 const testKey = `__keryx_test_key:${config.process.name}`;
@@ -42,10 +44,7 @@ export class Redis extends Initializer {
       await api.redis.subscription.set(testKey, Date.now());
       await api.redis.subscription.del(testKey);
     } catch (e) {
-      throw new TypedError({
-        type: ErrorType.SERVER_INITIALIZATION,
-        message: `Cannot connect to redis (${formatConnectionStringForLogging(config.redis.connectionString)}): ${e}`,
-      });
+      throwConnectionError("redis", config.redis.connectionString, e);
     }
 
     logger.info(

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/connectionString.ts
+++ b/packages/keryx/util/connectionString.ts
@@ -1,6 +1,20 @@
+import { ErrorType, TypedError } from "../classes/TypedError";
+
 /** Strip the password from a connection string for safe logging. Preserves protocol, user, host, port, and path. */
 export function formatConnectionStringForLogging(connectionString: string) {
   const connectionStringParsed = new URL(connectionString);
   const connectionStringInfo = `${connectionStringParsed.protocol ? `${connectionStringParsed.protocol}//` : ""}${connectionStringParsed.username ? `${connectionStringParsed.username}@` : ""}${connectionStringParsed.hostname}:${connectionStringParsed.port}${connectionStringParsed.pathname}`;
   return connectionStringInfo;
+}
+
+/** Throw a standardized `SERVER_INITIALIZATION` error for a failed connection probe. The connection string is password-stripped via {@link formatConnectionStringForLogging} before being embedded in the message. */
+export function throwConnectionError(
+  service: string,
+  connectionString: string,
+  error: unknown,
+): never {
+  throw new TypedError({
+    type: ErrorType.SERVER_INITIALIZATION,
+    message: `Cannot connect to ${service} (${formatConnectionStringForLogging(connectionString)}): ${error}`,
+  });
 }


### PR DESCRIPTION
## Summary

Extracts the repeated `TypedError` + `formatConnectionStringForLogging` pattern used when db/redis connection probes fail into a single helper `throwConnectionError(service, connectionString, error)` in `packages/keryx/util/connectionString.ts`.

- `packages/keryx/initializers/db.ts` — connection-probe `catch` now calls the helper; the migration-failure `catch` is intentionally left as-is (different semantic — "Cannot migrate" is not a connection error).
- `packages/keryx/initializers/redis.ts` — connection-probe `catch` now calls the helper; the now-unused `TypedError`/`ErrorType` imports are dropped.
- Version bump: `0.24.0` → `0.24.1` (patch — pure refactor, no behavior change).

Signature intentionally matches the suggestion in the issue and does *not* thread `originalError` through; that's tracked separately under the "preserve error cause" issue the #363 description references.

## Test plan

- [x] `bun lint` clean across all workspaces
- [x] `bun test` in `packages/keryx` — 643/643 pass
- [x] `bun test` in `example/backend` — 227/227 pass

Closes https://github.com/actionhero/keryx/issues/363

🤖 Generated with [Claude Code](https://claude.com/claude-code)