### PR TITLE
test: stress benchmarks for concurrent rate limit and fanout (closes #388)

### DIFF
--- a/example/backend/__tests__/benchmark/fanout.bench.test.ts
+++ b/example/backend/__tests__/benchmark/fanout.bench.test.ts
@@ -1,0 +1,287 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { Action } from "keryx";
+import { api, config } from "keryx";
+import { z } from "zod";
+import { HOOK_TIMEOUT, waitFor } from "../setup";
+
+// ---------------------------------------------------------------------------
+// Stress thresholds
+// ---------------------------------------------------------------------------
+const STRESS = {
+  workers: 8,
+  // Single fan-out
+  childCount: 500,
+  drainTimeoutMs: 60_000,
+  // Mixed batches
+  mixedSuccessCount: 250,
+  mixedFailureCount: 250,
+  // Many concurrent fan-outs
+  concurrentFanOuts: 50,
+  childrenPerFanOut: 10,
+};
+
+// ---------------------------------------------------------------------------
+// Stats helpers (kept in sync with transports.bench.test.ts)
+// ---------------------------------------------------------------------------
+interface Stats {
+  min: number;
+  avg: number;
+  p50: number;
+  p95: number;
+  p99: number;
+  max: number;
+  rps: number;
+  count: number;
+}
+
+function computeStats(durations: number[]): Stats {
+  const sorted = [...durations].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const count = sorted.length;
+  const percentile = (p: number) => sorted[Math.ceil((p / 100) * count) - 1];
+  return {
+    min: sorted[0],
+    avg: Math.round((sum / count) * 100) / 100,
+    p50: percentile(50),
+    p95: percentile(95),
+    p99: percentile(99),
+    max: sorted[count - 1],
+    rps: Math.round((count / (sum / 1000)) * 100) / 100,
+    count,
+  };
+}
+
+function printStats(name: string, stats: Stats) {
+  const fmt = (ms: number) => `${ms.toFixed(2)}ms`;
+  console.log(`\n  Benchmark: ${name}`);
+  console.log(`  Iterations: ${stats.count}`);
+  console.log(
+    `  Latency:  min=${fmt(stats.min)}  avg=${fmt(stats.avg)}  p50=${fmt(stats.p50)}  p95=${fmt(stats.p95)}  p99=${fmt(stats.p99)}  max=${fmt(stats.max)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stress actions
+// ---------------------------------------------------------------------------
+const STRESS_QUEUE = "bench-stress";
+const STRESS_CHILD = "bench-stress:child";
+const STRESS_FAILING = "bench-stress:failing";
+
+const processedIds: string[] = [];
+
+const childInputs = z.object({
+  itemId: z.string(),
+  _fanOutId: z.string().optional(),
+});
+
+class StressChildAction implements Action {
+  name = STRESS_CHILD;
+  inputs = childInputs;
+  task = { queue: STRESS_QUEUE };
+  run = async (params: z.infer<typeof childInputs>) => {
+    processedIds.push(params.itemId);
+    return { processed: params.itemId };
+  };
+}
+
+class FailingStressChildAction implements Action {
+  name = STRESS_FAILING;
+  inputs = childInputs;
+  task = { queue: STRESS_QUEUE };
+  run = async (params: z.infer<typeof childInputs>) => {
+    throw new Error(`stress-fail ${params.itemId}`);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+describe("fanOut stress benchmarks", () => {
+  let originalProcessors: number;
+
+  beforeAll(async () => {
+    originalProcessors = config.tasks.taskProcessors;
+    config.tasks.taskProcessors = STRESS.workers;
+    await api.start();
+
+    // Register stress actions and wrap them as resque jobs so the
+    // already-running workers can dispatch them.
+    const child = new StressChildAction();
+    api.actions.actions.push(child);
+    api.resque.jobs[child.name] = api.resque.wrapActionAsJob(child);
+
+    const failing = new FailingStressChildAction();
+    api.actions.actions.push(failing);
+    api.resque.jobs[failing.name] = api.resque.wrapActionAsJob(failing);
+
+    // Workers were constructed during api.start() before the stress jobs
+    // were registered. Cycle them so they pick up the new jobs map.
+    await api.resque.stopWorkers();
+    await api.resque.startWorkers();
+  }, HOOK_TIMEOUT);
+
+  afterAll(async () => {
+    api.actions.actions = api.actions.actions.filter(
+      (a) => a.name !== STRESS_CHILD && a.name !== STRESS_FAILING,
+    );
+    delete api.resque.jobs[STRESS_CHILD];
+    delete api.resque.jobs[STRESS_FAILING];
+
+    await api.stop();
+    config.tasks.taskProcessors = originalProcessors;
+  }, HOOK_TIMEOUT);
+
+  test(
+    `benchmark: ${STRESS.childCount} children dispatched and collected with no drops`,
+    async () => {
+      processedIds.length = 0;
+
+      const inputs = Array.from({ length: STRESS.childCount }, (_, i) => ({
+        itemId: `item-${i}`,
+      }));
+      const expectedIds = new Set(inputs.map((i) => i.itemId));
+
+      const start = performance.now();
+      const result = await api.actions.fanOut(STRESS_CHILD, inputs);
+
+      await waitFor(
+        async () => {
+          const s = await api.actions.fanOutStatus(result.fanOutId);
+          return s.completed + s.failed >= STRESS.childCount;
+        },
+        { interval: 25, timeout: STRESS.drainTimeoutMs },
+      );
+      const elapsed = performance.now() - start;
+
+      const status = await api.actions.fanOutStatus(result.fanOutId);
+
+      printStats(
+        `fanOut (${STRESS.childCount} children, ${STRESS.workers} workers)`,
+        computeStats([elapsed]),
+      );
+
+      expect(result.enqueued).toBe(STRESS.childCount);
+      expect(result.errors).toHaveLength(0);
+      expect(status.total).toBe(STRESS.childCount);
+      expect(status.completed).toBe(STRESS.childCount);
+      expect(status.failed).toBe(0);
+      expect(status.results).toHaveLength(STRESS.childCount);
+
+      // No drops, no dupes: every input id appears exactly once in results.
+      const collectedIds = new Set(
+        status.results.map((r) => r.params.itemId as string),
+      );
+      expect(collectedIds.size).toBe(STRESS.childCount);
+      for (const id of expectedIds) expect(collectedIds.has(id)).toBe(true);
+
+      // Worker-side bookkeeping matches.
+      expect(processedIds).toHaveLength(STRESS.childCount);
+      expect(new Set(processedIds).size).toBe(STRESS.childCount);
+    },
+    { timeout: 120_000 },
+  );
+
+  test(
+    "benchmark: mixed success/failure batches accounted with no cross-batch leakage",
+    async () => {
+      const successInputs = Array.from(
+        { length: STRESS.mixedSuccessCount },
+        (_, i) => ({ itemId: `ok-${i}` }),
+      );
+      const failureInputs = Array.from(
+        { length: STRESS.mixedFailureCount },
+        (_, i) => ({ itemId: `bad-${i}` }),
+      );
+
+      const [okResult, failResult] = await Promise.all([
+        api.actions.fanOut(STRESS_CHILD, successInputs),
+        api.actions.fanOut(STRESS_FAILING, failureInputs),
+      ]);
+
+      await Promise.all([
+        waitFor(
+          async () => {
+            const s = await api.actions.fanOutStatus(okResult.fanOutId);
+            return s.completed + s.failed >= STRESS.mixedSuccessCount;
+          },
+          { interval: 25, timeout: STRESS.drainTimeoutMs },
+        ),
+        waitFor(
+          async () => {
+            const s = await api.actions.fanOutStatus(failResult.fanOutId);
+            return s.completed + s.failed >= STRESS.mixedFailureCount;
+          },
+          { interval: 25, timeout: STRESS.drainTimeoutMs },
+        ),
+      ]);
+
+      const okStatus = await api.actions.fanOutStatus(okResult.fanOutId);
+      const failStatus = await api.actions.fanOutStatus(failResult.fanOutId);
+
+      expect(okStatus.total).toBe(STRESS.mixedSuccessCount);
+      expect(okStatus.completed).toBe(STRESS.mixedSuccessCount);
+      expect(okStatus.failed).toBe(0);
+      expect(okStatus.results).toHaveLength(STRESS.mixedSuccessCount);
+
+      expect(failStatus.total).toBe(STRESS.mixedFailureCount);
+      expect(failStatus.completed).toBe(0);
+      expect(failStatus.failed).toBe(STRESS.mixedFailureCount);
+      expect(failStatus.errors).toHaveLength(STRESS.mixedFailureCount);
+
+      // No cross-batch leakage: each fan-out's collected entries match its total.
+      expect(okStatus.results.length + okStatus.errors.length).toBe(
+        okStatus.total,
+      );
+      expect(failStatus.results.length + failStatus.errors.length).toBe(
+        failStatus.total,
+      );
+
+      // Inputs in each batch are distinct from the other batch.
+      const okIds = new Set(
+        okStatus.results.map((r) => r.params.itemId as string),
+      );
+      const failIds = new Set(
+        failStatus.errors.map((e) => e.params.itemId as string),
+      );
+      for (const id of okIds) expect(id.startsWith("ok-")).toBe(true);
+      for (const id of failIds) expect(id.startsWith("bad-")).toBe(true);
+    },
+    { timeout: 120_000 },
+  );
+
+  test(
+    `benchmark: ${STRESS.concurrentFanOuts} concurrent fanOut calls don't lose dispatches`,
+    async () => {
+      const batches = Array.from({ length: STRESS.concurrentFanOuts }, (_, b) =>
+        Array.from({ length: STRESS.childrenPerFanOut }, (_, i) => ({
+          itemId: `b${b}-i${i}`,
+        })),
+      );
+
+      const results = await Promise.all(
+        batches.map((inputs) => api.actions.fanOut(STRESS_CHILD, inputs)),
+      );
+
+      await Promise.all(
+        results.map((r) =>
+          waitFor(
+            async () => {
+              const s = await api.actions.fanOutStatus(r.fanOutId);
+              return s.completed + s.failed >= STRESS.childrenPerFanOut;
+            },
+            { interval: 25, timeout: STRESS.drainTimeoutMs },
+          ),
+        ),
+      );
+
+      for (const r of results) {
+        const s = await api.actions.fanOutStatus(r.fanOutId);
+        expect(s.total).toBe(STRESS.childrenPerFanOut);
+        expect(s.completed).toBe(STRESS.childrenPerFanOut);
+        expect(s.failed).toBe(0);
+        expect(s.results).toHaveLength(STRESS.childrenPerFanOut);
+      }
+    },
+    { timeout: 120_000 },
+  );
+});

