### PR TITLE
Security: optional HTTP Basic auth for /metrics endpoint (#456)

### DIFF
--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -18,11 +18,13 @@ OTEL_METRICS_ENABLED=true bun run start
 
 ## Configuration
 
-| Config Key     | Env Var                | Default      | Description                                                                                |
-| -------------- | ---------------------- | ------------ | ------------------------------------------------------------------------------------------ |
-| `enabled`      | `OTEL_METRICS_ENABLED` | `false`      | Master toggle for all instrumentation                                                      |
-| `metricsRoute` | `OTEL_METRICS_ROUTE`   | `"/metrics"` | Path for the Prometheus scrape endpoint                                                    |
-| `serviceName`  | `OTEL_SERVICE_NAME`    | _(app name)_ | Service name in metric labels. Defaults to the `name` field from your app's `package.json` |
+| Config Key            | Env Var                       | Default      | Description                                                                                |
+| --------------------- | ----------------------------- | ------------ | ------------------------------------------------------------------------------------------ |
+| `enabled`             | `OTEL_METRICS_ENABLED`        | `false`      | Master toggle for all instrumentation                                                      |
+| `metricsRoute`        | `OTEL_METRICS_ROUTE`          | `"/metrics"` | Path for the Prometheus scrape endpoint                                                    |
+| `serviceName`         | `OTEL_SERVICE_NAME`           | _(app name)_ | Service name in metric labels. Defaults to the `name` field from your app's `package.json` |
+| `metricsAuthUsername` | `OTEL_METRICS_AUTH_USERNAME`  | `""`         | When set together with `metricsAuthPassword`, requires HTTP Basic auth on `/metrics`       |
+| `metricsAuthPassword` | `OTEL_METRICS_AUTH_PASSWORD`  | `""`         | Password for the metrics endpoint when basic auth is enabled                               |
 
 ## Available Metrics
 
@@ -86,6 +88,33 @@ scrape_configs:
 ```
 
 The metrics endpoint is served on the existing web server — no additional ports or servers needed. It's intercepted before action routing, so it won't conflict with your API routes. Keryx validates at startup that no action route overlaps with the metrics path.
+
+### Authentication
+
+By default `/metrics` is unauthenticated. This is suitable for private networks (e.g. Kubernetes clusters) where network segmentation provides the access control. For publicly-exposed servers, enable HTTP Basic auth by setting both `OTEL_METRICS_AUTH_USERNAME` and `OTEL_METRICS_AUTH_PASSWORD`. When either is empty, the endpoint stays open.
+
+```bash
+OTEL_METRICS_ENABLED=true \
+OTEL_METRICS_AUTH_USERNAME=prometheus \
+OTEL_METRICS_AUTH_PASSWORD=secret \
+bun run start
+```
+
+Configure Prometheus to send the credentials on each scrape:
+
+```yaml
+scrape_configs:
+  - job_name: "keryx"
+    scrape_interval: 15s
+    metrics_path: "/metrics"
+    basic_auth:
+      username: "prometheus"
+      password_file: "/etc/prometheus/keryx_password"
+    static_configs:
+      - targets: ["keryx.example.com"]
+```
+
+Requests without an `Authorization: Basic ...` header (or with wrong credentials) get a `401 Unauthorized` with `WWW-Authenticate: Basic realm="Metrics"`.
 
 ## Custom Exporters
 

--- a/packages/keryx/__tests__/servers/web-metrics-auth.test.ts
+++ b/packages/keryx/__tests__/servers/web-metrics-auth.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { config } from "../../config";
+import { useTestServer } from "../setup";
+
+const originalEnabled = config.observability.enabled;
+const originalUser = config.observability.metricsAuthUsername;
+const originalPass = config.observability.metricsAuthPassword;
+
+beforeAll(() => {
+  config.observability.enabled = true;
+});
+
+const getUrl = useTestServer();
+
+afterAll(() => {
+  config.observability.enabled = originalEnabled;
+  config.observability.metricsAuthUsername = originalUser;
+  config.observability.metricsAuthPassword = originalPass;
+});
+
+describe("metrics endpoint auth", () => {
+  describe("when no credentials are configured", () => {
+    beforeAll(() => {
+      config.observability.metricsAuthUsername = "";
+      config.observability.metricsAuthPassword = "";
+    });
+
+    test("serves metrics without an Authorization header", async () => {
+      const res = await fetch(getUrl() + "/metrics");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/plain");
+    });
+  });
+
+  describe("when credentials are configured", () => {
+    beforeAll(() => {
+      config.observability.metricsAuthUsername = "admin";
+      config.observability.metricsAuthPassword = "s3cret";
+    });
+
+    test("returns 401 with WWW-Authenticate when no Authorization header is sent", async () => {
+      const res = await fetch(getUrl() + "/metrics");
+      expect(res.status).toBe(401);
+      expect(res.headers.get("WWW-Authenticate")).toBe('Basic realm="Metrics"');
+    });
+
+    test("returns 401 when the Authorization scheme is not Basic", async () => {
+      const res = await fetch(getUrl() + "/metrics", {
+        headers: { Authorization: "Bearer some-token" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test("returns 401 when the base64 payload is malformed", async () => {
+      const res = await fetch(getUrl() + "/metrics", {
+        headers: { Authorization: "Basic !!!not-base64!!!" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test("returns 401 when the decoded credentials lack a colon", async () => {
+      const res = await fetch(getUrl() + "/metrics", {
+        headers: { Authorization: `Basic ${btoa("missing-colon")}` },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test("returns 401 with a wrong username", async () => {
+      const res = await fetch(getUrl() + "/metrics", {
+        headers: { Authorization: `Basic ${btoa("wrong:s3cret")}` },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test("returns 401 with a wrong password", async () => {
+      const res = await fetch(getUrl() + "/metrics", {
+        headers: { Authorization: `Basic ${btoa("admin:wrong")}` },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test("returns 200 with correct credentials", async () => {
+      const res = await fetch(getUrl() + "/metrics", {
+        headers: { Authorization: `Basic ${btoa("admin:s3cret")}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body.length).toBeGreaterThan(0);
+    });
+
+    test("supports passwords containing colons", async () => {
+      const original = config.observability.metricsAuthPassword;
+      config.observability.metricsAuthPassword = "pass:with:colons";
+      try {
+        const res = await fetch(getUrl() + "/metrics", {
+          headers: {
+            Authorization: `Basic ${btoa("admin:pass:with:colons")}`,
+          },
+        });
+        expect(res.status).toBe(200);
+      } finally {
+        config.observability.metricsAuthPassword = original;
+      }
+    });
+  });
+});

