### PR TITLE
fix: typo MessageCrete -> MessageCreate in example backend

### DIFF
--- a/example/backend/__tests__/actions/message.test.ts
+++ b/example/backend/__tests__/actions/message.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { type ActionResponse, api } from "keryx";
 import type {
-  MessageCrete,
+  MessageCreate,
   MessagesList,
   MessageView,
 } from "../../actions/message";
@@ -31,7 +31,7 @@ describe("message:create", () => {
       body: JSON.stringify({ body: "Hello, world!" }),
     });
     expect(res.status).toBe(401);
-    const response = (await res.json()) as ActionResponse<MessageCrete>;
+    const response = (await res.json()) as ActionResponse<MessageCreate>;
     expect(response.error?.message).toEqual("Session not found");
   });
 
@@ -45,7 +45,7 @@ describe("message:create", () => {
       body: JSON.stringify({ body: "Hello, world!" }),
     });
     expect(res.status).toBe(401);
-    const response = (await res.json()) as ActionResponse<MessageCrete>;
+    const response = (await res.json()) as ActionResponse<MessageCreate>;
     expect(response.error?.message).toEqual("Session not found");
   });
 
@@ -60,7 +60,7 @@ describe("message:create", () => {
     });
     expect(res.status).toBe(200);
 
-    const response = (await res.json()) as ActionResponse<MessageCrete>;
+    const response = (await res.json()) as ActionResponse<MessageCreate>;
     expect(response.message.body).toEqual("Hello, world!");
     expect(response.message.id).toBeGreaterThanOrEqual(1);
     expect(response.message.createdAt).toBeGreaterThan(0);

--- a/example/backend/actions/message.ts
+++ b/example/backend/actions/message.ts
@@ -17,7 +17,7 @@ import { users } from "../schema/users";
 import { zMessageIdOrModel } from "../util/zodMixins";
 import type { SessionImpl } from "./session";
 
-export class MessageCrete implements Action {
+export class MessageCreate implements Action {
   name = "message:create";
   description =
     "Create a new chat message as the currently authenticated user. The message is persisted to the database and broadcast in real-time to all connected users via the 'messages' PubSub channel. Requires an active session. Returns the created message with its ID and timestamps.";
@@ -32,7 +32,7 @@ export class MessageCrete implements Action {
   });
 
   async run(
-    params: ActionParams<MessageCrete>,
+    params: ActionParams<MessageCreate>,
     connection: Connection<SessionImpl>,
   ) {
     const userId = connection.session!.data.userId!;

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.29.10",
+  "version": "0.29.9",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.29.9",
+  "version": "0.29.10",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Renames the misspelled `MessageCrete` class to `MessageCreate` in `example/backend/actions/message.ts`.
- Updates the matching `import` and three `ActionResponse<...>` casts in `example/backend/__tests__/actions/message.test.ts`.
- Patch-bumps `packages/keryx` 0.29.9 -> 0.29.10.

The action's `name` (`"message:create"`), HTTP route, and runtime behavior were always correct — only the exported TypeScript class identifier was wrong, so this is a pure rename with no behavior change.

closes #437

## Test plan

- [x] `bun run lint` (in `example/backend/`) — passes (tsc + biome).
- [x] `bun test __tests__/actions/message.test.ts` — 11/11 passing.
- [x] `rg MessageCrete` — zero matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)