### PR TITLE
ci: wire @keryxjs/csrf into publish and test workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,7 @@ on:
       - packages/keryx/package.json
       - packages/plugins/tracing/package.json
       - packages/plugins/resque-admin/package.json
+      - packages/plugins/csrf/package.json
 
 jobs:
   publish:
@@ -26,6 +27,9 @@ jobs:
           - package: resque-admin
             dir: packages/plugins/resque-admin
             npm_name: "@keryxjs/resque-admin"
+          - package: csrf
+            dir: packages/plugins/csrf
+            npm_name: "@keryxjs/csrf"
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -176,6 +176,38 @@ jobs:
         env:
           DATABASE_URL_TEST: postgres://postgres:postgres@localhost:5432/keryx-test
 
+  test-plugin-csrf:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: keryx-test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: cp packages/keryx/.env.example packages/keryx/.env
+      - run: cp packages/plugins/csrf/.env.example packages/plugins/csrf/.env
+      - name: Run csrf tests
+        run: cd packages/plugins/csrf && bun test
+        env:
+          DATABASE_URL_TEST: postgres://postgres:postgres@localhost:5432/keryx-test
+
   test-example-frontend:
     runs-on: ubuntu-latest
     steps:
@@ -241,7 +273,7 @@ jobs:
   complete:
     runs-on: ubuntu-latest
     if: always()
-    needs: [compile, lint, test-package, test-plugin-tracing, test-plugin-resque-admin, test-example-backend, test-example-frontend, test-docs, benchmark, docker-build-backend, docker-build-frontend]
+    needs: [compile, lint, test-package, test-plugin-tracing, test-plugin-resque-admin, test-plugin-csrf, test-example-backend, test-example-frontend, test-docs, benchmark, docker-build-backend, docker-build-frontend]
     steps:
       - run: |
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then

--- a/packages/plugins/csrf/package.json
+++ b/packages/plugins/csrf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keryxjs/csrf",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- The CSRF plugin from #481 was never added to `.github/workflows/publish.yaml`'s `paths` filter or matrix, so `@keryxjs/csrf@0.1.1` never published. Same gap in `test.yaml`, so csrf tests weren't running in CI.
- Adds csrf to both workflows (matrix entry + new `test-plugin-csrf` job mirroring `test-plugin-tracing`) and bumps csrf to `0.1.2` so the next push to main actually triggers a publish.

## Test plan

- [ ] CI on this PR shows a new `test-plugin-csrf` job and it passes.
- [ ] After merge, Publish workflow lists 4 matrix jobs and `npm view @keryxjs/csrf version` returns `0.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)