--- a/packages/keryx/config/observability.ts
+++ b/packages/keryx/config/observability.ts
@@ -4,4 +4,6 @@ export const configObservability = {
   enabled: await loadFromEnvIfSet("OTEL_METRICS_ENABLED", false),
   metricsRoute: await loadFromEnvIfSet("OTEL_METRICS_ROUTE", "/metrics"),
   serviceName: await loadFromEnvIfSet("OTEL_SERVICE_NAME", ""),
+  metricsAuthUsername: await loadFromEnvIfSet("OTEL_METRICS_AUTH_USERNAME", ""),
+  metricsAuthPassword: await loadFromEnvIfSet("OTEL_METRICS_AUTH_PASSWORD", ""),
 };

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.29.8",
+  "version": "0.29.9",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/servers/web.ts
+++ b/packages/keryx/servers/web.ts
@@ -1,6 +1,6 @@
+import { randomUUID } from "node:crypto";
 import { parse } from "node:url";
 import type { ServerWebSocket } from "bun";
-import { randomUUID } from "crypto";
 import { api, logger } from "../api";
 import { type HTTP_METHOD } from "../classes/Action";
 import { Connection } from "../classes/Connection";
@@ -11,6 +11,7 @@ import { config } from "../config";
 import type { PubSubMessage } from "../initializers/pubsub";
 import { ansi } from "../util/ansi";
 import { isOriginAllowed } from "../util/http";