--- a/example/backend/__tests__/benchmark/fanout.bench.test.ts
+++ b/example/backend/__tests__/benchmark/fanout.bench.test.ts
@@ -3,6 +3,7 @@ import type { Action } from "keryx";
 import { api, config } from "keryx";
 import { z } from "zod";
 import { HOOK_TIMEOUT, waitFor } from "../setup";
+import { computeStats, printStats } from "./stats";
 
 // ---------------------------------------------------------------------------
 // Stress thresholds
@@ -19,46 +20,6 @@ const STRESS = {
   concurrentFanOuts: 50,
   childrenPerFanOut: 10,
 };
-
-// ---------------------------------------------------------------------------
-// Stats helpers (kept in sync with transports.bench.test.ts)
-// ---------------------------------------------------------------------------
-interface Stats {
-  min: number;
-  avg: number;
-  p50: number;
-  p95: number;
-  p99: number;
-  max: number;
-  rps: number;
-  count: number;
-}
-
-function computeStats(durations: number[]): Stats {
-  const sorted = [...durations].sort((a, b) => a - b);
-  const sum = sorted.reduce((a, b) => a + b, 0);
-  const count = sorted.length;
-  const percentile = (p: number) => sorted[Math.ceil((p / 100) * count) - 1];
-  return {
-    min: sorted[0],
-    avg: Math.round((sum / count) * 100) / 100,
-    p50: percentile(50),
-    p95: percentile(95),
-    p99: percentile(99),
-    max: sorted[count - 1],
-    rps: Math.round((count / (sum / 1000)) * 100) / 100,
-    count,
-  };
-}
-
-function printStats(name: string, stats: Stats) {
-  const fmt = (ms: number) => `${ms.toFixed(2)}ms`;
-  console.log(`\n  Benchmark: ${name}`);
-  console.log(`  Iterations: ${stats.count}`);
-  console.log(
-    `  Latency:  min=${fmt(stats.min)}  avg=${fmt(stats.avg)}  p50=${fmt(stats.p50)}  p95=${fmt(stats.p95)}  p99=${fmt(stats.p99)}  max=${fmt(stats.max)}`,
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Stress actions

--- a/example/backend/__tests__/benchmark/rateLimit.bench.test.ts
+++ b/example/backend/__tests__/benchmark/rateLimit.bench.test.ts
@@ -1,0 +1,237 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import {
+  api,
+  CONNECTION_TYPE,
+  Connection,
+  checkRateLimit,
+  config,
+  ErrorType,
+  RateLimitMiddleware,
+  TypedError,
+} from "keryx";
+import { HOOK_TIMEOUT } from "../setup";
+
+// ---------------------------------------------------------------------------
+// Stress thresholds — generous for CI variance.
+// ---------------------------------------------------------------------------
+const STRESS = {
+  concurrentHits: 1_000,
+  isolationIdentifiers: 10,
+  isolationHitsPerIdentifier: 20,
+  // Wall-clock cap on the concurrent-call burst. Tuned generously for
+  // GitHub Actions runners; tighten if local p95 stays well under.
+  burstP95Ms: 5_000,
+  // Per-call latency (no contention, fresh window, high limit so the throw
+  // path is never taken).
+  perCallIterations: 1_000,
+  perCallWarmup: 10,
+  perCallP95Ms: 25,
+};
+
+// ---------------------------------------------------------------------------
+// Stats helpers (kept in sync with transports.bench.test.ts)
+// ---------------------------------------------------------------------------
+interface Stats {
+  min: number;
+  avg: number;
+  p50: number;
+  p95: number;
+  p99: number;
+  max: number;
+  rps: number;
+  count: number;
+}
+
+function computeStats(durations: number[]): Stats {
+  const sorted = [...durations].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const count = sorted.length;
+  const percentile = (p: number) => sorted[Math.ceil((p / 100) * count) - 1];
+  return {
+    min: sorted[0],
+    avg: Math.round((sum / count) * 100) / 100,
+    p50: percentile(50),
+    p95: percentile(95),
+    p99: percentile(99),
+    max: sorted[count - 1],
+    rps: Math.round((count / (sum / 1000)) * 100) / 100,
+    count,
+  };
+}
+
+function printStats(name: string, stats: Stats, thresholdMs: number) {
+  const fmt = (ms: number) => `${ms.toFixed(2)}ms`;
+  console.log(`\n  Benchmark: ${name}`);
+  console.log(`  Iterations: ${stats.count}`);
+  console.log(
+    `  Latency:  min=${fmt(stats.min)}  avg=${fmt(stats.avg)}  p50=${fmt(stats.p50)}  p95=${fmt(stats.p95)}  p99=${fmt(stats.p99)}  max=${fmt(stats.max)}`,
+  );
+  console.log(`  Throughput: ${stats.rps} req/s`);
+  console.log(
+    `  Threshold: p95 < ${thresholdMs}ms — ${stats.p95 <= thresholdMs ? "PASS" : "FAIL"}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bucket helper
+// ---------------------------------------------------------------------------
+type Outcome = "allowed" | "denied" | "unexpected";
+
+function bucket(
+  results: PromiseSettledResult<unknown>[],
+): Record<Outcome, number> {
+  const counts: Record<Outcome, number> = {
+    allowed: 0,
+    denied: 0,
+    unexpected: 0,
+  };
+  for (const r of results) {
+    if (r.status === "fulfilled") {
+      counts.allowed++;
+      continue;
+    }
+    if (
+      r.reason instanceof TypedError &&
+      r.reason.type === ErrorType.CONNECTION_RATE_LIMITED
+    ) {
+      counts.denied++;
+      continue;
+    }
+    counts.unexpected++;
+  }
+  return counts;
+}
+
+async function flushRateLimitKeys() {
+  const keys = await api.redis.redis.keys(`${config.rateLimit.keyPrefix}:*`);
+  if (keys.length > 0) await api.redis.redis.del(...keys);
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+describe("rateLimit stress benchmarks", () => {
+  let originalEnabled: boolean;
+
+  beforeAll(async () => {
+    originalEnabled = config.rateLimit.enabled;
+    config.rateLimit.enabled = true;
+    await api.start();
+  }, HOOK_TIMEOUT);
+
+  afterAll(async () => {
+    await flushRateLimitKeys();
+    config.rateLimit.enabled = originalEnabled;
+    await api.stop();
+  }, HOOK_TIMEOUT);
+
+  beforeEach(async () => {
+    await flushRateLimitKeys();
+  });
+
+  test(
+    "benchmark: concurrent hits partition allowed/denied deterministically",
+    async () => {
+      const limit = config.rateLimit.unauthenticatedLimit;
+      const total = STRESS.concurrentHits;
+
+      const calls = Array.from({ length: total }, () => {
+        const conn = new Connection(CONNECTION_TYPE.WEB, "10.0.0.99");
+        conn.session = undefined;
+        return RateLimitMiddleware.runBefore!({}, conn).finally(() => {
+          conn.destroy();
+        });
+      });
+
+      const start = performance.now();
+      const settled = await Promise.allSettled(calls);
+      const elapsed = performance.now() - start;
+
+      const counts = bucket(settled);
+
+      printStats(
+        `rateLimit (${total} concurrent, single identifier)`,
+        computeStats([elapsed]),
+        STRESS.burstP95Ms,
+      );
+
+      expect(counts.unexpected).toBe(0);
+      expect(counts.allowed).toBe(limit);
+      expect(counts.denied).toBe(total - limit);
+      expect(counts.allowed + counts.denied).toBe(total);
+      expect(elapsed).toBeLessThanOrEqual(STRESS.burstP95Ms);
+    },
+    { timeout: 60_000 },
+  );
+
+  test(
+    "benchmark: distinct identifiers stay isolated under concurrent load",
+    async () => {
+      const ids = Array.from(
+        { length: STRESS.isolationIdentifiers },
+        (_, i) => `10.0.1.${i + 1}`,
+      );
+      const perId = STRESS.isolationHitsPerIdentifier;
+
+      const calls = ids.flatMap((ip) =>
+        Array.from({ length: perId }, () => {
+          const conn = new Connection(CONNECTION_TYPE.WEB, ip);
+          conn.session = undefined;
+          return RateLimitMiddleware.runBefore!({}, conn).finally(() => {
+            conn.destroy();
+          });
+        }),
+      );
+
+      const settled = await Promise.allSettled(calls);
+      const counts = bucket(settled);
+
+      expect(counts.unexpected).toBe(0);
+      expect(counts.denied).toBe(0);
+      expect(counts.allowed).toBe(ids.length * perId);
+    },
+    { timeout: 60_000 },
+  );
+
+  test(
+    "benchmark: checkRateLimit per-call latency",
+    async () => {
+      const overrides = {
+        limit: 1_000_000,
+        windowMs: 60_000,
+        keyPrefix: "bench-rl",
+      };
+      const identifier = "ip:bench-latency";
+
+      // Warmup
+      for (let i = 0; i < STRESS.perCallWarmup; i++) {
+        await checkRateLimit(identifier, false, overrides);
+      }
+
+      const durations: number[] = [];
+      for (let i = 0; i < STRESS.perCallIterations; i++) {
+        const start = performance.now();
+        const info = await checkRateLimit(identifier, false, overrides);
+        const elapsed = performance.now() - start;
+        expect(info.retryAfter).toBeUndefined();
+        durations.push(elapsed);
+      }
+
+      const stats = computeStats(durations);
+      printStats("checkRateLimit() per-call", stats, STRESS.perCallP95Ms);
+      expect(stats.p95).toBeLessThanOrEqual(STRESS.perCallP95Ms);
+
+      // Cleanup the bench-rl prefix
+      const keys = await api.redis.redis.keys(`${overrides.keyPrefix}:*`);
+      if (keys.length > 0) await api.redis.redis.del(...keys);
+    },
+    { timeout: 60_000 },
+  );
+});

--- a/example/backend/__tests__/benchmark/rateLimit.bench.test.ts
+++ b/example/backend/__tests__/benchmark/rateLimit.bench.test.ts
@@ -17,6 +17,7 @@ import {
   TypedError,
 } from "keryx";
 import { HOOK_TIMEOUT } from "../setup";
+import { computeStats, printStats } from "./stats";
 
 // ---------------------------------------------------------------------------
 // Stress thresholds — generous for CI variance.
@@ -34,50 +35,6 @@ const STRESS = {
   perCallWarmup: 10,
   perCallP95Ms: 25,
 };
-
-// ---------------------------------------------------------------------------
-// Stats helpers (kept in sync with transports.bench.test.ts)
-// ---------------------------------------------------------------------------
-interface Stats {
-  min: number;
-  avg: number;
-  p50: number;
-  p95: number;
-  p99: number;
-  max: number;
-  rps: number;
-  count: number;
-}
-
-function computeStats(durations: number[]): Stats {
-  const sorted = [...durations].sort((a, b) => a - b);
-  const sum = sorted.reduce((a, b) => a + b, 0);
-  const count = sorted.length;
-  const percentile = (p: number) => sorted[Math.ceil((p / 100) * count) - 1];
-  return {
-    min: sorted[0],
-    avg: Math.round((sum / count) * 100) / 100,
-    p50: percentile(50),
-    p95: percentile(95),
-    p99: percentile(99),
-    max: sorted[count - 1],
-    rps: Math.round((count / (sum / 1000)) * 100) / 100,
-    count,
-  };
-}
-
-function printStats(name: string, stats: Stats, thresholdMs: number) {
-  const fmt = (ms: number) => `${ms.toFixed(2)}ms`;
-  console.log(`\n  Benchmark: ${name}`);
-  console.log(`  Iterations: ${stats.count}`);
-  console.log(
-    `  Latency:  min=${fmt(stats.min)}  avg=${fmt(stats.avg)}  p50=${fmt(stats.p50)}  p95=${fmt(stats.p95)}  p99=${fmt(stats.p99)}  max=${fmt(stats.max)}`,
-  );
-  console.log(`  Throughput: ${stats.rps} req/s`);
-  console.log(
-    `  Threshold: p95 < ${thresholdMs}ms — ${stats.p95 <= thresholdMs ? "PASS" : "FAIL"}`,
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Bucket helper

--- a/example/backend/__tests__/benchmark/stats.ts
+++ b/example/backend/__tests__/benchmark/stats.ts
@@ -1,0 +1,46 @@
+export interface Stats {
+  min: number;
+  avg: number;
+  p50: number;
+  p95: number;
+  p99: number;
+  max: number;
+  rps: number;
+  count: number;
+}
+
+export function computeStats(durations: number[]): Stats {
+  const sorted = [...durations].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const count = sorted.length;
+  const percentile = (p: number) => sorted[Math.ceil((p / 100) * count) - 1];
+  return {
+    min: sorted[0],
+    avg: Math.round((sum / count) * 100) / 100,
+    p50: percentile(50),
+    p95: percentile(95),
+    p99: percentile(99),
+    max: sorted[count - 1],
+    rps: Math.round((count / (sum / 1000)) * 100) / 100,
+    count,
+  };
+}
+
+export function printStats(name: string, stats: Stats, thresholdMs?: number) {
+  const fmt = (ms: number) => `${ms.toFixed(2)}ms`;
+  console.log(`\n  Benchmark: ${name}`);
+  console.log(`  Iterations: ${stats.count}`);
+  console.log(
+    `  Latency:  min=${fmt(stats.min)}  avg=${fmt(stats.avg)}  p50=${fmt(stats.p50)}  p95=${fmt(stats.p95)}  p99=${fmt(stats.p99)}  max=${fmt(stats.max)}`,
+  );
+  // For single-iteration runs (e.g. end-to-end fan-out drains), throughput
+  // is just 1/duration and not meaningful — suppress it.
+  if (stats.count > 1) {
+    console.log(`  Throughput: ${stats.rps} req/s`);
+  }
+  if (thresholdMs !== undefined) {
+    console.log(
+      `  Threshold: p95 < ${thresholdMs}ms — ${stats.p95 <= thresholdMs ? "PASS" : "FAIL"}`,
+    );
+  }
+}

--- a/example/backend/__tests__/benchmark/transports.bench.test.ts
+++ b/example/backend/__tests__/benchmark/transports.bench.test.ts
@@ -4,6 +4,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { $ } from "bun";
 import { api, config } from "keryx";
 import { HOOK_TIMEOUT, serverUrl } from "../setup";
+import { computeStats, printStats } from "./stats";
 
 // ---------------------------------------------------------------------------
 // Thresholds — generous enough for slow GitHub Actions runners.
@@ -17,50 +18,6 @@ const THRESHOLDS = {
   mcp: { iterations: 50, warmup: 2, p95ms: 100 },
   cli: { iterations: 10, warmup: 1, p95ms: 3_000 },
 };
-
-// ---------------------------------------------------------------------------
-// Stats helpers
-// ---------------------------------------------------------------------------
-interface Stats {
-  min: number;
-  avg: number;
-  p50: number;
-  p95: number;
-  p99: number;
-  max: number;
-  rps: number;
-  count: number;
-}
-
-function computeStats(durations: number[]): Stats {
-  const sorted = [...durations].sort((a, b) => a - b);
-  const sum = sorted.reduce((a, b) => a + b, 0);
-  const count = sorted.length;
-  const percentile = (p: number) => sorted[Math.ceil((p / 100) * count) - 1];
-  return {
-    min: sorted[0],
-    avg: Math.round((sum / count) * 100) / 100,
-    p50: percentile(50),
-    p95: percentile(95),
-    p99: percentile(99),
-    max: sorted[count - 1],
-    rps: Math.round((count / (sum / 1000)) * 100) / 100,
-    count,
-  };
-}
-
-function printStats(name: string, stats: Stats, thresholdMs: number) {
-  const fmt = (ms: number) => `${ms.toFixed(2)}ms`;
-  console.log(`\n  Benchmark: ${name}`);
-  console.log(`  Iterations: ${stats.count}`);
-  console.log(
-    `  Latency:  min=${fmt(stats.min)}  avg=${fmt(stats.avg)}  p50=${fmt(stats.p50)}  p95=${fmt(stats.p95)}  p99=${fmt(stats.p99)}  max=${fmt(stats.max)}`,
-  );
-  console.log(`  Throughput: ${stats.rps} req/s`);
-  console.log(
-    `  Threshold: p95 < ${thresholdMs}ms — ${stats.p95 <= thresholdMs ? "PASS" : "FAIL"}`,
-  );
-}
 
 // ---------------------------------------------------------------------------
 // OAuth helpers (for MCP transport)


### PR DESCRIPTION
## Summary

- Adds `rateLimit.bench.test.ts`: 1000 concurrent hits on one identifier asserting an exact 20/980 allowed/denied split, 10-identifier isolation, and a `checkRateLimit()` per-call latency bench (~25k req/s on the dev box).
- Adds `fanout.bench.test.ts`: 500 children dispatched across 8 workers asserting no drops or dupes, mixed success/failure batches with no cross-batch leakage, and 50 concurrent `fanOut` calls of 10 children each.
- Closes #388. Both files live under `example/backend/__tests__/benchmark/` so they run in the existing dedicated `benchmark` CI job.

## Test plan

- [x] \`bun benchmark\` — all 10 benches pass (4 transports + 3 fanout + 3 rate limit), ~4.2s wall-clock
- [x] 3× back-to-back stability runs — deterministic, no flakes
- [x] \`bun lint\` clean across all workspaces
- [ ] CI \`benchmark\` job green
- [ ] CI \`test-example-backend\` shards green (the existing \`find\` glob picks up \`*.bench.test.ts\` too, mirroring the existing transports bench)