### PR TITLE
Migrate conductor.json to .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,7 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+archive = "bun .conductor/teardown.ts"
+run = "bun dev"
+run_mode = "nonconcurrent"
+setup = "bun install && bun .conductor/setup.ts"

--- a/conductor.json
+++ b/conductor.json
@@ -1,8 +1,0 @@
-{
-  "scripts": {
-    "setup": "bun install && bun .conductor/setup.ts",
-    "run": "bun dev",
-    "archive": "bun .conductor/teardown.ts"
-  },
-  "runScriptMode": "nonconcurrent"
-}


### PR DESCRIPTION
This PR migrates the legacy `conductor.json` configuration to the new `.conductor/settings.toml` format.

Generated by Conductor.