### PR TITLE
fix(ci): bump publish workflow to Node 24 so npm@latest installs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
       - run: npm install -g npm@latest
       - run: bun install

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Problem

The `Publish` workflow has failed on the last two pushes to `main` (runs [`29392710738`](https://github.com/actionhero/keryx/actions/runs/29392710738), [`29389045752`](https://github.com/actionhero/keryx/actions/runs/29389045752)). No packages are being published on version bumps.

The failure is in the `npm install -g npm@latest` step, before anything publishes:

```
npm error code EBADENGINE
npm error engine Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v22.14.0"}
```

The workflow pinned `node-version: "22.14.0"`. Current npm (`npm@12.0.1`, what `npm@latest` now resolves to) requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, so the stale pin is too old and the install aborts with exit code 1, failing every matrix leg.

## Fix

Bump `node-version` to `"24"` in `.github/workflows/publish.yaml`. This floats to the latest Node 24.x on the runner, satisfies the `^24.15.0` branch of npm's engine requirement, and won't re-break the next time `npm@latest` bumps its minimum (a hard pin is exactly what broke here).

The `npm install -g npm@latest` step and `npm publish --provenance` are unchanged — only the Node version was the problem.

## Verification

Bumps `keryx` to `0.34.1`, which re-triggers this Publish workflow on merge — a live confirmation that the `npm install -g npm@latest` step now passes and the workflow proceeds to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)