### PR TITLE
Use `declare module "keryx"` in framework initializers (closes #413)

### DIFF
--- a/example/backend/__tests__/initializers/db.test.ts
+++ b/example/backend/__tests__/initializers/db.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
-import { api, type Transaction } from "keryx";
+import { api } from "keryx";
 import { users } from "../../schema/users";
 import { HOOK_TIMEOUT } from "./../setup";
 
@@ -128,7 +128,7 @@ describe("db initializer", () => {
   test("transactions work", async () => {
     await api.db.clearDatabase();
 
-    await api.db.db.transaction(async (tx: Transaction) => {
+    await api.db.db.transaction(async (tx) => {
       await tx.insert(users).values({
         name: "Transaction User",
         email: "transaction@example.com",

--- a/packages/keryx/__tests__/initializers/moduleAugmentation.test.ts
+++ b/packages/keryx/__tests__/initializers/moduleAugmentation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+const INITIALIZERS_DIR = path.resolve(__dirname, "../../initializers");
+
+describe("framework initializer module augmentations", () => {
+  const files = fs
+    .readdirSync(INITIALIZERS_DIR)
+    .filter((f) => f.endsWith(".ts"));
+
+  test("at least one initializer is present", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  test.each(files)("%s augments `keryx`, not a relative path", (file) => {
+    const source = fs.readFileSync(path.join(INITIALIZERS_DIR, file), "utf-8");
+    if (!source.includes("declare module")) return;
+
+    // Consumers installing keryx via npm only see augmentations to the
+    // package name. Relative-path augmentations do not propagate (#413).
+    expect(source).toContain('declare module "keryx"');
+    expect(source).not.toMatch(/declare module "\.\.?\/[^"]*"/);
+  });
+});

--- a/packages/keryx/initializers/actionts.ts
+++ b/packages/keryx/initializers/actionts.ts
@@ -60,7 +60,7 @@ export type FanOutStatus = {
   errors: Array<{ params: Record<string, any>; error: string }>;
 };
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<Actions["initialize"]>>;
   }

--- a/packages/keryx/initializers/channels.ts
+++ b/packages/keryx/initializers/channels.ts
@@ -22,7 +22,7 @@ const REFRESH_PRESENCE_LUA = await Bun.file(
   join(LUA_DIR, "refresh-presence.lua"),
 ).text();
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<Channels["initialize"]>>;
   }

--- a/packages/keryx/initializers/connections.ts
+++ b/packages/keryx/initializers/connections.ts
@@ -3,7 +3,7 @@ import { Initializer } from "../classes/Initializer";
 
 const namespace = "connections";
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<Connections["initialize"]>>;
   }

--- a/packages/keryx/initializers/db.ts
+++ b/packages/keryx/initializers/db.ts
@@ -18,7 +18,7 @@ import {
 
 const namespace = "db";
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<DB["initialize"]>>;
   }

--- a/packages/keryx/initializers/mcp.ts
+++ b/packages/keryx/initializers/mcp.ts
@@ -22,7 +22,7 @@ type McpHandleRequest = (req: Request, ip: string) => Promise<Response>;
 
 const namespace = "mcp";
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<McpInitializer["initialize"]>>;
   }

--- a/packages/keryx/initializers/oauth.ts
+++ b/packages/keryx/initializers/oauth.ts
@@ -27,7 +27,7 @@ import {
 
 const namespace = "oauth";
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<OAuthInitializer["initialize"]>>;
   }

--- a/packages/keryx/initializers/observability.ts
+++ b/packages/keryx/initializers/observability.ts
@@ -11,7 +11,7 @@ import { config } from "../config";
 
 const namespace = "observability";
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<Observability["initialize"]>>;
   }

--- a/packages/keryx/initializers/process.ts
+++ b/packages/keryx/initializers/process.ts
@@ -4,7 +4,7 @@ import { config } from "../config";
 
 const namespace = "process";
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<Process["initialize"]>>;
   }

--- a/packages/keryx/initializers/pubsub.ts
+++ b/packages/keryx/initializers/pubsub.ts
@@ -24,7 +24,7 @@ export type ClientUnsubscribeMessage = {
   channel: string;
 };
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<PubSub["initialize"]>>;
   }

--- a/packages/keryx/initializers/redis.ts
+++ b/packages/keryx/initializers/redis.ts
@@ -10,7 +10,7 @@ import {
 const namespace = "redis";
 const testKey = `__keryx_test_key:${config.process.name}`;
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<Redis["initialize"]>>;
   }

--- a/packages/keryx/initializers/resque.ts
+++ b/packages/keryx/initializers/resque.ts
@@ -33,7 +33,7 @@ function logResqueEvent(
   }
 }
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<Resque["initialize"]>>;
   }

--- a/packages/keryx/initializers/servers.ts
+++ b/packages/keryx/initializers/servers.ts
@@ -8,7 +8,7 @@ import { globLoader } from "../util/glob";
 
 const namespace = "servers";
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<Servers["initialize"]>>;
   }

--- a/packages/keryx/initializers/session.ts
+++ b/packages/keryx/initializers/session.ts
@@ -87,7 +87,7 @@ async function destroy(connection: Connection) {
   return response > 0;
 }
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<Session["initialize"]>>;
   }

--- a/packages/keryx/initializers/signals.ts
+++ b/packages/keryx/initializers/signals.ts
@@ -5,7 +5,7 @@ import { config } from "../config";
 
 const namespace = "signals";
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<Signals["initialize"]>>;
   }

--- a/packages/keryx/initializers/swagger.ts
+++ b/packages/keryx/initializers/swagger.ts
@@ -10,7 +10,7 @@ import {
 
 const namespace = "swagger";
 
-declare module "../classes/API" {
+declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<SwaggerInitializer["initialize"]>>;
   }

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Closes #413.

## Summary

- All 15 framework initializers in `packages/keryx/initializers/` now augment the `API` interface via `declare module "keryx"` instead of the relative `declare module "../classes/API"`. When keryx is consumed as an npm package (not a workspace link), only augmentations to the published module name propagate, so the relative form left `typeof api.db`, `api.redis`, etc. collapsed to `any` in downstream apps.
- Added `packages/keryx/__tests__/initializers/moduleAugmentation.test.ts` as a regression guard that asserts every initializer augments `"keryx"`, mirroring the existing scaffold-generator expectation.
- Bumped `packages/keryx` to `0.25.3`. Removed an obsolete `tx: Transaction` annotation in `example/backend/__tests__/initializers/db.test.ts` that only compiled because `api.db.db` was previously `any` — proof that consumer-side types are now correct.

## Test plan

- [x] `bun lint` clean across all 4 workspaces (tsc + biome)
- [x] `packages/keryx` — 697 tests pass, including 16 new augmentation guard tests
- [x] `example/backend` — 227 tests pass