### PR TITLE
feat(mcp): support MCP Apps (dynamic UIs) via mcp.ui + UIResponse

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -40,6 +40,7 @@ For example: \`/guide/actions.md\`, \`/reference/config.md\`
 - Tasks: /guide/tasks.md
 - Middleware: /guide/middleware.md
 - MCP Server: /guide/mcp.md
+- MCP Apps (Dynamic UIs): /guide/mcp-apps.md
 - Configuration: /guide/config.md
 - Plugins: /guide/plugins.md
 - CLI: /guide/cli.md
@@ -192,6 +193,7 @@ export default defineConfig({
             { text: "Tasks", link: "/guide/tasks" },
             { text: "Middleware", link: "/guide/middleware" },
             { text: "MCP", link: "/guide/mcp" },
+            { text: "MCP Apps", link: "/guide/mcp-apps" },
             { text: "Configuration", link: "/guide/config" },
             { text: "Plugins", link: "/guide/plugins" },
           ],

--- a/docs/guide/mcp-apps.md
+++ b/docs/guide/mcp-apps.md
@@ -1,0 +1,170 @@
+---
+description: MCP Apps — render an action's MCP tool result as an interactive HTML UI in the host, with structured data delivered via UIResponse.
+---
+
+# MCP Apps (Dynamic UIs)
+
+[MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview) is an extension to the Model Context Protocol that lets a tool return an **interactive HTML UI** instead of just text. The host (Claude, Claude Desktop, VS Code Copilot, and others) renders that UI inline in the conversation, inside a sandboxed iframe. The UI can call back into your server's tools and receive fresh data — a dashboard, form, chart, or viewer that lives right next to the chat.
+
+In Keryx this is a natural extension of the action model. Just as an action already exposes an MCP tool, resource, or prompt, it can declare a UI. You add one `mcp.ui` block and return a [`UIResponse`](#uiresponse) from `run()` — Keryx wires up the rest.
+
+::: tip Prerequisite
+MCP Apps build on the MCP server. Enable it first (see [MCP Server](./mcp.md)), then add a UI to any tool action.
+:::
+
+## How it works
+
+An MCP App combines two MCP primitives that Keryx registers for you:
+
+1. **A tool** whose description points at a UI via `_meta.ui.resourceUri`.
+2. **A `ui://` resource** that serves the app's self-contained HTML.
+
+When the model calls the tool, the host fetches the `ui://` resource, renders the HTML in a sandboxed iframe, and pushes the tool's **`structuredContent`** to the app for rendering. The app can then call any tool on your server to fetch more data — all over a secure `postMessage` channel.
+
+```
+Action (mcp.ui + returns UIResponse)
+  ├─▶ tool  "status-app"        _meta.ui.resourceUri = "ui://status-app"
+  └─▶ resource  "ui://status-app"  →  text/html;profile=mcp-app  (your HTML)
+
+tool call ─▶ UIResponse ─▶ { content: [text], structuredContent: {…} }
+                                    │                    │
+                             model context          app rendering
+```
+
+## Declaring a UI
+
+Add a `ui` block to an action's `mcp` config. The only required field is `html` — a self-contained HTML document for the app.
+
+```ts
+import { Action, api, UIResponse } from "keryx";
+import { z } from "zod";
+
+export class StatusDashboardApp implements Action {
+  name = "status:app";
+  description = "Show live server status as an interactive dashboard.";
+  inputs = z.object({});
+  mcp = {
+    ui: {
+      html: STATUS_DASHBOARD_HTML, // self-contained HTML string
+      prefersBorder: true,
+    },
+  };
+
+  async run() {
+    return new UIResponse(
+      {
+        name: api.process.name,
+        pid: api.process.pid,
+        uptime: new Date().getTime() - api.bootTime,
+      },
+      { text: `Server ${api.process.name} is running.` },
+    );
+  }
+}
+```
+
+That's it — the tool `status-app` is now linked to a `ui://status-app` resource, and calling it delivers the structured data to the app.
+
+::: info The UI is just a string
+Keryx never touches the filesystem for you. `html` is a plain string, so you decide where it comes from — an inline template literal for small UIs, or a file you read yourself:
+
+```ts
+const html = await Bun.file(
+  new URL("./status-app.html", import.meta.url),
+).text();
+```
+
+Production apps typically **bundle** their UI (framework + JS + CSS) into a single HTML file — for example with [Vite](https://vitejs.dev/) and [`vite-plugin-singlefile`](https://github.com/richVL/vite-plugin-singlefile) — then read the built file here.
+:::
+
+## `UIResponse`
+
+Return a `UIResponse` from `run()` to hand the host two payloads at once:
+
+- **`structuredContent`** — the object your app UI renders. Delivered to the app, **not** added to the model's context.
+- **`text`** — a text summary added to the model's context. Defaults to `JSON.stringify(structuredContent)`.
+
+```ts
+new UIResponse(structuredContent, { text: "optional model-facing summary" });
+// or: UIResponse.from(structuredContent, { text: "…" })
+```
+
+Over non-MCP transports (HTTP, WebSocket, CLI) a `UIResponse` serializes to its `structuredContent` via `toJSON()`, so the same action still returns useful JSON everywhere. A `GET` to the action's web route returns the structured object directly.
+
+## The UI side
+
+Inside the HTML, talk to the host with the [`@modelcontextprotocol/ext-apps`](https://github.com/modelcontextprotocol/ext-apps) `App` class (a thin wrapper over the `ui/` `postMessage` protocol):
+
+```ts
+import { App } from "@modelcontextprotocol/ext-apps";
+
+const app = new App({ name: "Server Status", version: "1.0.0" });
+
+// The host pushes this tool's structuredContent when the app first renders.
+app.ontoolresult = (result) => render(result.structuredContent);
+
+// Proactively call any tool on your Keryx server.
+async function refresh() {
+  const result = await app.callServerTool({ name: "status", arguments: {} });
+  render(result.structuredContent);
+}
+
+app.connect();
+```
+
+Because every Keryx action is already a tool, your app can call any of them with `callServerTool` — no separate API to build.
+
+## `McpUiConfig` options
+
+| Property        | Type       | Default             | Description                                                                 |
+| --------------- | ---------- | ------------------- | --------------------------------------------------------------------------- |
+| `html`          | `string`   | _(required)_        | Self-contained HTML for the app UI.                                         |
+| `resourceUri`   | `string`   | `ui://<tool-name>`  | The `ui://` resource URI the tool links to.                                 |
+| `csp`           | `object`   | —                   | External origins the app may reach (see [CSP](#csp-and-permissions)).       |
+| `permissions`   | `object`   | —                   | Extra iframe capabilities: `camera`, `microphone`, `geolocation`, `clipboardWrite`. |
+| `prefersBorder` | `boolean`  | —                   | Hint the host to render a border/frame around the app.                      |
+| `domain`        | `string`   | —                   | Logical grouping/isolation hint for the host.                               |
+
+## CSP and permissions
+
+Apps render under a deny-by-default Content-Security-Policy. Keep the HTML self-contained and no CSP tuning is needed. If your UI loads scripts, styles, or data from external origins, declare them:
+
+```ts
+mcp = {
+  ui: {
+    html,
+    csp: {
+      resourceDomains: ["https://esm.sh"], // load scripts/styles from
+      connectDomains: ["https://api.example.com"], // fetch/XHR/WebSocket to
+    },
+    permissions: { clipboardWrite: {} },
+  },
+};
+```
+
+| CSP field         | Controls                                        |
+| ----------------- | ----------------------------------------------- |
+| `resourceDomains` | Scripts, styles, images, fonts the app may load |
+| `connectDomains`  | Origins the app may `fetch`/XHR/WebSocket to     |
+| `frameDomains`    | Origins the app may embed in nested frames      |
+| `baseUriDomains`  | Origins allowed in the app's `<base href>`      |
+
+## Testing
+
+To see an app render you need a host that supports MCP Apps. Two easy options:
+
+- **basic-host** — the [ext-apps](https://github.com/modelcontextprotocol/ext-apps) repo ships a local test host. From `examples/basic-host`, point it at your server:
+
+  ```bash
+  SERVERS='["http://localhost:8080/mcp"]' npm start
+  ```
+
+- **Claude** — expose your local server with a tunnel (e.g. `npx cloudflared tunnel --url http://localhost:8080`) and add it as a [custom connector](https://support.anthropic.com/en/articles/11175166).
+
+For automated tests, assert the wiring over a normal MCP session: the tool's `_meta.ui.resourceUri` appears in `tools/list`, the `ui://` resource reads back HTML with the `text/html;profile=mcp-app` MIME type, and a `tools/call` returns `structuredContent`. See `example/backend/__tests__/initializers/mcp.test.ts`.
+
+## See also
+
+- [MCP Server](./mcp.md) — enabling MCP, tools, resources, prompts, OAuth
+- [MCP Apps specification](https://modelcontextprotocol.io/extensions/apps/overview)
+- [ext-apps examples](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples) — starter templates for React, Vue, Svelte, and vanilla JS

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -71,6 +71,7 @@ The full `mcp` property is of type `McpActionConfig`:
 | `isSignupAction` | `boolean`             | —       | Tag as the signup action for the OAuth flow                                        |
 | `resource`       | `object`              | —       | Expose this action as an MCP resource (see [Resources](#resources) below)          |
 | `prompt`         | `object`              | —       | Expose this action as an MCP prompt (see [Prompts](#prompts) below)                |
+| `ui`             | `McpUiConfig`         | —       | Render the tool's result as an interactive UI (see [MCP Apps](./mcp-apps.md))      |
 | `responseFormat` | `MCP_RESPONSE_FORMAT` | `JSON`  | Response format for MCP tool calls (see [Response Format](#response-format) below) |
 
 The `isLoginAction` and `isSignupAction` markers tell the OAuth system which actions to invoke when users authenticate through the MCP authorization page. These actions must return `OAuthActionResponse` (`{ user: { id: number } }`).

--- a/example/backend/__tests__/actions/mcp.test.ts
+++ b/example/backend/__tests__/actions/mcp.test.ts
@@ -55,3 +55,25 @@ describe("greeting:prompt", () => {
     );
   });
 });
+
+describe("status:app (MCP App)", () => {
+  test("GET /status/app returns the structuredContent (UIResponse serializes via toJSON)", async () => {
+    const res = await fetch(getUrl() + "/api/status/app");
+    expect(res.status).toBe(200);
+
+    // Over HTTP a UIResponse serializes to its structuredContent, so the same
+    // action is useful outside of MCP too.
+    const payload = (await res.json()) as {
+      name: string;
+      pid: number;
+      version: string;
+      uptime: number;
+      consumedMemoryMB: number;
+    };
+    expect(payload.name).toBeDefined();
+    expect(typeof payload.pid).toBe("number");
+    expect(payload.version).toBeDefined();
+    expect(payload.uptime).toBeGreaterThanOrEqual(0);
+    expect(payload.consumedMemoryMB).toBeGreaterThan(0);
+  });
+});

--- a/example/backend/__tests__/initializers/mcp.test.ts
+++ b/example/backend/__tests__/initializers/mcp.test.ts
@@ -502,6 +502,62 @@ describe("mcp initializer (enabled)", () => {
       expect(content).toBeArray();
       expect(content.length).toBeGreaterThan(0);
     });
+
+    describe("MCP Apps (dynamic UIs)", () => {
+      test("app tool declares _meta.ui.resourceUri in tools/list", async () => {
+        const result = await client.listTools();
+        const tool = result.tools.find((t) => t.name === "status-app");
+        expect(tool).toBeTruthy();
+        expect((tool!._meta as any)?.ui?.resourceUri).toBe("ui://status-app");
+      });
+
+      test("the ui:// resource is listed", async () => {
+        const result = await client.listResources();
+        const uris = result.resources.map((r) => r.uri);
+        expect(uris).toContain("ui://status-app");
+      });
+
+      test("resources/read returns app HTML with the MCP Apps mime type and _meta.ui", async () => {
+        const result = await client.readResource({ uri: "ui://status-app" });
+        expect(result.contents.length).toBeGreaterThan(0);
+        const content = result.contents[0];
+        expect(content.uri).toBe("ui://status-app");
+        expect(content.mimeType).toBe("text/html;profile=mcp-app");
+        const text = (content as { text: string }).text;
+        expect(text).toContain("<!doctype html>");
+        expect(text).toContain("ext-apps");
+        const ui = (content._meta as any)?.ui;
+        expect(ui?.prefersBorder).toBe(true);
+        expect(ui?.csp?.resourceDomains).toContain("https://esm.sh");
+      });
+
+      test("app tool call returns structuredContent plus a text summary", async () => {
+        const result = await client.callTool({
+          name: "status-app",
+          arguments: {},
+        });
+        expect(result.isError).toBeFalsy();
+
+        const structured = result.structuredContent as Record<string, unknown>;
+        expect(structured).toBeTruthy();
+        for (const key of [
+          "name",
+          "pid",
+          "version",
+          "uptime",
+          "consumedMemoryMB",
+        ]) {
+          expect(structured).toHaveProperty(key);
+        }
+
+        const content = result.content as Array<{
+          type: string;
+          text?: string;
+        }>;
+        expect(content[0].type).toBe("text");
+        expect(content[0].text).toContain("is running");
+      });
+    });
   });
 
   describe("OAuth endpoints", () => {

--- a/example/backend/actions/mcp.ts
+++ b/example/backend/actions/mcp.ts
@@ -1,4 +1,4 @@
-import { Action, type ActionParams, api, HTTP_METHOD } from "keryx";
+import { Action, type ActionParams, api, HTTP_METHOD, UIResponse } from "keryx";
 import { z } from "zod";
 import pkg from "../package.json";
 
@@ -63,5 +63,61 @@ export class GreetingPrompt implements Action {
         },
       ],
     };
+  }
+}
+
+/**
+ * Self-contained HTML for the Server Status MCP App, loaded from a sibling `.html` file.
+ *
+ * Keryx never reads files for you — a `UIResponse` action just needs an HTML string — so we
+ * read it ourselves at module load. Keeping the UI in its own `.html` file gives you real
+ * editor support (syntax highlighting, formatting) instead of a giant template literal.
+ *
+ * `status-app.html` uses the `@modelcontextprotocol/ext-apps` `App` class (loaded from a CDN,
+ * hence the `csp.resourceDomains` allowance below) to talk to the host over postMessage.
+ * Production apps typically bundle their UI (e.g. Vite + vite-plugin-singlefile) and read the
+ * built single-file HTML here instead.
+ */
+const STATUS_DASHBOARD_HTML = await Bun.file(
+  new URL("./status-app.html", import.meta.url),
+).text();
+
+/**
+ * An MCP App: a tool that renders live server status as an interactive dashboard.
+ *
+ * Declaring `mcp.ui` registers a `ui://status-app` HTML resource and links this tool to it.
+ * `run()` returns a {@link UIResponse} so the host delivers `structuredContent` to the app
+ * for rendering while still adding a text summary to the model's context.
+ */
+export class StatusDashboardApp implements Action {
+  name = "status:app";
+  description =
+    "Show live server status (name, PID, version, uptime, memory) as an interactive dashboard.";
+  inputs = z.object({});
+  mcp = {
+    tool: true,
+    ui: {
+      html: STATUS_DASHBOARD_HTML,
+      // The UI imports the ext-apps App class from a CDN, so allow it in the app's CSP.
+      csp: { resourceDomains: ["https://esm.sh"] },
+      prefersBorder: true,
+    },
+  };
+  web = { route: "/status/app", method: HTTP_METHOD.GET };
+
+  async run() {
+    const consumedMemoryMB =
+      Math.round((process.memoryUsage().heapUsed / 1024 / 1024) * 100) / 100;
+
+    return new UIResponse(
+      {
+        name: api.process.name,
+        pid: api.process.pid,
+        version: pkg.version,
+        uptime: new Date().getTime() - api.bootTime,
+        consumedMemoryMB,
+      },
+      { text: `Server ${api.process.name} is running (v${pkg.version}).` },
+    );
   }
 }

--- a/example/backend/actions/status-app.html
+++ b/example/backend/actions/status-app.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Server Status</title>
+    <style>
+      :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; }
+      body { margin: 0; padding: 16px; }
+      main { max-width: 420px; margin: 0 auto; }
+      header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+      h1 { font-size: 1.1rem; margin: 0; }
+      .pill { font-size: .75rem; padding: 2px 8px; border-radius: 999px; background: rgba(127,127,127,.18); }
+      dl { display: grid; grid-template-columns: auto 1fr; gap: 6px 16px; margin: 0; }
+      dt { color: rgba(127,127,127,.9); }
+      dd { margin: 0; font-variant-numeric: tabular-nums; text-align: right; }
+      footer { display: flex; align-items: center; gap: 12px; margin-top: 16px; }
+      button { padding: 6px 12px; border-radius: 8px; border: 1px solid rgba(127,127,127,.4); background: transparent; color: inherit; cursor: pointer; }
+      button:disabled { opacity: .5; cursor: default; }
+      #updated { font-size: .75rem; color: rgba(127,127,127,.9); }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header><h1>Server Status</h1><span id="name" class="pill">&mdash;</span></header>
+      <dl>
+        <dt>Process ID</dt><dd id="pid">&mdash;</dd>
+        <dt>Version</dt><dd id="version">&mdash;</dd>
+        <dt>Uptime</dt><dd id="uptime">&mdash;</dd>
+        <dt>Memory</dt><dd id="memory">&mdash;</dd>
+      </dl>
+      <footer><button id="refresh">Refresh</button><span id="updated"></span></footer>
+    </main>
+    <script type="module">
+      import { App } from "https://esm.sh/@modelcontextprotocol/ext-apps";
+
+      const app = new App({ name: "Server Status", version: "1.0.0" });
+      const el = (id) => document.getElementById(id);
+
+      function formatUptime(ms) {
+        if (ms == null) return "—";
+        const s = Math.floor(ms / 1000);
+        const h = Math.floor(s / 3600);
+        const m = Math.floor((s % 3600) / 60);
+        return `${h}h ${m}m ${s % 60}s`;
+      }
+
+      function render(data) {
+        if (!data) return;
+        el("name").textContent = data.name || "server";
+        el("pid").textContent = data.pid != null ? String(data.pid) : "—";
+        el("version").textContent = data.version || "—";
+        el("uptime").textContent = formatUptime(data.uptime);
+        el("memory").textContent =
+          data.consumedMemoryMB != null ? `${data.consumedMemoryMB} MB` : "—";
+        el("updated").textContent = `Updated ${new Date().toLocaleTimeString()}`;
+      }
+
+      // The host pushes this tool's structuredContent when the app first renders.
+      app.ontoolresult = (result) => render(result.structuredContent);
+
+      // The Refresh button proactively re-calls the `status` tool on the server.
+      el("refresh").addEventListener("click", async () => {
+        el("refresh").disabled = true;
+        try {
+          const result = await app.callServerTool({ name: "status", arguments: {} });
+          let data = result.structuredContent;
+          if (!data && result.content && result.content[0]) {
+            try {
+              data = JSON.parse(result.content[0].text);
+            } catch {
+              data = null;
+            }
+          }
+          render(data);
+        } finally {
+          el("refresh").disabled = false;
+        }
+      });
+
+      app.connect();
+    </script>
+  </body>
+</html>

--- a/packages/keryx/__tests__/classes/UIResponse.test.ts
+++ b/packages/keryx/__tests__/classes/UIResponse.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { UIResponse } from "../../classes/UIResponse";
+
+describe("UIResponse", () => {
+  test("defaults text to JSON.stringify(structuredContent)", () => {
+    const data = { name: "server", pid: 42 };
+    const res = new UIResponse(data);
+    expect(res.structuredContent).toEqual(data);
+    expect(res.text).toBe(JSON.stringify(data));
+  });
+
+  test("uses provided model-facing text", () => {
+    const res = new UIResponse({ ok: true }, { text: "All good" });
+    expect(res.text).toBe("All good");
+    expect(res.structuredContent).toEqual({ ok: true });
+  });
+
+  test("static from() is equivalent to the constructor", () => {
+    const res = UIResponse.from({ a: 1 }, { text: "one" });
+    expect(res).toBeInstanceOf(UIResponse);
+    expect(res.structuredContent).toEqual({ a: 1 });
+    expect(res.text).toBe("one");
+  });
+
+  test("toJSON() serializes to the structured payload, not the wrapper", () => {
+    const data = { count: 3, items: ["a", "b"] };
+    const res = new UIResponse(data);
+    expect(res.toJSON()).toEqual(data);
+    // So HTTP/WS/CLI transports serialize the data, not { structuredContent, text }.
+    expect(JSON.parse(JSON.stringify(res))).toEqual(data);
+  });
+});

--- a/packages/keryx/classes/Action.ts
+++ b/packages/keryx/classes/Action.ts
@@ -7,6 +7,56 @@ export enum MCP_RESPONSE_FORMAT {
   MARKDOWN = "markdown",
 }
 
+/**
+ * MIME type for MCP App UI resources, per the MCP Apps extension.
+ * A `ui://` resource declared via an action's `mcp.ui` config is served with this type.
+ * @see {@link https://modelcontextprotocol.io/extensions/apps/overview}
+ */
+export const MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
+
+/**
+ * Configures an action as an **MCP App** — a tool whose result renders an interactive
+ * HTML UI in the host (Claude, Claude Desktop, VS Code Copilot, …) inside a sandboxed iframe.
+ *
+ * When set, Keryx registers a `ui://` resource that serves `html`, links the action's tool
+ * to it via the tool's `_meta.ui.resourceUri`, and — when `run()` returns a `UIResponse` —
+ * delivers `structuredContent` to the app for rendering.
+ *
+ * @see {@link https://modelcontextprotocol.io/extensions/apps/overview}
+ */
+export type McpUiConfig = {
+  /**
+   * Self-contained HTML for the app UI. Keep external assets minimal (or inline them) so the
+   * default deny-by-default CSP applies. To serve HTML from a file, read it yourself
+   * (e.g. `await Bun.file(path).text()`) and pass the string here.
+   */
+  html: string;
+  /** The `ui://` resource URI. Defaults to `ui://<tool-name>`. */
+  resourceUri?: string;
+  /** Content-Security-Policy allowances for external origins the app may reach. */
+  csp?: {
+    /** Origins the app may `connect` to (fetch/XHR/WebSocket). */
+    connectDomains?: string[];
+    /** Origins the app may load sub-resources (scripts, styles, images, fonts) from. */
+    resourceDomains?: string[];
+    /** Origins the app may embed in nested frames. */
+    frameDomains?: string[];
+    /** Origins allowed in the app's `<base href>`. */
+    baseUriDomains?: string[];
+  };
+  /** Additional iframe capabilities the app requests (subject to host/user consent). */
+  permissions?: {
+    camera?: Record<string, never>;
+    microphone?: Record<string, never>;
+    geolocation?: Record<string, never>;
+    clipboardWrite?: Record<string, never>;
+  };
+  /** Hint that the host should render a border/frame around the app. */
+  prefersBorder?: boolean;
+  /** Logical domain grouping for the app (host-specific display/isolation hint). */
+  domain?: string;
+};
+
 export enum HTTP_METHOD {
   GET = "GET",
   POST = "POST",
@@ -51,6 +101,13 @@ export type McpActionConfig = {
     /** Human-readable display title for the prompt */
     title?: string;
   };
+  /**
+   * Register this action as an **MCP App** (a dynamic UI). The tool is linked to an
+   * auto-registered `ui://` HTML resource, and the action's `run()` should return a
+   * {@link UIResponse} to deliver structured data to the app.
+   * @see {@link https://modelcontextprotocol.io/extensions/apps/overview}
+   */
+  ui?: McpUiConfig;
   /**
    * Response format for MCP tool calls.
    * `MCP_RESPONSE_FORMAT.JSON` (default) returns `JSON.stringify(response)`.

--- a/packages/keryx/classes/Connection.ts
+++ b/packages/keryx/classes/Connection.ts
@@ -10,6 +10,7 @@ import type { Action, ActionParams } from "./Action";
 import { LogFormat } from "./Logger";
 import { StreamingResponse } from "./StreamingResponse";
 import { ErrorType, TypedError } from "./TypedError";
+import { UIResponse } from "./UIResponse";
 
 /**
  * Per-invocation context passed to {@link BeforeActHook} and {@link AfterActHook}.
@@ -424,6 +425,10 @@ export class Connection<
           if (updatedResponse instanceof StreamingResponse) {
             logger.warn(
               `Middleware cannot replace a StreamingResponse for action '${action.name}'`,
+            );
+          } else if (updatedResponse instanceof UIResponse) {
+            logger.warn(
+              `Middleware cannot replace a UIResponse for action '${action.name}'`,
             );
           } else {
             updatedResponse = middlewareResponse.updatedResponse;

--- a/packages/keryx/classes/UIResponse.ts
+++ b/packages/keryx/classes/UIResponse.ts
@@ -1,0 +1,72 @@
+/**
+ * Response type for actions that back an **MCP App** (a dynamic UI).
+ * Actions return a `UIResponse` from `run()` to hand the host two payloads at once:
+ * a `structuredContent` object rendered by the app's HTML UI, and a `text`
+ * representation added to the model's context.
+ *
+ * See {@link https://modelcontextprotocol.io/extensions/apps/overview | MCP Apps}.
+ */
+
+/**
+ * A response that pairs app-facing structured data with model-facing text.
+ *
+ * Returned from an action whose `mcp.ui` config declares an HTML UI. The MCP
+ * server delivers `structuredContent` to the app (via `ui/notifications/tool-result`,
+ * where it is used for rendering and is *not* added to model context) and the
+ * `text` as a normal text content block (which *is* added to model context).
+ *
+ * Over non-MCP transports (HTTP, WebSocket, CLI) a `UIResponse` serializes to
+ * its `structuredContent` via {@link UIResponse.toJSON}, so the same action still
+ * returns useful JSON everywhere.
+ *
+ * Use the static factory {@link UIResponse.from} or the constructor directly.
+ */
+export class UIResponse {
+  /** Structured data delivered to the app UI for rendering (not added to model context). */
+  readonly structuredContent: Record<string, unknown>;
+  /**
+   * Text representation added to the model's context. Defaults to
+   * `JSON.stringify(structuredContent)` when not provided.
+   */
+  readonly text: string;
+
+  /**
+   * @param structuredContent - The structured data the app UI will render. Must be a
+   *   JSON-serializable object; it is delivered to the app verbatim and is not added to
+   *   the model's context.
+   * @param options - Optional model-facing text.
+   * @param options.text - Text representation added to the model's context. When omitted,
+   *   defaults to `JSON.stringify(structuredContent)`.
+   */
+  constructor(
+    structuredContent: Record<string, unknown>,
+    options?: { text?: string },
+  ) {
+    this.structuredContent = structuredContent;
+    this.text = options?.text ?? JSON.stringify(structuredContent);
+  }
+
+  /**
+   * Convenience factory mirroring `StreamingResponse.sse()` / `.stream()`.
+   *
+   * @param structuredContent - The structured data the app UI will render.
+   * @param options - Optional model-facing text (see the constructor).
+   * @returns A new `UIResponse`.
+   */
+  static from(
+    structuredContent: Record<string, unknown>,
+    options?: { text?: string },
+  ): UIResponse {
+    return new UIResponse(structuredContent, options);
+  }
+
+  /**
+   * Serialize to the structured payload so non-MCP transports (HTTP, WebSocket, CLI)
+   * return the data rather than the wrapper object.
+   *
+   * @returns The `structuredContent` object.
+   */
+  toJSON(): Record<string, unknown> {
+    return this.structuredContent;
+  }
+}

--- a/packages/keryx/index.ts
+++ b/packages/keryx/index.ts
@@ -19,8 +19,12 @@ import "./initializers/signals";
 import "./initializers/swagger";
 
 export * from "./api";
-export type { ActionMiddleware } from "./classes/Action";
-export { HTTP_METHOD, MCP_RESPONSE_FORMAT } from "./classes/Action";
+export type { ActionMiddleware, McpUiConfig } from "./classes/Action";
+export {
+  HTTP_METHOD,
+  MCP_APP_MIME_TYPE,
+  MCP_RESPONSE_FORMAT,
+} from "./classes/Action";
 export type { ChannelMiddleware } from "./classes/Channel";
 export { CHANNEL_NAME_PATTERN } from "./classes/Channel";
 export type {
@@ -34,6 +38,7 @@ export { LogLevel } from "./classes/Logger";
 export type { KeryxPlugin, PluginGenerator } from "./classes/Plugin";
 export { SSEResponse, StreamingResponse } from "./classes/StreamingResponse";
 export { ErrorStatusCodes, ErrorType, TypedError } from "./classes/TypedError";
+export { UIResponse } from "./classes/UIResponse";
 export type { KeryxConfig } from "./config";
 export type { OnEnqueueHook } from "./initializers/actionts";
 export type {

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/mcpServer.ts
+++ b/packages/keryx/util/mcpServer.ts
@@ -11,11 +11,12 @@ import type {
 import { randomUUID } from "crypto";
 import * as z4mini from "zod/v4-mini";
 import { api, logger } from "../api";
-import type { Action } from "../classes/Action";
-import { MCP_RESPONSE_FORMAT } from "../classes/Action";
+import type { Action, McpUiConfig } from "../classes/Action";
+import { MCP_APP_MIME_TYPE, MCP_RESPONSE_FORMAT } from "../classes/Action";
 import { CONNECTION_TYPE, Connection } from "../classes/Connection";
 import { StreamingResponse } from "../classes/StreamingResponse";
 import { ErrorType, TypedError } from "../classes/TypedError";
+import { UIResponse } from "../classes/UIResponse";
 import { config } from "../config";
 import pkg from "../package.json";
 import { appendHeaders } from "../util/http";
@@ -135,9 +136,33 @@ export function createMcpServer(): McpServer {
 
   registerTools(mcpServer);
   registerResources(mcpServer);
+  registerUiResources(mcpServer);
   registerPrompts(mcpServer);
 
   return mcpServer;
+}
+
+/**
+ * Compute the `ui://` resource URI for an action's MCP App.
+ * Defaults to `ui://<tool-name>` when `mcp.ui.resourceUri` is not set.
+ */
+function uiResourceUri(action: Action): string {
+  return action.mcp?.ui?.resourceUri ?? `ui://${formatToolName(action.name)}`;
+}
+
+/**
+ * Build the MCP Apps `_meta.ui` object from an action's `mcp.ui` config,
+ * omitting empty sub-objects so the resource metadata stays minimal.
+ */
+function buildUiMeta(ui: McpUiConfig): Record<string, unknown> {
+  const meta: Record<string, unknown> = {};
+  if (ui.csp && Object.keys(ui.csp).length > 0) meta.csp = ui.csp;
+  if (ui.permissions && Object.keys(ui.permissions).length > 0) {
+    meta.permissions = ui.permissions;
+  }
+  if (ui.prefersBorder !== undefined) meta.prefersBorder = ui.prefersBorder;
+  if (ui.domain !== undefined) meta.domain = ui.domain;
+  return meta;
 }
 
 function registerTools(mcpServer: McpServer) {
@@ -151,6 +176,7 @@ function registerTools(mcpServer: McpServer) {
     const toolConfig: {
       description?: string;
       inputSchema?: any;
+      _meta?: Record<string, unknown>;
     } = {};
 
     if (action.description) {
@@ -160,6 +186,12 @@ function registerTools(mcpServer: McpServer) {
     toolConfig.inputSchema = action.inputs
       ? sanitizeSchemaForMcp(action.inputs)
       : z4mini.strictObject({});
+
+    // Link MCP App tools to their `ui://` resource so the host can preload and
+    // render the UI. See https://modelcontextprotocol.io/extensions/apps/overview
+    if (action.mcp?.ui) {
+      toolConfig._meta = { ui: { resourceUri: uiResourceUri(action) } };
+    }
 
     mcpServer.registerTool(
       toolName,
@@ -225,6 +257,15 @@ function registerTools(mcpServer: McpServer) {
             }
             return {
               content: [{ type: "text" as const, text: accumulated }],
+            };
+          }
+
+          // MCP App responses carry both a text block (added to model context)
+          // and structuredContent (delivered to the app UI for rendering).
+          if (response instanceof UIResponse) {
+            return {
+              content: [{ type: "text" as const, text: response.text }],
+              structuredContent: response.structuredContent,
             };
           }
 
@@ -320,6 +361,50 @@ function registerResources(mcpServer: McpServer) {
         (mcpUri: URL, extra: any) => readCb(mcpUri, {}, extra),
       );
     }
+  }
+}
+
+/**
+ * Register a `ui://` HTML resource for every action that declares `mcp.ui`.
+ * The resource serves the app's self-contained HTML with the MCP Apps MIME type
+ * and any `_meta.ui` (CSP, permissions, etc.). The matching tool is linked to it
+ * via `_meta.ui.resourceUri` in `registerTools()`.
+ */
+function registerUiResources(mcpServer: McpServer) {
+  const registered = new Set<string>();
+  for (const action of api.actions.actions) {
+    const ui = action.mcp?.ui;
+    if (!ui) continue;
+
+    const resourceUri = uiResourceUri(action);
+    if (registered.has(resourceUri)) {
+      logger.warn(
+        `Skipping duplicate MCP App UI resource '${resourceUri}' (action '${action.name}')`,
+      );
+      continue;
+    }
+    registered.add(resourceUri);
+
+    const uiMeta = buildUiMeta(ui);
+    const hasMeta = Object.keys(uiMeta).length > 0;
+    const metadata: Record<string, unknown> = { mimeType: MCP_APP_MIME_TYPE };
+    if (hasMeta) metadata._meta = { ui: uiMeta };
+
+    mcpServer.registerResource(
+      `${formatToolName(action.name)}-ui`,
+      resourceUri,
+      metadata,
+      (mcpUri: URL) => ({
+        contents: [
+          {
+            uri: mcpUri.toString(),
+            mimeType: MCP_APP_MIME_TYPE,
+            text: ui.html,
+            ...(hasMeta ? { _meta: { ui: uiMeta } } : {}),
+          },
+        ],
+      }),
+    );
   }
 }
 


### PR DESCRIPTION
Adds first-class support for [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview) (dynamic UIs): an action becomes an interactive UI by declaring an `mcp.ui` block and returning a `UIResponse`, and Keryx auto-registers a `ui://` HTML resource (served as `text/html;profile=mcp-app`), links the tool via `_meta.ui.resourceUri`, and delivers `structuredContent` to the app for rendering while adding a text summary to the model's context. The new `UIResponse` class (parallel to `StreamingResponse`) keeps model-facing text separate from app-facing data and serializes to its structured payload over HTTP/WS/CLI, so the same action stays useful on every transport. Ships a `StatusDashboardApp` example (UI loaded from a sibling `.html` file), a new `docs/guide/mcp-apps.md`, and unit + MCP integration tests, with zero new server dependencies. Bumps keryx to 0.34.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)