### PR TITLE
feat(mcp): adopt 2026-07-28 OAuth hardening (iss param, application_type)

### DIFF
--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -232,6 +232,8 @@ MCP clients authenticate using OAuth 2.1 with PKCE (Proof Key for Code Exchange)
 The OAuth implementation includes several hardening measures:
 
 - **Redirect URI validation** — URIs registered via `/oauth/register` must not contain fragments or userinfo, and must use HTTPS for non-localhost addresses. When exchanging authorization codes, the redirect URI must match the registered URI exactly (origin + pathname).
+- **Issuer identification (`iss`)** — the authorization response redirect includes an `iss` parameter identifying this authorization server, and `/.well-known/oauth-authorization-server` advertises `authorization_response_iss_parameter_supported: true`. Clients validate `iss` to defend against mix-up attacks ([RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207), MCP 2026-07-28 / SEP-2468).
+- **Client `application_type`** — `POST /oauth/register` accepts an `application_type` of `"web"` (the default) or `"native"`, stored on the client record so native/CLI clients are not misclassified as web clients (MCP 2026-07-28 / SEP-837). Any other value is rejected with `invalid_client_metadata`.
 - **Registration rate limiting** — `POST /oauth/register` has a separate, stricter rate limit (default: 5 requests per hour per IP) to prevent abuse. See `RATE_LIMIT_OAUTH_REGISTER_LIMIT` and `RATE_LIMIT_OAUTH_REGISTER_WINDOW_MS` in [Configuration](/guide/config).
 - **CORS** — OAuth and MCP endpoints respect the `allowedOrigins` configuration. When `allowedOrigins` is `"*"`, credentials headers are not sent, per the browser spec. Set a specific origin in production for credentialed requests to work.
 

--- a/example/backend/__tests__/initializers/mcp.test.ts
+++ b/example/backend/__tests__/initializers/mcp.test.ts
@@ -59,7 +59,10 @@ async function getAccessToken(): Promise<string> {
   const metaMatch = authHtml.match(
     /<meta name="redirect-url" content="([^"]+)"\s*\/?>/,
   );
-  const code = new URL(metaMatch![1]).searchParams.get("code")!;
+  const redirectUrl = new URL(metaMatch![1]);
+  // RFC 9207 (MCP 2026-07-28 / SEP-2468): the success redirect must carry `iss`.
+  expect(redirectUrl.searchParams.get("iss")).toBe(baseUrl());
+  const code = redirectUrl.searchParams.get("code")!;
 
   // Exchange code for token
   const tokenRes = await fetch(`${baseUrl()}/oauth/token`, {
@@ -524,6 +527,7 @@ describe("mcp initializer (enabled)", () => {
       expect(body.registration_endpoint).toContain("/oauth/register");
       expect(body.response_types_supported).toContain("code");
       expect(body.code_challenge_methods_supported).toContain("S256");
+      expect(body.authorization_response_iss_parameter_supported).toBe(true);
     });
 
     test("OAuth client registration works", async () => {
@@ -540,6 +544,35 @@ describe("mcp initializer (enabled)", () => {
       expect(body.client_id).toBeTruthy();
       expect(body.redirect_uris).toEqual(["http://localhost:3000/callback"]);
       expect(body.client_name).toBe("Test Client");
+    });
+
+    test("OAuth registration honors application_type (SEP-837)", async () => {
+      const res = await fetch(`${baseUrl()}/oauth/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          redirect_uris: ["http://localhost:3000/callback"],
+          client_name: "Native Client",
+          application_type: "native",
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.application_type).toBe("native");
+    });
+
+    test("OAuth registration rejects an unknown application_type", async () => {
+      const res = await fetch(`${baseUrl()}/oauth/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          redirect_uris: ["http://localhost:3000/callback"],
+          application_type: "bogus",
+        }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("invalid_client_metadata");
     });
 
     test("OAuth registration rejects malformed redirect_uris", async () => {

--- a/packages/keryx/__tests__/util/oauthHandlers.test.ts
+++ b/packages/keryx/__tests__/util/oauthHandlers.test.ts
@@ -107,6 +107,12 @@ describe("handleMetadata", () => {
     expect(body.revocation_endpoint_auth_methods_supported).toEqual(["none"]);
     expect(body.client_id_metadata_document_supported).toBe(false);
   });
+
+  test("advertises RFC 9207 iss parameter support (MCP 2026-07-28)", async () => {
+    const res = handleMetadata("https://example.com");
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.authorization_response_iss_parameter_supported).toBe(true);
+  });
 });
 
 describe("handleRegister", () => {
@@ -153,6 +159,54 @@ describe("handleRegister", () => {
     expect(body.grant_types).toEqual(["authorization_code"]);
     expect(body.response_types).toEqual(["code"]);
     expect(body.token_endpoint_auth_method).toBe("none");
+  });
+
+  test("defaults application_type to web when omitted (SEP-837)", async () => {
+    const req = new Request("http://localhost/oauth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: ["http://localhost:9999/cb"],
+      }),
+    });
+    const res = await handleRegister(req);
+    const body = (await res.json()) as OAuthClient;
+    expect(body.application_type).toBe("web");
+  });
+
+  test("stores and echoes a declared application_type (SEP-837)", async () => {
+    const req = new Request("http://localhost/oauth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: ["http://localhost:9999/cb"],
+        application_type: "native",
+      }),
+    });
+    const res = await handleRegister(req);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as OAuthClient;
+    expect(body.application_type).toBe("native");
+
+    const stored = await api.redis.redis.get(`oauth:client:${body.client_id}`);
+    expect((JSON.parse(stored!) as OAuthClient).application_type).toBe(
+      "native",
+    );
+  });
+
+  test("rejects an unknown application_type with invalid_client_metadata", async () => {
+    const req = new Request("http://localhost/oauth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: ["http://localhost:9999/cb"],
+        application_type: "bogus",
+      }),
+    });
+    const res = await handleRegister(req);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_client_metadata");
   });
 });
 
