### PR TITLE
refactor: extract compressBody helper in webCompression

### DIFF
--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.29.10",
+  "version": "0.29.9",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.29.9",
+  "version": "0.29.10",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/webCompression.ts
+++ b/packages/keryx/util/webCompression.ts
@@ -54,6 +54,27 @@ function isIncompressible(contentType: string | null): boolean {
 }
 
 /**
+ * Pipe a body through a `CompressionStream` and build a new `Response` carrying the
+ * compression headers (`Content-Encoding`, appended `Vary`, removed `Content-Length`).
+ */
+function compressBody(
+  body: ReadableStream,
+  encoding: "br" | "gzip",
+  response: Response,
+): Response {
+  const format: Bun.CompressionFormat = encoding === "br" ? "brotli" : "gzip";
+  const compressionStream = new CompressionStream(format);
+  const stream = body.pipeThrough(compressionStream);
+
+  const headers = new Headers(response.headers);
+  headers.set("Content-Encoding", encoding);
+  headers.append("Vary", "Accept-Encoding");
+  headers.delete("Content-Length");
+
+  return new Response(stream, { status: response.status, headers });
+}
+
+/**
  * Conditionally compress an HTTP response based on the client's `Accept-Encoding` header,
  * the response content type, and the configured compression threshold.
  *
@@ -112,40 +133,9 @@ export async function compressResponse(
       });
     }
 
-    // Compress the buffered body
-    const format: Bun.CompressionFormat = encoding === "br" ? "brotli" : "gzip";
-    // @ts-ignore Bun supports "brotli" as CompressionFormat but DOM lib does not
-    const compressionStream = new CompressionStream(format);
-    // @ts-ignore Bun's ReadableStream type is incompatible with Node/DOM ReadableStream
-    const stream = new Blob([body]).stream().pipeThrough(compressionStream);
-
-    const headers = new Headers(response.headers);
-    headers.set("Content-Encoding", encoding);
-    headers.append("Vary", "Accept-Encoding");
-    headers.delete("Content-Length");
-
-    // @ts-ignore Bun's ReadableStream type is incompatible with Node/DOM ReadableStream
-    return new Response(stream, {
-      status: response.status,
-      headers,
-    });
+    return compressBody(new Blob([body]).stream(), encoding, response);
   }
 
   // Content-Length is present and above threshold — stream-compress
-  const format: Bun.CompressionFormat = encoding === "br" ? "brotli" : "gzip";
-  // @ts-ignore Bun supports "brotli" as CompressionFormat but DOM lib does not
-  const compressionStream = new CompressionStream(format);
-  // @ts-ignore Bun's ReadableStream type is incompatible with Node/DOM ReadableStream
-  const stream = response.body.pipeThrough(compressionStream);
-
-  const headers = new Headers(response.headers);
-  headers.set("Content-Encoding", encoding);
-  headers.append("Vary", "Accept-Encoding");
-  headers.delete("Content-Length");
-
-  // @ts-ignore Bun's ReadableStream type is incompatible with Node/DOM ReadableStream
-  return new Response(stream, {
-    status: response.status,
-    headers,
-  });
+  return compressBody(response.body, encoding, response);
 }


### PR DESCRIPTION
## Summary

- Extract the duplicated `CompressionStream` + response-rebuild logic in `packages/keryx/util/webCompression.ts` into a single private `compressBody(body, encoding, response)` helper.
- Both call sites (buffered fallback and streaming with Content-Length) collapse to one-liners.
- Bonus: the helper's typed signature lets TypeScript resolve the stream/format types on its own — all four original `@ts-ignore` directives are removed (none needed, not even `@ts-expect-error`).
- Patch version bump: 0.29.9 → 0.29.10.

closes #432

## Test plan

- [x] `bun test __tests__/util/webCompression.test.ts` — 19/19 pass
- [x] `bun test` (full keryx package suite) — 771/771 pass
- [x] `bun lint` — clean across all workspaces (no unused suppression warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)