### PR TITLE
Security: warn at startup when stack traces leak on non-localhost bind

### DIFF
--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -160,6 +160,8 @@ By default, error responses include stack traces in development but omit them in
 
 The web server default is based on `NODE_ENV` — when `NODE_ENV=production`, stack traces are automatically hidden from HTTP responses to avoid leaking internal implementation details.
 
+If the server boots with `includeStackInErrors=true` and binds to a non-localhost address, a warning is logged at startup. Stack traces in error responses leak deployment paths, package structure, and file/line numbers. To suppress them on a non-production host that is publicly reachable, set `WEB_SERVER_INCLUDE_STACK_IN_ERRORS=false` (or `NODE_ENV=production`).
+
 ## Reverse Proxy & Forwarded Headers
 
 The server can derive its external-facing origin (used in OAuth metadata, MCP `WWW-Authenticate` URLs, and protected-resource metadata) from `X-Forwarded-Proto` and `X-Forwarded-Host` headers. Because any client can spoof these headers when the server is reachable directly, trusting them unconditionally would let an attacker poison OAuth discovery responses and redirect MCP clients to attacker-controlled hosts.

--- a/packages/keryx/__tests__/servers/web.test.ts
+++ b/packages/keryx/__tests__/servers/web.test.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { Status } from "../../actions/status";
 import { type ActionResponse, api, config } from "../../api";
 import { type Action, HTTP_METHOD } from "../../classes/Action";
+import { shouldWarnStackLeak } from "../../util/webStackLeakWarning";
 import { useTestServer } from "./../setup";
 
 const getUrl = useTestServer();
@@ -66,6 +67,31 @@ describe("actions", () => {
     } finally {
       config.server.web.includeStackInErrors = original;
     }
+  });
+});
+
+describe("stack trace leak warning", () => {
+  test("returns null when stack traces are disabled", () => {
+    expect(shouldWarnStackLeak("0.0.0.0", false)).toBeNull();
+    expect(shouldWarnStackLeak("example.com", false)).toBeNull();
+  });
+
+  test("returns null for localhost variants even with stacks enabled", () => {
+    expect(shouldWarnStackLeak("localhost", true)).toBeNull();
+    expect(shouldWarnStackLeak("127.0.0.1", true)).toBeNull();
+    expect(shouldWarnStackLeak("::1", true)).toBeNull();
+    expect(shouldWarnStackLeak("[::1]", true)).toBeNull();
+  });
+
+  test("returns a warning for non-localhost binds with stacks enabled", () => {
+    const msg = shouldWarnStackLeak("0.0.0.0", true);
+    expect(msg).toContain("Stack traces are enabled");
+    expect(msg).toContain("host=0.0.0.0");
+    expect(msg).toContain("WEB_SERVER_INCLUDE_STACK_IN_ERRORS=false");
+    expect(shouldWarnStackLeak("10.0.0.5", true)).toContain("host=10.0.0.5");
+    expect(shouldWarnStackLeak("example.com", true)).toContain(
+      "host=example.com",
+    );
   });
 });
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.29.10",
+  "version": "0.29.11",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/servers/web.ts
+++ b/packages/keryx/servers/web.ts
@@ -28,6 +28,7 @@ import {
   handleWebsocketSubscribe,
   handleWebsocketUnsubscribe,
 } from "../util/webSocket";
+import { shouldWarnStackLeak } from "../util/webStackLeakWarning";
 import { handleStaticFile } from "../util/webStaticFiles";
 
 /**
@@ -151,6 +152,12 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
       this.url = `http://${config.server.web.host}:${this.port}`;
       const startMessage = `started server @ ${this.url}`;
       logger.info(logger.colorize ? ansi.bgBlue(startMessage) : startMessage);
+
+      const stackLeakWarning = shouldWarnStackLeak(
+        config.server.web.host,
+        config.server.web.includeStackInErrors,
+      );
+      if (stackLeakWarning) logger.warn(stackLeakWarning);
     } catch (e) {
       await Bun.sleep(1000);
       startupAttempts++;

--- a/packages/keryx/util/webStackLeakWarning.ts
+++ b/packages/keryx/util/webStackLeakWarning.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns a warning message when the web server is configured to leak stack
+ * traces to remote callers, otherwise `null`. Stack traces in error responses
+ * leak deployment paths and code structure, which is fine on a developer's
+ * laptop but a footgun on a publicly reachable host.
+ */
+export function shouldWarnStackLeak(
+  host: string,
+  includeStackInErrors: boolean,
+): string | null {
+  if (!includeStackInErrors) return null;
+  const isLocalBind =
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "[::1]";
+  if (isLocalBind) return null;
+  return (
+    `⚠️  Stack traces are enabled in error responses (host=${host}). ` +
+    `This leaks internal paths and code structure. ` +
+    `Set NODE_ENV=production or WEB_SERVER_INCLUDE_STACK_IN_ERRORS=false before exposing this server publicly.`
+  );
+}


### PR DESCRIPTION
## Summary

Closes https://github.com/actionhero/keryx/issues/448.

When `includeStackInErrors=true` and the web server binds to anything other than `localhost` / `127.0.0.1` / `::1` / `[::1]`, log a warning at startup pointing operators to `NODE_ENV=production` or `WEB_SERVER_INCLUDE_STACK_IN_ERRORS=false`.

The default behavior (stack traces in dev) is preserved per the issue's recommendation — the warning is the only behavioral change.

## Changes

- New helper `shouldWarnStackLeak(host, includeStackInErrors)` in `packages/keryx/util/webStackLeakWarning.ts`. Lives under `util/` rather than `servers/` because the framework's `globLoader` `new`'s every exported function from `servers/*.ts` and would have instantiated the helper as a fake "server."
- `WebServer.start()` calls the helper after `Bun.serve` succeeds and emits via `logger.warn` when it returns a string.
- Unit tests cover localhost variants (no warning), stacks-disabled (no warning), and public/DNS binds with stacks on (warning includes the host and the override env var).
- Doc paragraph appended to the "Error Stack Traces" section in `docs/guide/security.md`.
- Patch bump `0.29.10` → `0.29.11`.

## Test plan

- [x] `bun test` in `packages/keryx` — 775 pass / 0 fail (was 772 before)
- [x] `bun lint` at the workspace root — clean across all workspaces
- [ ] Manual: `WEB_SERVER_HOST=0.0.0.0 bun run dev` in `example/backend` → warning appears at startup
- [ ] Manual: `WEB_SERVER_HOST=0.0.0.0 WEB_SERVER_INCLUDE_STACK_IN_ERRORS=false bun run dev` → no warning
- [ ] Manual: `bun run dev` (default `localhost`) → no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)