### PR TITLE
Security: exact string match for OAuth redirect URIs

### DIFF
--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -138,7 +138,7 @@ When clients register via `/oauth/register`, redirect URIs are validated:
 - Must not contain userinfo (username/password in the URL)
 - Must use HTTPS for non-localhost URIs
 
-When exchanging authorization codes, the redirect URI must match the registered URI exactly (origin + pathname comparison).
+When authorizing or exchanging authorization codes, the redirect URI must match a registered URI using exact string comparison (per RFC 6749 §3.1.2.3).
 
 ### Registration Rate Limiting
 

--- a/packages/keryx/__tests__/util/oauth.test.ts
+++ b/packages/keryx/__tests__/util/oauth.test.ts
@@ -60,13 +60,31 @@ describe("redirectUrisMatch", () => {
     ).toBe(true);
   });
 
-  test("query params are ignored", () => {
+  test("appended query param returns false (RFC 6749 §3.1.2.3)", () => {
     expect(
       redirectUrisMatch(
         "https://example.com/cb",
         "https://example.com/cb?state=xyz",
       ),
+    ).toBe(false);
+  });
+
+  test("matching query params return true", () => {
+    expect(
+      redirectUrisMatch(
+        "https://example.com/cb?foo=bar",
+        "https://example.com/cb?foo=bar",
+      ),
     ).toBe(true);
+  });
+
+  test("different query param values return false", () => {
+    expect(
+      redirectUrisMatch(
+        "https://example.com/cb?foo=bar",
+        "https://example.com/cb?foo=baz",
+      ),
+    ).toBe(false);
   });
 
   test("different pathname returns false", () => {
@@ -85,15 +103,6 @@ describe("redirectUrisMatch", () => {
     expect(
       redirectUrisMatch("http://localhost:3000/cb", "http://localhost:4000/cb"),
     ).toBe(false);
-  });
-
-  test("malformed input returns false", () => {
-    expect(redirectUrisMatch("not-a-url", "https://example.com/cb")).toBe(
-      false,
-    );
-    expect(redirectUrisMatch("https://example.com/cb", "not-a-url")).toBe(
-      false,
-    );
   });
 });
 

--- a/packages/keryx/__tests__/util/oauthHandlers.test.ts
+++ b/packages/keryx/__tests__/util/oauthHandlers.test.ts
@@ -688,6 +688,22 @@ describe("handleAuthorizePost", () => {
     expect(html).toContain("Invalid redirect URI");
   });
 
+  test("redirect_uri with appended query param is rejected", async () => {
+    const { clientId } = await registerClient("http://localhost:9999/cb");
+    const res = await handleAuthorizePost(
+      buildPost({
+        client_id: clientId,
+        redirect_uri: "http://localhost:9999/cb?evil=1",
+        code_challenge: "chal",
+        code_challenge_method: "S256",
+        response_type: "code",
+      }),
+      templates,
+    );
+    const html = await res.text();
+    expect(html).toContain("Invalid redirect URI");
+  });
+
   test("non-S256 code_challenge_method is rejected", async () => {
     const { clientId } = await registerClient("http://localhost:9999/cb");
     const res = await handleAuthorizePost(

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.29.10",
+  "version": "0.29.11",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/oauth.ts
+++ b/packages/keryx/util/oauth.ts
@@ -40,23 +40,14 @@ export function validateRedirectUri(uri: string): {
 }
 
 /**
- * Compare two redirect URIs by origin and pathname (ignoring query params).
- * Returns `false` if either URI is malformed.
+ * Compare two redirect URIs with exact string matching, as required by
+ * RFC 6749 §3.1.2.3 and RFC 8252 §8.4.
  */
 export function redirectUrisMatch(
   registeredUri: string,
   requestedUri: string,
 ): boolean {
-  try {
-    const registered = new URL(registeredUri);
-    const requested = new URL(requestedUri);
-    return (
-      registered.origin === requested.origin &&
-      registered.pathname === requested.pathname
-    );
-  } catch {
-    return false;
-  }
+  return registeredUri === requestedUri;
 }
 
 /** Encode a byte array as a URL-safe base64 string (no padding). Used for PKCE code challenges. */


### PR DESCRIPTION
## Summary

`redirectUrisMatch()` previously compared only `origin + pathname`, allowing an attacker to append query parameters to a registered redirect URI and slip past the `/oauth/authorize` endpoint. RFC 6749 §3.1.2.3 and RFC 8252 §8.4 both require **exact** string matching.

The token endpoint already did strict equality, but the authorize endpoint was the weak link — a code could be issued before the strict check ever ran.

## Changes

- `packages/keryx/util/oauth.ts` — `redirectUrisMatch()` now does exact `===` comparison
- `packages/keryx/__tests__/util/oauth.test.ts` — flipped the (incorrectly) passing query-params-ignored test, added matching/different query-param coverage
- `packages/keryx/__tests__/util/oauthHandlers.test.ts` — regression test asserting an appended `?evil=1` is rejected at the authorize endpoint
- `docs/guide/security.md` — corrected description to "exact string comparison (per RFC 6749 §3.1.2.3)"
- `packages/keryx/package.json` — bumped to `0.29.11`

## Test plan

- [x] `bun test __tests__/util/oauth.test.ts` (23/23 pass)
- [x] `bun test __tests__/util/oauthHandlers.test.ts` (32/32 pass)
- [x] Full framework suite: 774 pass, 0 fail
- [x] `bun lint` clean across all workspaces

Closes https://github.com/actionhero/keryx/issues/455

🤖 Generated with [Claude Code](https://claude.com/claude-code)