### PR TITLE
Raise CLI integration test timeout to avoid flaky 5s default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ actionhero
 packages/keryx/.env
 packages/keryx/drizzle
 packages/keryx/README.md
+packages/keryx/assets/
 example/backend/.env
 example/frontend/.env
 types

--- a/example/backend/__tests__/cli/cli.test.ts
+++ b/example/backend/__tests__/cli/cli.test.ts
@@ -52,31 +52,38 @@ describe("CLI", () => {
     expect(stdout.toString()).toContain("The user's password");
   });
 
-  test("create user and session via the CLI as integration test", async () => {
-    const { stdout, stderr, exitCode } =
-      await $`./keryx.ts "user:create" --name test --email test@test.com --password testpass123`.quiet();
+  test(
+    "create user and session via the CLI as integration test",
+    async () => {
+      const { stdout, stderr, exitCode } =
+        await $`./keryx.ts "user:create" --name test --email test@test.com --password testpass123`.quiet();
 
-    expect(exitCode).toBe(0);
-    expect(stderr).toBeEmpty();
+      expect(exitCode).toBe(0);
+      expect(stderr).toBeEmpty();
 
-    const { response } = JSON.parse(stdout.toString());
-    expect(response.user.id).toBeGreaterThan(0);
-    expect(response.user.email).toEqual("test@test.com");
+      const { response } = JSON.parse(stdout.toString());
+      expect(response.user.id).toBeGreaterThan(0);
+      expect(response.user.email).toEqual("test@test.com");
 
-    const {
-      stdout: stdout2,
-      stderr: stderr2,
-      exitCode: exitCode2,
-    } = await $`./keryx.ts "session:create" --email test@test.com --password testpass123`.quiet();
+      const {
+        stdout: stdout2,
+        stderr: stderr2,
+        exitCode: exitCode2,
+      } = await $`./keryx.ts "session:create" --email test@test.com --password testpass123`.quiet();
 
-    expect(exitCode2).toBe(0);
-    expect(stderr2).toBeEmpty();
+      expect(exitCode2).toBe(0);
+      expect(stderr2).toBeEmpty();
 
-    const { response: response2 } = JSON.parse(stdout2.toString());
-    expect(response2.user.id).toBeGreaterThan(1);
-    expect(response2.user.email).toEqual("test@test.com");
-    expect(response2.session.id).not.toBeNull();
-  });
+      const { response: response2 } = JSON.parse(stdout2.toString());
+      expect(response2.user.id).toBeGreaterThan(1);
+      expect(response2.user.email).toEqual("test@test.com");
+      expect(response2.session.id).not.toBeNull();
+    },
+    // Two full CLI subprocess boots (init + start + action + stop) can exceed
+    // Bun's default 5s per-test timeout under load — especially in CI runners
+    // where the benchmark suite caps a single CLI call at 3s.
+    HOOK_TIMEOUT,
+  );
 
   describe("CLI errors", () => {
     test("action not found", async () => {

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
The "create user and session via the CLI as integration test" spawns two
./keryx.ts subprocesses. Each boot does full init + start + action + stop,
and the benchmark threshold alone caps a single CLI call at 3s in CI. Two
back-to-back calls under the load of the full 25-file backend suite
reliably exceed Bun's default 5s per-test timeout (observed consistently
in `bun run ci`, which runs the whole suite in one process rather than the
sharded GitHub Actions layout).

Apply HOOK_TIMEOUT (15s) to the test — same budget used by the beforeAll
and the benchmark helpers.

Also bumps keryx to 0.25.1.