+import { verifyBasicAuth } from "../util/webBasicAuth";
 import { compressResponse } from "../util/webCompression";
 import {
   buildError,
@@ -325,6 +326,23 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
       config.observability.enabled &&
       parsedUrl.pathname === config.observability.metricsRoute
     ) {
+      if (
+        !verifyBasicAuth(
+          req,
+          config.observability.metricsAuthUsername,
+          config.observability.metricsAuthPassword,
+        )
+      ) {
+        return {
+          response: new Response("Unauthorized", {
+            status: 401,
+            headers: {
+              "WWW-Authenticate": 'Basic realm="Metrics"',
+              "Content-Type": "text/plain",
+            },
+          }),
+        };
+      }
       const body = await api.observability.collectMetrics();
       return {
         response: new Response(body || "", {

--- a/packages/keryx/util/webBasicAuth.ts
+++ b/packages/keryx/util/webBasicAuth.ts
@@ -1,0 +1,53 @@
+import { timingSafeEqual } from "node:crypto";
+
+// Pads to a common length so we don't leak the expected length via early-return.
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  const len = Math.max(aBuf.length, bBuf.length, 1);
+  const aPadded = Buffer.alloc(len);
+  const bPadded = Buffer.alloc(len);
+  aBuf.copy(aPadded);
+  bBuf.copy(bPadded);
+  return timingSafeEqual(aPadded, bPadded) && aBuf.length === bBuf.length;
+}
+
+/**
+ * Verifies an HTTP Basic auth `Authorization` header against expected credentials
+ * using a constant-time string compare.
+ *
+ * @param req - The incoming `Request`. Read for its `Authorization` header.
+ * @param expectedUsername - The username to match. If empty, auth is treated as
+ *   disabled and the function returns `true`.
+ * @param expectedPassword - The password to match. If empty, auth is treated as
+ *   disabled and the function returns `true`.
+ * @returns `true` when auth is disabled (either credential empty) or when the
+ *   header carries valid `Basic <base64>` credentials matching both expected
+ *   values. `false` for any malformed, missing, or wrong header.
+ */
+export function verifyBasicAuth(
+  req: Request,
+  expectedUsername: string,
+  expectedPassword: string,
+): boolean {
+  if (!expectedUsername || !expectedPassword) return true;
+
+  const header = req.headers.get("Authorization");
+  if (!header?.startsWith("Basic ")) return false;
+
+  let decoded: string;
+  try {
+    decoded = atob(header.slice(6).trim());
+  } catch {
+    return false;
+  }
+
+  const idx = decoded.indexOf(":");
+  if (idx === -1) return false;
+  const user = decoded.slice(0, idx);
+  const pass = decoded.slice(idx + 1);
+
+  const userOk = timingSafeStringEqual(user, expectedUsername);
+  const passOk = timingSafeStringEqual(pass, expectedPassword);
+  return userOk && passOk;
+}


### PR DESCRIPTION
## Summary

- Adds optional HTTP Basic auth on the Prometheus `/metrics` endpoint, controlled by two new env vars (`OTEL_METRICS_AUTH_USERNAME`, `OTEL_METRICS_AUTH_PASSWORD`); when either is empty the endpoint stays open, so existing private-network deployments are unaffected.
- New `util/webBasicAuth.ts` exports a generic `verifyBasicAuth(req, user, pass)` helper using `crypto.timingSafeEqual` with length-padding; `web.ts` calls it in the metrics route and returns `401 Unauthorized` with `WWW-Authenticate: Basic realm="Metrics"` on missing/invalid credentials.
- Docs updated (config table + new "Authentication" section with a Prometheus `basic_auth:` scrape example), 9 new tests in `web-metrics-auth.test.ts` cover open-by-default plus missing/wrong-scheme/malformed/no-colon/wrong-creds → 401 and correct-creds → 200, and `keryx` is patch-bumped to 0.29.9. Resolves #456.

## Test plan

- [x] `bun lint` clean
- [x] `bun test-package` — 764/764 tests pass (incl. 9 new metrics-auth cases)
- [ ] Manual smoke: set `OTEL_METRICS_ENABLED=true` + auth env vars, verify `curl /metrics` → 401 and `curl -u user:pass /metrics` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)