@@ -666,6 +720,7 @@ describe("handleAuthorizePost", () => {
         response_type: "code",
       }),
       templates,
+      "https://example.com",
     );
     expect(res.status).toBe(200);
     const html = await res.text();
@@ -683,6 +738,7 @@ describe("handleAuthorizePost", () => {
         response_type: "code",
       }),
       templates,
+      "https://example.com",
     );
     const html = await res.text();
     expect(html).toContain("Invalid redirect URI");
@@ -699,6 +755,7 @@ describe("handleAuthorizePost", () => {
         response_type: "code",
       }),
       templates,
+      "https://example.com",
     );
     const html = await res.text();
     expect(html).toContain("Invalid redirect URI");
@@ -715,6 +772,7 @@ describe("handleAuthorizePost", () => {
         response_type: "code",
       }),
       templates,
+      "https://example.com",
     );
     const html = await res.text();
     expect(html).toContain("S256");
@@ -734,6 +792,7 @@ describe("handleAuthorizePost", () => {
         // No mode => login path
       }),
       templates,
+      "https://example.com",
     );
     const html = await res.text();
     expect(html.toLowerCase()).toContain("no login action");
@@ -751,6 +810,7 @@ describe("handleAuthorizePost", () => {
         mode: "signup",
       }),
       templates,
+      "https://example.com",
     );
     const html = await res.text();
     expect(html.toLowerCase()).toContain("no signup action");
@@ -764,7 +824,11 @@ describe("handleAuthorizePost", () => {
       headers: { "Content-Type": "multipart/form-data" },
       body: "not-actually-multipart",
     });
-    const res = await handleAuthorizePost(req, templates);
+    const res = await handleAuthorizePost(
+      req,
+      templates,
+      "https://example.com",
+    );
     expect(res.status).toBe(400);
   });
 });

--- a/packages/keryx/initializers/oauth.ts
+++ b/packages/keryx/initializers/oauth.ts
@@ -135,7 +135,7 @@ export class OAuthInitializer extends Initializer {
         return handleAuthorizeGet(url, templates);
       }
       if (path === OAUTH_PATHS.authorize && method === "POST") {
-        return handleAuthorizePost(req, templates);
+        return handleAuthorizePost(req, templates, origin);
       }
       if (path === OAUTH_PATHS.token && method === "POST") {
         return appendHeaders(await handleToken(req), corsHeaders);

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/oauthHandlers/authorize.ts
+++ b/packages/keryx/util/oauthHandlers/authorize.ts
@@ -90,10 +90,19 @@ async function runAuthAction(
   }
 }
 
