### PR TITLE
refactor: flatten parseRequestParams query merging (#434)

### DIFF
--- a/packages/keryx/__tests__/util/webRouting.test.ts
+++ b/packages/keryx/__tests__/util/webRouting.test.ts
@@ -217,6 +217,38 @@ describe("parseRequestParams", () => {
       expect(params.name).toBe("from-body");
       expect(params.extra).toBe("query-val");
     });
+
+    test("body scalar + query scalar with same key produces an array", async () => {
+      const params = await parseRequestParams(
+        jsonRequest({ tag: "from-body" }),
+        parsedUrl("tag=from-query"),
+      );
+      expect(params.tag).toEqual(["from-body", "from-query"]);
+    });
+
+    test("body scalar + repeated query of same key flattens", async () => {
+      const params = await parseRequestParams(
+        jsonRequest({ tag: "body" }),
+        parsedUrl("tag=q1&tag=q2"),
+      );
+      expect(params.tag).toEqual(["body", "q1", "q2"]);
+    });
+
+    test("path param + repeated query of same key flattens", async () => {
+      const req = new Request("http://localhost/test", { method: "GET" });
+      const params = await parseRequestParams(req, parsedUrl("id=q1&id=q2"), {
+        id: "from-path",
+      });
+      expect(params.id).toEqual(["from-path", "q1", "q2"]);
+    });
+
+    test("body array + query scalar of same key flattens", async () => {
+      const params = await parseRequestParams(
+        jsonRequest({ tag: ["a", "b"] }),
+        parsedUrl("tag=c"),
+      );
+      expect(params.tag).toEqual(["a", "b", "c"]);
+    });
   });
 });
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.29.8",
+  "version": "0.29.9",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/webRouting.ts
+++ b/packages/keryx/util/webRouting.ts
@@ -113,6 +113,28 @@ async function readBodyWithLimit(req: Request): Promise<string> {
 }
 
 /**
+ * Merge a value into the params object under `key`, appending to any existing
+ * value rather than replacing it. If `key` is not set, assigns `value` as-is.
+ * If it is set, produces an array containing the existing value(s) followed by
+ * the incoming value(s). Used to fold body, form-data, and query string
+ * sources into a single params object while preserving repeated keys.
+ */
+function appendParam(
+  params: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  if (params[key] === undefined) {
+    params[key] = value;
+    return;
+  }
+  const incoming = Array.isArray(value) ? value : [value];
+  params[key] = Array.isArray(params[key])
+    ? [...(params[key] as unknown[]), ...incoming]
+    : [params[key], ...incoming];
+}
+
+/**
  * Parse request parameters from path params, request body (JSON or form-data),
  * and query string into a single plain object.
  *
@@ -179,44 +201,12 @@ export async function parseRequestParams(
     }
 
     const f = await req.formData();
-    f.forEach((value, key) => {
-      if (params[key] !== undefined) {
-        if (Array.isArray(params[key])) {
-          (params[key] as unknown[]).push(value);
-        } else {
-          params[key] = [params[key], value];
-        }
-      } else {
-        params[key] = value;
-      }
-    });
+    f.forEach((value, key) => appendParam(params, key, value));
   }
 
   if (url.query) {
     for (const [key, values] of Object.entries(url.query)) {
-      if (values !== undefined) {
-        if (Array.isArray(values)) {
-          if (params[key] !== undefined) {
-            if (Array.isArray(params[key])) {
-              (params[key] as unknown[]).push(...values);
-            } else {
-              params[key] = [params[key], ...values];
-            }
-          } else {
-            params[key] = values;
-          }
-        } else {
-          if (params[key] !== undefined) {
-            if (Array.isArray(params[key])) {
-              (params[key] as unknown[]).push(values);
-            } else {
-              params[key] = [params[key], values];
-            }
-          } else {
-            params[key] = values;
-          }
-        }
-      }
+      if (values !== undefined) appendParam(params, key, values);
     }
   }
 


### PR DESCRIPTION
## Summary

- Extract a private `appendParam` helper in `packages/keryx/util/webRouting.ts` to fold body, form-data, and query string sources into a single params object
- Collapse the 4-level nested query-string block (~25 lines → 5 lines) and a similar nested form-data block (~12 lines → 2 lines) into single calls — no behavioral change
- Add tests for previously-untested cross-source merge cases (body scalar + query scalar/array, path + query array, body array + query scalar)
- Patch bump `keryx` to `0.29.9`

Closes https://github.com/actionhero/keryx/issues/434

## Test plan

- [x] `bun test __tests__/util/webRouting.test.ts` — 33 pass (29 existing + 4 new)
- [x] `bun test-package` — 759 pass across the keryx framework
- [x] `bun lint` — clean across all 4 workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)