### PR TITLE
fix(render): 10x rate limits so MCP clients can connect

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -35,6 +35,15 @@ services:
         value: "true"
       - key: RATE_LIMIT_ENABLED
         value: "true"
+      # 10x the framework defaults (20 / 200 / 5) to accommodate MCP clients
+      # like Cursor that make many requests while connecting (OAuth discovery,
+      # dynamic client registration, and repeated initialize attempts).
+      - key: RATE_LIMIT_UNAUTH_LIMIT
+        value: "200"
+      - key: RATE_LIMIT_AUTH_LIMIT
+        value: "2000"
+      - key: RATE_LIMIT_OAUTH_REGISTER_LIMIT
+        value: "50"
       - key: TASKS_ENABLED
         value: "true"
       - key: APPLICATION_URL


### PR DESCRIPTION
Cursor and other MCP clients make many requests while connecting (OAuth discovery, dynamic client registration, and repeated `initialize` attempts), which trips the default rate limits on the demo backend — most notably the 5/hour OAuth-registration cap, producing a ~46-minute retry-after. This bumps the unauthenticated (200/min), authenticated (2000/min), and OAuth-register (50/hour) limits to 10x the framework defaults via env vars in `render.yaml`. No framework code changes, so no package version bump is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)