-/** Handle the OAuth authorize form POST (signin/signup). */
+/**
+ * Handle the OAuth authorize form POST (signin/signup).
+ *
+ * @param req - The incoming form POST request.
+ * @param templates - Loaded OAuth HTML templates for rendering the auth/success pages.
+ * @param origin - The externally-visible origin of this authorization server. Used
+ *   as the `iss` (issuer) value on the authorization-code redirect per RFC 9207
+ *   (MCP 2026-07-28 / SEP-2468); matches the `issuer` advertised in AS metadata.
+ */
 export async function handleAuthorizePost(
   req: Request,
   templates: OAuthTemplates,
+  origin: string,
 ): Promise<Response> {
   let fields: Record<string, string>;
   try {
@@ -163,6 +172,8 @@ export async function handleAuthorizePost(
 
   const redirectUrl = new URL(oauthParams.redirectUri);
   redirectUrl.searchParams.set("code", code);
+  // RFC 9207 — advertise the issuer so the client can detect mix-up attacks.
+  redirectUrl.searchParams.set("iss", origin);
   if (oauthParams.state)
     redirectUrl.searchParams.set("state", oauthParams.state);
 

--- a/packages/keryx/util/oauthHandlers/metadata.ts
+++ b/packages/keryx/util/oauthHandlers/metadata.ts
@@ -30,6 +30,9 @@ export function handleMetadata(origin: string): Response {
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
+    // RFC 9207 — return the `iss` parameter on authorization responses so
+    // clients can guard against mix-up attacks (MCP 2026-07-28 / SEP-2468).
+    authorization_response_iss_parameter_supported: true,
     token_endpoint_auth_methods_supported: ["none"],
     introspection_endpoint_auth_methods_supported: ["none"],
     revocation_endpoint_auth_methods_supported: ["none"],

--- a/packages/keryx/util/oauthHandlers/register.ts
+++ b/packages/keryx/util/oauthHandlers/register.ts
@@ -37,6 +37,17 @@ export async function handleRegister(req: Request): Promise<Response> {
     }
   }
 
+  // `application_type` is required of clients per MCP 2026-07-28 / SEP-837, but
+  // remains optional here for backwards compatibility; default to the OIDC
+  // default of "web" when omitted (RFC 7591).
+  const applicationType = body.application_type ?? "web";
+  if (applicationType !== "web" && applicationType !== "native") {
+    return oauthError(
+      "invalid_client_metadata",
+      'application_type must be "web" or "native"',
+    );
+  }
+
   const clientId = randomUUID();
   const client: OAuthClient = {
     client_id: clientId,
@@ -45,6 +56,7 @@ export async function handleRegister(req: Request): Promise<Response> {
     grant_types: body.grant_types ?? ["authorization_code"],
     response_types: body.response_types ?? ["code"],
     token_endpoint_auth_method: body.token_endpoint_auth_method ?? "none",
+    application_type: applicationType,
   };
 
   await api.redis.redis.set(

--- a/packages/keryx/util/oauthHandlers/types.ts
+++ b/packages/keryx/util/oauthHandlers/types.ts
@@ -5,6 +5,12 @@ export type OAuthClient = {
   grant_types?: string[];
   response_types?: string[];
   token_endpoint_auth_method?: string;
+  /**
+   * OpenID Connect `application_type` (`"web"` | `"native"`), declared at
+   * registration per MCP 2026-07-28 / SEP-837 so the authorization server does
+   * not misclassify native/CLI clients as web clients. Defaults to `"web"`.
+   */
+  application_type?: "web" | "native";
 };
 
 export type AuthCode = {


### PR DESCRIPTION
Brings keryx's OAuth 2.1 authorization server in line with the server-side OAuth changes from the upcoming MCP **2026-07-28** spec — specifically the parts that don't depend on a new `@modelcontextprotocol/sdk` release (none is published yet; the stateless-core/session/transport migration remains blocked on that SDK). Authorization-code redirects now include the `iss` parameter and `/.well-known/oauth-authorization-server` advertises `authorization_response_iss_parameter_supported: true`, per RFC 9207 / SEP-2468, so clients can defend against mix-up attacks. Dynamic client registration now accepts, validates, stores, and echoes an `application_type` of `"web"` (default) or `"native"` per SEP-837, rejecting other values with `invalid_client_metadata`. Adds framework and example-backend tests for all of the above and documents the new hardening in `docs/guide/mcp.md`. Bumps `keryx` to `0.33.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)