### PR TITLE
Add plugin lifecycle hooks under api.hooks (closes #419)

### DIFF
--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -175,6 +175,84 @@ export class MyAction extends Action {
 }
 ```
 
+### Lifecycle Hooks
+
+Plugins can observe or wrap three framework-wide lifecycle events: HTTP requests, task enqueue, and task execution. All hooks are registered via the `api.hooks` namespace from code (not the plugin manifest), typically inside a plugin initializer's `initialize()`.
+
+Use lifecycle hooks when action middleware (`runBefore` / `runAfter`) isn't enough — for example, to wrap an entire HTTP request in a tracing span, inject trace headers into every enqueued job, or restore distributed trace context before a worker runs an action.
+
+```ts
+import { api, Initializer } from "keryx";
+
+class MyTracer extends Initializer {
+  constructor() {
+    super("myTracer");
+    this.dependsOn = ["hooks"]; // ensure api.hooks is ready
+  }
+  async initialize() {
+    api.hooks.web.beforeRequest((req, ctx) => { /* ... */ });
+    api.hooks.web.afterRequest((req, res, ctx) => { /* ... */ });
+    api.hooks.actions.onEnqueue((name, inputs, queue) => { /* ... */ });
+    api.hooks.actions.beforeAct((name, params, connection, ctx) => { /* ... */ });
+    api.hooks.actions.afterAct((name, params, connection, ctx, outcome) => { /* ... */ });
+    api.hooks.resque.beforeJob((name, params, ctx) => { /* ... */ });
+    api.hooks.resque.afterJob((name, params, ctx, outcome) => { /* ... */ });
+  }
+}
+```
+
+**HTTP request hooks** — `api.hooks.web.beforeRequest` fires at the start of every HTTP request before routing (covers static files, OAuth, MCP, metrics, and actions); `api.hooks.web.afterRequest` fires after the `Response` is built, before compression. WebSocket upgrades do not fire these hooks. A shared `RequestContext` passes from `beforeRequest` to `afterRequest` so state can be threaded through `ctx.metadata`:
+
+```ts
+api.hooks.web.beforeRequest((req, ctx) => {
+  ctx.metadata.startedAt = Date.now();
+});
+api.hooks.web.afterRequest((_req, _res, ctx) => {
+  const elapsed = Date.now() - (ctx.metadata.startedAt as number);
+  // record span, log, etc.
+});
+```
+
+**Task enqueue hook** — `api.hooks.actions.onEnqueue` fires on every `api.actions.enqueue`, `enqueueAt`, `enqueueIn`, and each per-job call inside `fanOut`. Return a replacement `TaskInputs` object to mutate the payload before it hits Redis; return `void` to leave it unchanged:
+
+```ts
+api.hooks.actions.onEnqueue((actionName, inputs, queue) => {
+  return { ...inputs, _traceparent: currentTraceparent() };
+});
+```
+
+**Action lifecycle hooks (cross-transport)** — `api.hooks.actions.beforeAct` and `api.hooks.actions.afterAct` fire inside `Connection.act()` for every action invocation, regardless of transport (web, websocket, task, cli, mcp, …). The `Connection` is passed so handlers can branch on `connection.type`. Unlike `hooks.web.beforeRequest` (HTTP-only) and `hooks.resque.beforeJob` (task-only), these fire across all transports with one registration. They fire after params are validated and don't run if the action isn't found or validation fails.
+
+```ts
+api.hooks.actions.beforeAct((name, params, connection, ctx) => {
+  ctx.metadata.span = startSpan(`action:${name}`, {
+    transport: connection.type,
+  });
+});
+api.hooks.actions.afterAct((_name, _params, _connection, ctx, outcome) => {
+  const span = ctx.metadata.span as Span;
+  if (outcome.success) span.setStatus({ code: "OK" });
+  else span.recordException(outcome.error as Error);
+  span.end();
+});
+```
+
+**Task execution hooks** — `api.hooks.resque.beforeJob` and `api.hooks.resque.afterJob` fire inside the job wrapper, bracketing the action run. They have access to the decoded action name and params (unlike the underlying `worker.on("job")` event, which only sees raw `job.args`). `afterJob` receives a unified `JobOutcome` that discriminates success from failure via `outcome.success`, so both paths reach a single handler:
+
+```ts
+api.hooks.resque.beforeJob((name, params, ctx) => {
+  ctx.metadata.span = startSpan(name, params);
+});
+api.hooks.resque.afterJob((_name, _params, ctx, outcome) => {
+  const span = ctx.metadata.span as Span;
+  if (outcome.success) span.setStatus({ code: "OK" });
+  else span.recordException(outcome.error as Error);
+  span.end();
+});
+```
+
+All hook types (`RequestContext`, `BeforeRequestHook`, `AfterRequestHook`, `OnEnqueueHook`, `ActContext`, `ActOutcome`, `BeforeActHook`, `AfterActHook`, `JobContext`, `JobOutcome`, `BeforeJobHook`, `AfterJobHook`) are exported from `"keryx"`. Hooks run sequentially in registration order; thrown errors propagate (a throw in `beforeRequest` aborts the request, a throw in `beforeAct` fails the action, a throw in `beforeJob` fails the job).
+
 ### Custom Generators
 
 Plugins can register custom types for the `keryx generate` CLI command. Provide a Mustache template and an output directory:

--- a/packages/keryx/__tests__/classes/Connection.test.ts
+++ b/packages/keryx/__tests__/classes/Connection.test.ts
@@ -540,3 +540,160 @@ describe("Action timeouts", () => {
     );
   });
 });
+
+describe("action lifecycle hooks (api.hooks.actions.beforeAct / afterAct)", () => {
+  const resetHooks = () => {
+    const hooksInitializer = api.initializers.find((i) => i.name === "hooks");
+    (hooksInitializer as any).actionsBeforeAct.length = 0;
+    (hooksInitializer as any).actionsAfterAct.length = 0;
+  };
+
+  class EchoAction extends Action {
+    constructor() {
+      super({
+        name: "test:echo",
+        description: "Echoes params back",
+        inputs: z.object({ val: z.string() }),
+      });
+    }
+    async run(params: { val: string }) {
+      return { echoed: params.val };
+    }
+  }
+
+  class ExplodeAction extends Action {
+    constructor() {
+      super({
+        name: "test:explode",
+        description: "Throws",
+        inputs: z.object({}),
+      });
+    }
+    async run(): Promise<unknown> {
+      throw new Error("boom");
+    }
+  }
+
+  beforeAll(() => {
+    api.actions.actions.push(new EchoAction());
+    api.actions.actions.push(new ExplodeAction());
+  });
+
+  afterAll(() => {
+    api.actions.actions = api.actions.actions.filter(
+      (a: Action) => a.name !== "test:echo" && a.name !== "test:explode",
+    );
+    resetHooks();
+  });
+
+  test("beforeAct fires with connection, actionName, and params", async () => {
+    resetHooks();
+    const seen: Array<{
+      actionName: string;
+      params: any;
+      type: string;
+    }> = [];
+    api.hooks.actions.beforeAct((actionName, params, connection) => {
+      seen.push({ actionName, params, type: connection.type });
+    });
+
+    const conn = new Connection("cli", "hook-test-cli");
+    await conn.act("test:echo", { val: "hi" });
+
+    expect(seen).toEqual([
+      { actionName: "test:echo", params: { val: "hi" }, type: "cli" },
+    ]);
+  });
+
+  test("afterAct receives success outcome with response", async () => {
+    resetHooks();
+    const outcomes: Array<{
+      success: boolean;
+      response?: unknown;
+      duration: number;
+    }> = [];
+    api.hooks.actions.afterAct((_name, _params, _conn, _ctx, outcome) => {
+      outcomes.push({
+        success: outcome.success,
+        response: outcome.success ? outcome.response : undefined,
+        duration: outcome.duration,
+      });
+    });
+
+    const conn = new Connection("task", "hook-test-task");
+    await conn.act("test:echo", { val: "ok" });
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].success).toBe(true);
+    expect(outcomes[0].response).toEqual({ echoed: "ok" });
+    expect(outcomes[0].duration).toBeGreaterThanOrEqual(0);
+  });
+
+  test("afterAct receives failure outcome when action throws", async () => {
+    resetHooks();
+    const outcomes: Array<{ success: boolean; errorMessage?: string }> = [];
+    api.hooks.actions.afterAct((_name, _params, _conn, _ctx, outcome) => {
+      outcomes.push({
+        success: outcome.success,
+        errorMessage: outcome.success
+          ? undefined
+          : (outcome.error as { message?: string })?.message,
+      });
+    });
+
+    const conn = new Connection("websocket", "hook-test-ws");
+    await conn.act("test:explode", {});
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].success).toBe(false);
+    expect(outcomes[0].errorMessage).toContain("boom");
+  });
+
+  test("ctx.metadata flows from beforeAct to afterAct", async () => {
+    resetHooks();
+    let carried: unknown;
+    api.hooks.actions.beforeAct((_name, _params, _conn, ctx) => {
+      ctx.metadata.marker = "threaded";
+    });
+    api.hooks.actions.afterAct((_name, _params, _conn, ctx) => {
+      carried = ctx.metadata.marker;
+    });
+
+    const conn = new Connection("cli", "hook-test-ctx");
+    await conn.act("test:echo", { val: "x" });
+
+    expect(carried).toBe("threaded");
+  });
+
+  test("hooks do not fire when the action is not found", async () => {
+    resetHooks();
+    let fired = 0;
+    api.hooks.actions.beforeAct(() => {
+      fired++;
+    });
+    api.hooks.actions.afterAct(() => {
+      fired++;
+    });
+
+    const conn = new Connection("cli", "hook-test-missing");
+    const { error } = await conn.act("test:not-a-real-action", {});
+    expect(error?.type).toBe(ErrorType.CONNECTION_ACTION_NOT_FOUND);
+    expect(fired).toBe(0);
+  });
+
+  test("hooks do not fire when param validation fails", async () => {
+    resetHooks();
+    let fired = 0;
+    api.hooks.actions.beforeAct(() => {
+      fired++;
+    });
+    api.hooks.actions.afterAct(() => {
+      fired++;
+    });
+
+    const conn = new Connection("cli", "hook-test-bad-params");
+    const { error } = await conn.act("test:echo", {}); // missing required `val`
+    expect(error).toBeDefined();
+    expect(fired).toBe(0);
+  });
+});

--- a/packages/keryx/__tests__/initializers/fanout.test.ts
+++ b/packages/keryx/__tests__/initializers/fanout.test.ts
@@ -462,3 +462,45 @@ describe("fanOut overload types (compile-time)", () => {
     expect(typeof _never).toBe("function");
   });
 });
+
+describe("onEnqueue hook in fanOut", () => {
+  afterEach(() => {
+    const hooksInitializer = api.initializers.find((i) => i.name === "hooks");
+    (hooksInitializer as any).actionsOnEnqueue.length = 0;
+  });
+
+  test("fires once per child job in a fan-out batch", async () => {
+    const calls: Array<{ actionName: string; queue: string }> = [];
+    api.hooks.actions.onEnqueue((actionName, _inputs, queue) => {
+      calls.push({ actionName, queue });
+    });
+
+    await api.actions.fanOut("fanout:child", [
+      { itemId: "1" },
+      { itemId: "2" },
+      { itemId: "3" },
+    ]);
+
+    expect(calls).toHaveLength(3);
+    expect(calls.every((c) => c.actionName === "fanout:child")).toBe(true);
+    expect(calls.every((c) => c.queue === "worker")).toBe(true);
+  });
+
+  test("returned inputs from hook land in each child job payload", async () => {
+    api.hooks.actions.onEnqueue((_name, inputs) => ({
+      ...inputs,
+      injected: true,
+    }));
+
+    await api.actions.fanOut("fanout:child", [
+      { itemId: "a" },
+      { itemId: "b" },
+    ]);
+
+    const jobs = await api.actions.queued("worker");
+    expect(jobs).toHaveLength(2);
+    for (const job of jobs) {
+      expect(job.args[0].injected).toBe(true);
+    }
+  });
+});

--- a/packages/keryx/__tests__/initializers/resque.test.ts
+++ b/packages/keryx/__tests__/initializers/resque.test.ts
@@ -180,4 +180,143 @@ describe("with workers and scheduler", () => {
     );
     delete api.resque.jobs.bare_action;
   });
+
+  test("beforeJob and afterJob hooks fire on success with shared ctx", async () => {
+    const before: string[] = [];
+    const after: Array<{ outcome: string; marker: unknown }> = [];
+    const before_ = (name: string, _p: any, ctx: any) => {
+      before.push(name);
+      ctx.metadata.marker = "from-before";
+    };
+    const after_ = (_n: string, _p: any, ctx: any, outcome: any) => {
+      after.push({
+        outcome: outcome.success ? "success" : "failure",
+        marker: ctx.metadata.marker,
+      });
+    };
+    api.hooks.resque.beforeJob(before_);
+    api.hooks.resque.afterJob(after_);
+
+    try {
+      await api.actions.enqueue("test_action", { val: "hooked" });
+      await api.resque.startWorkers();
+      await waitFor(() => after.length > 0);
+      expect(before).toEqual(["test_action"]);
+      expect(after).toEqual([{ outcome: "success", marker: "from-before" }]);
+    } finally {
+      const hooksInitializer = api.initializers.find((i) => i.name === "hooks");
+      (hooksInitializer as any).resqueBeforeJob.length = 0;
+      (hooksInitializer as any).resqueAfterJob.length = 0;
+    }
+  });
+
+  test("afterJob receives failure outcome when action throws", async () => {
+    const outcomes: Array<{ success: boolean; errorMessage?: string }> = [];
+    api.hooks.resque.afterJob((_n, _p, _ctx, outcome) => {
+      outcomes.push({
+        success: outcome.success,
+        errorMessage: outcome.success
+          ? undefined
+          : (outcome.error as Error)?.message,
+      });
+    });
+
+    class ExplodingAction implements Action {
+      name = "exploding_action";
+      inputs = z.object({});
+      run = async (): Promise<void> => {
+        throw new Error("kaboom");
+      };
+    }
+    const instance = new ExplodingAction();
+    api.actions.actions.push(instance);
+    api.resque.jobs[instance.name] = api.resque.wrapActionAsJob(instance);
+
+    try {
+      await api.actions.enqueue("exploding_action");
+      await api.resque.startWorkers();
+      await waitFor(() => outcomes.length > 0);
+      expect(outcomes[0].success).toBe(false);
+      expect(outcomes[0].errorMessage).toContain("kaboom");
+    } finally {
+      const hooksInitializer2 = api.initializers.find(
+        (i) => i.name === "hooks",
+      );
+      (hooksInitializer2 as any).resqueAfterJob.length = 0;
+      api.actions.actions = api.actions.actions.filter(
+        (a) => a.name !== "exploding_action",
+      );
+      delete api.resque.jobs.exploding_action;
+    }
+  });
+});
+
+describe("onEnqueue hook", () => {
+  afterEach(() => {
+    const hooksInitializer = api.initializers.find((i) => i.name === "hooks");
+    (hooksInitializer as any).actionsOnEnqueue.length = 0;
+  });
+
+  test("fires for enqueue with actionName, inputs, and queue", async () => {
+    const calls: Array<{
+      actionName: string;
+      inputs: any;
+      queue: string;
+    }> = [];
+    api.hooks.actions.onEnqueue((actionName, inputs, queue) => {
+      calls.push({ actionName, inputs, queue });
+    });
+
+    await api.actions.enqueue("test_action", { val: "payload" });
+    expect(calls).toEqual([
+      {
+        actionName: "test_action",
+        inputs: { val: "payload" },
+        queue: DEFAULT_QUEUE,
+      },
+    ]);
+  });
+
+  test("returning new inputs replaces the enqueued payload", async () => {
+    api.hooks.actions.onEnqueue((_name, inputs) => ({
+      ...inputs,
+      injected: "yes",
+    }));
+
+    await api.actions.enqueue("test_action", { val: "orig" });
+    const jobs = await api.actions.queued();
+    expect(jobs[0].args[0]).toEqual({ val: "orig", injected: "yes" });
+  });
+
+  test("fires for enqueueIn", async () => {
+    let fired = false;
+    api.hooks.actions.onEnqueue(() => {
+      fired = true;
+    });
+    await api.actions.enqueueIn(5000, "test_action", { val: "delayed" });
+    expect(fired).toBe(true);
+  });
+
+  test("fires for enqueueAt", async () => {
+    let fired = false;
+    api.hooks.actions.onEnqueue(() => {
+      fired = true;
+    });
+    await api.actions.enqueueAt(
+      Date.now() + 5000,
+      "test_action",
+      { val: "at" },
+      DEFAULT_QUEUE,
+      true,
+    );
+    expect(fired).toBe(true);
+  });
+
+  test("multiple hooks run in order and thread inputs through", async () => {
+    api.hooks.actions.onEnqueue((_n, inputs) => ({ ...inputs, a: 1 }));
+    api.hooks.actions.onEnqueue((_n, inputs) => ({ ...inputs, b: 2 }));
+    await api.actions.enqueue("test_action", { val: "chain" });
+    const jobs = await api.actions.queued();
+    expect(jobs[0].args[0]).toEqual({ val: "chain", a: 1, b: 2 });
+  });
 });

--- a/packages/keryx/__tests__/servers/web.test.ts
+++ b/packages/keryx/__tests__/servers/web.test.ts
@@ -566,3 +566,79 @@ describe("compression", () => {
     }
   });
 });
+
+describe("request hooks", () => {
+  const resetHooks = () => {
+    const hooksInitializer = api.initializers.find((i) => i.name === "hooks");
+    (hooksInitializer as any).webBeforeRequest.length = 0;
+    (hooksInitializer as any).webAfterRequest.length = 0;
+  };
+
+  test("beforeRequest fires before the response is produced", async () => {
+    resetHooks();
+    const seen: Array<{ url: string; metadata: Record<string, unknown> }> = [];
+    api.hooks.web.beforeRequest((req, ctx) => {
+      seen.push({ url: req.url, metadata: ctx.metadata });
+    });
+
+    const res = await fetch(getUrl() + "/api/status");
+    expect(res.status).toBe(200);
+    expect(seen.length).toBe(1);
+    expect(seen[0].url).toContain("/api/status");
+  });
+
+  test("afterRequest receives the final Response", async () => {
+    resetHooks();
+    const seen: Array<{ status: number }> = [];
+    api.hooks.web.afterRequest((_req, res) => {
+      seen.push({ status: res.status });
+    });
+
+    await fetch(getUrl() + "/api/status");
+    expect(seen.length).toBe(1);
+    expect(seen[0].status).toBe(200);
+  });
+
+  test("ctx.metadata flows from beforeRequest to afterRequest", async () => {
+    resetHooks();
+    let carried: unknown;
+    api.hooks.web.beforeRequest((_req, ctx) => {
+      ctx.metadata.marker = "hello";
+    });
+    api.hooks.web.afterRequest((_req, _res, ctx) => {
+      carried = ctx.metadata.marker;
+    });
+
+    await fetch(getUrl() + "/api/status");
+    expect(carried).toBe("hello");
+  });
+
+  test("hooks fire for non-action requests (e.g. 404 paths)", async () => {
+    resetHooks();
+    let fired = 0;
+    api.hooks.web.beforeRequest(() => {
+      fired++;
+    });
+    api.hooks.web.afterRequest(() => {
+      fired++;
+    });
+
+    const res = await fetch(getUrl() + "/.well-known/does-not-exist");
+    expect(res.status).toBe(404);
+    expect(fired).toBe(2);
+  });
+
+  test("multiple beforeRequest hooks run in registration order", async () => {
+    resetHooks();
+    const calls: string[] = [];
+    api.hooks.web.beforeRequest(() => {
+      calls.push("a");
+    });
+    api.hooks.web.beforeRequest(() => {
+      calls.push("b");
+    });
+
+    await fetch(getUrl() + "/api/status");
+    expect(calls).toEqual(["a", "b"]);
+  });
+});

--- a/packages/keryx/classes/Connection.ts
+++ b/packages/keryx/classes/Connection.ts
@@ -12,6 +12,54 @@ import { StreamingResponse } from "./StreamingResponse";
 import { ErrorType, TypedError } from "./TypedError";
 
 /**
+ * Per-invocation context passed to {@link BeforeActHook} and {@link AfterActHook}.
+ * The same object instance threads from `beforeAct` to `afterAct` for a single
+ * action invocation, so hooks can stash span refs, timing data, etc.
+ */
+export interface ActContext {
+  /** Mutable scratch space shared between `beforeAct` and `afterAct`. */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Unified outcome passed to {@link AfterActHook}. Discriminate via the `success` field.
+ * Covers both the happy-path and error paths of an action invocation.
+ */
+export type ActOutcome =
+  | { success: true; response: unknown; duration: number }
+  | { success: false; error: unknown; duration: number };
+
+/**
+ * Runs inside `Connection.act()` after params are validated and before the action's
+ * own `runBefore` middleware. Fires for every action invocation regardless of
+ * transport (web, websocket, task, cli, mcp, …) — inspect `connection.type` to
+ * discriminate. Throwing fails the action.
+ *
+ * Register via `api.hooks.actions.beforeAct(...)`.
+ */
+export type BeforeActHook = (
+  actionName: string,
+  params: Record<string, unknown>,
+  connection: Connection,
+  ctx: ActContext,
+) => Promise<void> | void;
+
+/**
+ * Runs inside `Connection.act()` after the action completes (success or failure),
+ * in a `finally` block so it always fires if the corresponding `beforeAct` fired.
+ * Receives the same `ctx` plus an {@link ActOutcome} describing what happened.
+ *
+ * Register via `api.hooks.actions.afterAct(...)`.
+ */
+export type AfterActHook = (
+  actionName: string,
+  params: Record<string, unknown>,
+  connection: Connection,
+  ctx: ActContext,
+  outcome: ActOutcome,
+) => Promise<void> | void;
+
+/**
  * Represents a client connection to the server — HTTP request, WebSocket, or internal caller.
  * Each connection tracks its own session, channel subscriptions, and rate-limit state.
  *
@@ -108,6 +156,11 @@ export class Connection<
 
     let action: Action | undefined;
     let formattedParams: Record<string, unknown> | undefined;
+    // Cross-transport action hooks (api.hooks.actions.beforeAct / afterAct).
+    // beforeActRan guards afterAct so we only fire after-hooks for invocations
+    // where before-hooks also fired (i.e. action found + params validated).
+    const actCtx: ActContext = { metadata: {} };
+    let beforeActRan = false;
     try {
       action = this.findAction(actionName);
       if (!action) {
@@ -121,6 +174,11 @@ export class Connection<
       if (!this.sessionLoaded) await this.loadSession();
 
       formattedParams = await this.formatParams(params, action);
+
+      for (const hook of api.hooks.actions.beforeActHooks) {
+        await hook(action.name, formattedParams, this, actCtx);
+      }
+      beforeActRan = true;
 
       for (const middleware of action.middleware ?? []) {
         if (middleware.runBefore) {
@@ -182,6 +240,15 @@ export class Connection<
               }
             }
           }
+        }
+      }
+      if (beforeActRan && action && formattedParams) {
+        const actDuration = new Date().getTime() - reqStartTime;
+        const outcome: ActOutcome = error
+          ? { success: false, error, duration: actDuration }
+          : { success: true, response, duration: actDuration };
+        for (const hook of api.hooks.actions.afterActHooks) {
+          await hook(action.name, formattedParams, this, actCtx, outcome);
         }
       }
       this._actDepth--;

--- a/packages/keryx/index.ts
+++ b/packages/keryx/index.ts
@@ -5,6 +5,7 @@ import "./initializers/actionts";
 import "./initializers/channels";
 import "./initializers/connections";
 import "./initializers/db";
+import "./initializers/hooks";
 import "./initializers/mcp";
 import "./initializers/oauth";
 import "./initializers/observability";
@@ -22,16 +23,34 @@ export type { ActionMiddleware } from "./classes/Action";
 export { HTTP_METHOD, MCP_RESPONSE_FORMAT } from "./classes/Action";
 export type { ChannelMiddleware } from "./classes/Channel";
 export { CHANNEL_NAME_PATTERN } from "./classes/Channel";
+export type {
+  ActContext,
+  ActOutcome,
+  AfterActHook,
+  BeforeActHook,
+} from "./classes/Connection";
 export { Connection } from "./classes/Connection";
 export { LogLevel } from "./classes/Logger";
 export type { KeryxPlugin, PluginGenerator } from "./classes/Plugin";
 export { SSEResponse, StreamingResponse } from "./classes/StreamingResponse";
 export { ErrorStatusCodes, ErrorType, TypedError } from "./classes/TypedError";
 export type { KeryxConfig } from "./config";
+export type { OnEnqueueHook } from "./initializers/actionts";
+export type {
+  AfterJobHook,
+  BeforeJobHook,
+  JobContext,
+  JobOutcome,
+} from "./initializers/resque";
 export type { SessionData } from "./initializers/session";
 export { checkRateLimit, RateLimitMiddleware } from "./middleware/rateLimit";
 export { TransactionMiddleware } from "./middleware/transaction";
-export type { WebServer } from "./servers/web";
+export type {
+  AfterRequestHook,
+  BeforeRequestHook,
+  RequestContext,
+  WebServer,
+} from "./servers/web";
 export { buildProgram } from "./util/cli";
 export { deepMerge, deepMergeDefaults, loadFromEnvIfSet } from "./util/config";
 export { getValidTypes } from "./util/generate";

--- a/packages/keryx/initializers/actionts.ts
+++ b/packages/keryx/initializers/actionts.ts
@@ -68,10 +68,43 @@ declare module "keryx" {
 
 export type TaskInputs = Record<string, any>;
 
+/**
+ * Runs when any action is enqueued — via {@link Actions.enqueue}, {@link Actions.enqueueAt},
+ * {@link Actions.enqueueIn}, or the per-job calls inside {@link Actions.fanOut}. Fires after
+ * the queue has been resolved and before the job is placed in Redis.
+ *
+ * Return a new `TaskInputs` object to replace the payload (e.g. to inject trace headers),
+ * or return `void` / `undefined` to leave the payload unchanged. If multiple hooks are
+ * registered they run sequentially in registration order; each receives the output of
+ * the previous one.
+ *
+ * Register via `api.hooks.actions.onEnqueue(...)`.
+ */
+export type OnEnqueueHook = (
+  actionName: string,
+  inputs: TaskInputs,
+  queue: string,
+) => Promise<TaskInputs | void> | TaskInputs | void;
+
 export class Actions extends Initializer {
   constructor() {
     super(namespace);
+    this.dependsOn = ["hooks"];
   }
+
+  /** Run all registered `onEnqueue` hooks, threading inputs through each. */
+  private runOnEnqueueHooks = async (
+    actionName: string,
+    inputs: TaskInputs,
+    queue: string,
+  ): Promise<TaskInputs> => {
+    let current = inputs;
+    for (const hook of api.hooks.actions.onEnqueueHooks) {
+      const next = await hook(actionName, current, queue);
+      if (next !== undefined) current = next;
+    }
+    return current;
+  };
 
   /**
    * Enqueue an action to be performed in the background.
@@ -96,11 +129,12 @@ export class Actions extends Initializer {
       });
     }
     queue = queue ?? action?.task?.queue ?? DEFAULT_QUEUE;
+    const finalInputs = await this.runOnEnqueueHooks(actionName, inputs, queue);
     api.observability.task.enqueuedTotal.add(1, {
       action: actionName,
       queue,
     });
-    return api.resque.queue.enqueue(queue, actionName, [inputs]);
+    return api.resque.queue.enqueue(queue, actionName, [finalInputs]);
   };
 
   /**
@@ -302,11 +336,12 @@ export class Actions extends Initializer {
     queue: string = DEFAULT_QUEUE,
     suppressDuplicateTaskError = false,
   ) => {
+    const finalInputs = await this.runOnEnqueueHooks(actionName, inputs, queue);
     return api.resque.queue.enqueueAt(
       timestamp,
       queue,
       actionName,
-      [inputs],
+      [finalInputs],
       suppressDuplicateTaskError,
     );
   };
@@ -328,11 +363,12 @@ export class Actions extends Initializer {
     queue: string = DEFAULT_QUEUE,
     suppressDuplicateTaskError = false,
   ) => {
+    const finalInputs = await this.runOnEnqueueHooks(actionName, inputs, queue);
     return api.resque.queue.enqueueIn(
       time,
       queue,
       actionName,
-      [inputs],
+      [finalInputs],
       suppressDuplicateTaskError,
     );
   };

--- a/packages/keryx/initializers/hooks.ts
+++ b/packages/keryx/initializers/hooks.ts
@@ -1,0 +1,114 @@
+import type { AfterActHook, BeforeActHook } from "../classes/Connection";
+import { Initializer } from "../classes/Initializer";
+import type { AfterRequestHook, BeforeRequestHook } from "../servers/web";
+import type { OnEnqueueHook } from "./actionts";
+import type { AfterJobHook, BeforeJobHook } from "./resque";
+
+const namespace = "hooks";
+
+declare module "keryx" {
+  export interface API {
+    [namespace]: Awaited<ReturnType<Hooks["initialize"]>>;
+  }
+}
+
+/**
+ * Central registry for framework lifecycle hooks. Plugins register hooks here
+ * from their initializer's `initialize()`; the framework iterates the registered
+ * hooks at runtime.
+ *
+ * Public surface: `api.hooks.web`, `api.hooks.actions`, `api.hooks.resque`. See
+ * the respective hook type definitions for semantics (in `servers/web.ts`,
+ * `initializers/actionts.ts`, `initializers/resque.ts`).
+ */
+export class Hooks extends Initializer {
+  private webBeforeRequest: BeforeRequestHook[] = [];
+  private webAfterRequest: AfterRequestHook[] = [];
+  private actionsOnEnqueue: OnEnqueueHook[] = [];
+  private actionsBeforeAct: BeforeActHook[] = [];
+  private actionsAfterAct: AfterActHook[] = [];
+  private resqueBeforeJob: BeforeJobHook[] = [];
+  private resqueAfterJob: AfterJobHook[] = [];
+
+  constructor() {
+    super(namespace);
+  }
+
+  async initialize() {
+    const self = this;
+    return {
+      web: {
+        /**
+         * Register a hook to run at the start of every HTTP request, before
+         * routing. Covers static files, OAuth, MCP, metrics, and actions.
+         * Does not fire for WebSocket upgrades.
+         */
+        beforeRequest(hook: BeforeRequestHook): void {
+          self.webBeforeRequest.push(hook);
+        },
+        /**
+         * Register a hook to run after the `Response` is built, before
+         * compression. Receives the same `ctx` object passed to `beforeRequest`,
+         * so state stashed in `ctx.metadata` flows through.
+         */
+        afterRequest(hook: AfterRequestHook): void {
+          self.webAfterRequest.push(hook);
+        },
+        /** @internal Iterated by `WebServer.handleIncomingConnection`. */
+        beforeRequestHooks:
+          self.webBeforeRequest as ReadonlyArray<BeforeRequestHook>,
+        /** @internal Iterated by `WebServer.handleIncomingConnection`. */
+        afterRequestHooks:
+          self.webAfterRequest as ReadonlyArray<AfterRequestHook>,
+      },
+      actions: {
+        /**
+         * Register a hook to run on every enqueue. Fires for `enqueue`,
+         * `enqueueAt`, `enqueueIn`, and per-job inside `fanOut`. Hooks may
+         * mutate inputs by returning a replacement object.
+         */
+        onEnqueue(hook: OnEnqueueHook): void {
+          self.actionsOnEnqueue.push(hook);
+        },
+        /**
+         * Register a hook to run inside `Connection.act()` after params are
+         * validated and before the action's `runBefore` middleware. Fires for
+         * every action invocation across all transports (web, websocket, task,
+         * cli, mcp, …) — inspect `connection.type` to discriminate.
+         */
+        beforeAct(hook: BeforeActHook): void {
+          self.actionsBeforeAct.push(hook);
+        },
+        /**
+         * Register a hook to run inside `Connection.act()` in a `finally` block
+         * after the action completes (success or failure). Receives the same
+         * `ctx` as `beforeAct` plus a unified {@link ActOutcome}. Fires across
+         * all transports.
+         */
+        afterAct(hook: AfterActHook): void {
+          self.actionsAfterAct.push(hook);
+        },
+        /** @internal Iterated by `Actions.enqueue`, `enqueueAt`, `enqueueIn`. */
+        onEnqueueHooks: self.actionsOnEnqueue as ReadonlyArray<OnEnqueueHook>,
+        /** @internal Iterated inside `Connection.act`. */
+        beforeActHooks: self.actionsBeforeAct as ReadonlyArray<BeforeActHook>,
+        /** @internal Iterated inside `Connection.act`. */
+        afterActHooks: self.actionsAfterAct as ReadonlyArray<AfterActHook>,
+      },
+      resque: {
+        /** Register a hook to run before each job's action executes. */
+        beforeJob(hook: BeforeJobHook): void {
+          self.resqueBeforeJob.push(hook);
+        },
+        /** Register a hook to run after each job's action executes (success or failure). */
+        afterJob(hook: AfterJobHook): void {
+          self.resqueAfterJob.push(hook);
+        },
+        /** @internal Iterated inside `wrapActionAsJob.perform`. */
+        beforeJobHooks: self.resqueBeforeJob as ReadonlyArray<BeforeJobHook>,
+        /** @internal Iterated inside `wrapActionAsJob.perform`. */
+        afterJobHooks: self.resqueAfterJob as ReadonlyArray<AfterJobHook>,
+      },
+    };
+  }
+}

--- a/packages/keryx/initializers/resque.ts
+++ b/packages/keryx/initializers/resque.ts
@@ -18,8 +18,53 @@ import {
 import { Initializer } from "../classes/Initializer";
 import { LogFormat } from "../classes/Logger";
 import { TypedError } from "../classes/TypedError";
+import type { TaskInputs } from "./actionts";
 
 const namespace = "resque";
+
+/**
+ * Per-job context passed to {@link BeforeJobHook} and {@link AfterJobHook}.
+ * The same object instance is threaded from `beforeJob` to `afterJob`, so hooks can
+ * stash span refs, timing data, or any other state in `metadata`.
+ */
+export interface JobContext {
+  /** Mutable scratch space shared between `beforeJob` and `afterJob`. */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Unified outcome passed to {@link AfterJobHook}. Discriminate via the `success` field.
+ * Covers both the worker `success` and `failure` paths in a single shape.
+ */
+export type JobOutcome =
+  | { success: true; result: unknown; duration: number }
+  | { success: false; error: unknown; duration: number };
+
+/**
+ * Runs inside the job wrapper immediately before the action executes (i.e. before
+ * `connection.act()`). Receives the action name and decoded params, giving plugins
+ * access to trace headers or other correlation data embedded in inputs. Hooks run
+ * sequentially in registration order. Throwing fails the job.
+ */
+export type BeforeJobHook = (
+  actionName: string,
+  params: TaskInputs,
+  ctx: JobContext,
+) => Promise<void> | void;
+
+/**
+ * Runs inside the job wrapper after the action executes, in a `finally` block so it
+ * fires for both success and failure. Receives the same `ctx` passed to `beforeJob`
+ * plus a {@link JobOutcome} describing what happened. Hooks run sequentially in
+ * registration order. Errors thrown by an `afterJob` hook do not mask an action
+ * error but may surface instead of it if the action succeeded.
+ */
+export type AfterJobHook = (
+  actionName: string,
+  params: TaskInputs,
+  ctx: JobContext,
+  outcome: JobOutcome,
+) => Promise<void> | void;
 
 function logResqueEvent(
   level: "info" | "warn",
@@ -49,7 +94,7 @@ let SERVER_JOB_COUNTER = 1;
 export class Resque extends Initializer {
   constructor() {
     super(namespace);
-    this.dependsOn = ["redis", "actions", "process"];
+    this.dependsOn = ["redis", "actions", "process", "hooks"];
   }
 
   /** Create and connect the resque `Queue` instance (used for enqueuing jobs). */
@@ -322,15 +367,32 @@ export class Resque extends Initializer {
 
         const fanOutId = plainParams._fanOutId as string | undefined;
 
+        const jobCtx: JobContext = { metadata: {} };
+        const jobStartTime = Date.now();
+        for (const hook of api.hooks.resque.beforeJobHooks) {
+          await hook(action.name, plainParams, jobCtx);
+        }
+
         let response: Awaited<ReturnType<(typeof action)["run"]>>;
         let error: TypedError | undefined;
+        let outcome: JobOutcome | undefined;
         try {
           const payload = await connection.act(action.name, plainParams);
           response = payload.response;
           error = payload.error;
 
           if (error) throw error;
+          outcome = {
+            success: true,
+            result: response,
+            duration: Date.now() - jobStartTime,
+          };
         } catch (e) {
+          outcome = {
+            success: false,
+            error: e,
+            duration: Date.now() - jobStartTime,
+          };
           // Collect fan-out error before re-throwing
           if (fanOutId) {
             const metaKey = `fanout:${fanOutId}`;
@@ -351,6 +413,11 @@ export class Resque extends Initializer {
           }
           throw e;
         } finally {
+          if (outcome) {
+            for (const hook of api.hooks.resque.afterJobHooks) {
+              await hook(action.name, plainParams, jobCtx, outcome);
+            }
+          }
           if (
             action.task &&
             action.task.frequency &&

--- a/packages/keryx/initializers/servers.ts
+++ b/packages/keryx/initializers/servers.ts
@@ -17,7 +17,7 @@ declare module "keryx" {
 export class Servers extends Initializer {
   constructor() {
     super(namespace);
-    this.dependsOn = ["actions"];
+    this.dependsOn = ["actions", "hooks"];
     this.runModes = [RUN_MODE.SERVER];
   }
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.25.5",
+  "version": "0.26.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/servers/web.ts
+++ b/packages/keryx/servers/web.ts
@@ -26,9 +26,48 @@ import {
 import { handleStaticFile } from "../util/webStaticFiles";
 
 /**
+ * Per-request context passed to {@link BeforeRequestHook} and {@link AfterRequestHook}.
+ * The same object instance is passed to both hooks for a given request, so `beforeRequest`
+ * implementations can stash state (e.g. span refs, start time) in `metadata` for
+ * `afterRequest` to pick up.
+ */
+export interface RequestContext {
+  /** Client IP address as reported by `server.requestIP()`, or `"unknown-IP"`. */
+  ip: string;
+  /** Session id from the session cookie, or a freshly minted UUID. */
+  id: string;
+  /** Mutable scratch space shared between `beforeRequest` and `afterRequest`. */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Runs at the start of every HTTP request, before any routing or static file handling.
+ * WebSocket upgrades do not fire this hook. Throwing an error propagates out of the
+ * request handler. Hooks run sequentially in registration order.
+ */
+export type BeforeRequestHook = (
+  req: Request,
+  ctx: RequestContext,
+) => Promise<void> | void;
+
+/**
+ * Runs after the `Response` is built and before compression. Receives the same `ctx`
+ * object that was passed to the matching `beforeRequest`. Hooks run sequentially in
+ * registration order.
+ */
+export type AfterRequestHook = (
+  req: Request,
+  res: Response,
+  ctx: RequestContext,
+) => Promise<void> | void;
+
+/**
  * HTTP + WebSocket server built on `Bun.serve`. Handles REST action routing (with path params),
  * static file serving (with ETag/304 caching), WebSocket connections (actions, PubSub subscribe/unsubscribe),
- * OAuth endpoints, and MCP SSE streams. Exposes `api.servers.web`.
+ * OAuth endpoints, and MCP SSE streams.
+ *
+ * Plugins register HTTP lifecycle hooks via `api.hooks.web.beforeRequest` /
+ * `api.hooks.web.afterRequest`.
  */
 export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
   /** The actual port the server bound to (resolved after start, e.g. when config port is 0). */
@@ -169,7 +208,16 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
     )
       return; // upgrade the request to a WebSocket
 
+    const ctx: RequestContext = { ip, id, metadata: {} };
+    for (const hook of api.hooks.web.beforeRequestHooks) {
+      await hook(req, ctx);
+    }
+
     const response = await this.handleHttpRequest(req, server, ip, id);
+
+    for (const hook of api.hooks.web.afterRequestHooks) {
+      await hook(req, response, ctx);
+    }
 
     // SSE and other streaming responses: disable idle timeout and skip compression
     if (response.headers.get("Content-Type")?.includes("text/event-stream")) {


### PR DESCRIPTION
## Summary

Introduces a central `api.hooks` namespace so plugins can hook into framework lifecycle events that today have no extension point. Five hook pairs, all generic (not OTel-specific):

- **`api.hooks.web.beforeRequest` / `afterRequest`** — wraps the whole HTTP request (static files, OAuth, MCP SSE, actions) before the `Connection` is created, so plugins can parent an HTTP-level span.
- **`api.hooks.actions.onEnqueue`** — fires on every `enqueue` / `enqueueAt` / `enqueueIn` / per-job in `fanOut`; return replacement `TaskInputs` to inject payload (e.g. trace headers).
- **`api.hooks.actions.beforeAct` / `afterAct`** — fires inside `Connection.act()` for every action invocation across all transports (web, ws, task, cli, mcp); handler receives the `Connection` for transport discrimination.
- **`api.hooks.resque.beforeJob` / `afterJob`** — brackets action execution inside `wrapActionAsJob.perform`; `afterJob` gets a unified success/failure `JobOutcome`.

Hooks register from plugin initializer code (`dependsOn: ["hooks"]`); no change to the `KeryxPlugin` manifest. All hook types are exported from `"keryx"`. Bumps the package to 0.26.0. Docs updated in `guide/plugins.md`; 715/716 tests pass (one pre-existing scaffold-e2e flake, unrelated).

## Test plan

- [ ] `cd packages/keryx && bun test` — framework suite (712+ tests, includes new coverage for all five hook pairs across transports + success/failure/not-found/invalid-param cases)
- [ ] `bun run ci` — lint + all workspace tests
- [ ] Manually register a hook in each namespace from a plugin initializer and confirm it fires at the expected lifecycle point

🤖 Generated with [Claude Code](https://claude.com/claude-code)