### PR TITLE
Add DB pool exhaustion tests (closes #384)

### DIFF
--- a/packages/keryx/__tests__/initializers/db.test.ts
+++ b/packages/keryx/__tests__/initializers/db.test.ts
@@ -3,6 +3,7 @@ import { sql } from "drizzle-orm";
 import { Pool } from "pg";
 import { api } from "../../api";
 import { ErrorType, TypedError } from "../../classes/TypedError";
+import { config } from "../../config";
 import { DB } from "../../initializers/db";
 import { HOOK_TIMEOUT } from "../setup";
 
@@ -80,5 +81,92 @@ describe("DB initializer", () => {
     } finally {
       (api as any).db = liveDb;
     }
+  });
+});
+
+describe("DB pool exhaustion", () => {
+  const originalMax = config.database.pool.max;
+  const originalConnectTimeout = config.database.pool.connectionTimeoutMillis;
+
+  beforeAll(async () => {
+    await api.stop();
+    config.database.pool.max = 2;
+    config.database.pool.connectionTimeoutMillis = 500;
+    await api.start();
+  }, HOOK_TIMEOUT);
+
+  afterAll(async () => {
+    await api.stop();
+    config.database.pool.max = originalMax;
+    config.database.pool.connectionTimeoutMillis = originalConnectTimeout;
+    await api.start();
+  }, HOOK_TIMEOUT);
+
+  test("queues requests beyond pool.max instead of erroring", async () => {
+    const start = Date.now();
+    const queries = Array.from({ length: 4 }, () =>
+      api.db.pool.query("SELECT pg_sleep(0.2), 1 as one"),
+    );
+    // Yield so the pool dispatches 2 and queues the rest.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(api.db.pool.waitingCount).toBeGreaterThanOrEqual(1);
+    expect(api.db.pool.totalCount).toBeLessThanOrEqual(2);
+
+    const results = await Promise.all(queries);
+    expect(results).toHaveLength(4);
+    for (const r of results) expect(r.rows[0].one).toBe(1);
+    // 4 queries × 0.2s serialized 2-at-a-time should take ~0.4s.
+    expect(Date.now() - start).toBeGreaterThanOrEqual(350);
+  });
+
+  test("rejects with a timeout error when queue wait exceeds connectionTimeoutMillis", async () => {
+    const held = Array.from({ length: 2 }, () =>
+      api.db.pool.query("SELECT pg_sleep(2)").catch(() => undefined),
+    );
+    // Yield so held queries claim both connections.
+    await new Promise((r) => setTimeout(r, 20));
+
+    await expect(api.db.pool.query("SELECT 1")).rejects.toThrow(
+      /timeout|timed out/i,
+    );
+
+    // Let the held queries finish (or fail on shutdown) before moving on.
+    await Promise.all(held);
+  });
+
+  test("pool recovers after the queue drains", async () => {
+    const result = await api.db.pool.query("SELECT 1::int as one");
+    expect(result.rows[0].one).toBe(1);
+    expect(api.db.pool.waitingCount).toBe(0);
+
+    const burst = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        api.db.pool.query("SELECT 1::int as one"),
+      ),
+    );
+    expect(burst).toHaveLength(4);
+    for (const r of burst) expect(r.rows[0].one).toBe(1);
+  });
+
+  test("pool.end() drains in-flight queries on graceful shutdown", async () => {
+    // Standalone pool so we don't tear down api.db mid-suite.
+    const pool = new Pool({
+      connectionString: config.database.connectionString,
+      max: 2,
+    });
+    const inflight = Promise.all([
+      pool.query("SELECT pg_sleep(0.2), 1 as one"),
+      pool.query("SELECT pg_sleep(0.2), 2 as two"),
+    ]);
+    // Yield so queries claim connections before we request shutdown.
+    await new Promise((r) => setTimeout(r, 20));
+
+    const ended = pool.end();
+    const [results] = await Promise.all([inflight, ended]);
+    const [q1, q2] = results;
+    expect(q1.rows[0].one).toBe(1);
+    expect(q2.rows[0].two).toBe(2);
+
+    await expect(pool.query("SELECT 1")).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Adds a `describe("DB pool exhaustion", ...)` block in `packages/keryx/__tests__/initializers/db.test.ts` covering the four production failure modes called out in #384: queue-behind-max, `connectionTimeoutMillis` rejection, post-drain recovery, and graceful-shutdown drain via `pool.end()`.
- No production code changes; the exhaustion describe captures and restores the original `pool.max` / `connectionTimeoutMillis` around its own lifecycle, and the graceful-shutdown test uses a standalone `Pool` so the shared `api.db` is not torn down mid-suite.

## Test plan
- [x] \`cd packages/keryx && bun test __tests__/initializers/db.test.ts\` — 12 pass / 0 fail
- [x] Full framework suite matches baseline (pre-existing env failures are unrelated: docs build, example/backend DB config)
- [x] \`bun lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)