### PR TITLE
fix(mcp): allow browser connector origins so claude.ai can connect

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -312,6 +312,7 @@ See the [Security guide](/guide/security) for details on how rate limiting works
 | -------------------- | -------------------------- | ------------------- |
 | `enabled`            | `MCP_SERVER_ENABLED`       | `false`             |
 | `route`              | `MCP_SERVER_ROUTE`         | `"/mcp"`            |
+| `allowedOrigins`     | `MCP_ALLOWED_ORIGINS`      | Claude/ChatGPT/VS Code Web |
 | `instructions`       | `MCP_SERVER_INSTRUCTIONS`  | package description |
 | `oauthClientTtl`     | `MCP_OAUTH_CLIENT_TTL`     | `2592000`           |
 | `oauthCodeTtl`       | `MCP_OAUTH_CODE_TTL`       | `300`               |

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -237,6 +237,7 @@ The OAuth implementation includes several hardening measures:
 - **Client `application_type`** — `POST /oauth/register` accepts an `application_type` of `"web"` (the default) or `"native"`, stored on the client record so native/CLI clients are not misclassified as web clients (MCP 2026-07-28 / SEP-837). Any other value is rejected with `invalid_client_metadata`.
 - **Registration rate limiting** — `POST /oauth/register` has a separate, stricter rate limit (default: 5 requests per hour per IP) to prevent abuse. See `RATE_LIMIT_OAUTH_REGISTER_LIMIT` and `RATE_LIMIT_OAUTH_REGISTER_WINDOW_MS` in [Configuration](/guide/config).
 - **CORS** — OAuth and MCP endpoints respect the `allowedOrigins` configuration. When `allowedOrigins` is `"*"`, credentials headers are not sent, per the browser spec. Set a specific origin in production for credentialed requests to work.
+- **Browser MCP clients** — The MCP endpoint admits browser requests whose `Origin` is in `MCP_ALLOWED_ORIGINS` (comma-separated), in addition to `APPLICATION_URL` and `WEB_SERVER_ALLOWED_ORIGINS`. It defaults to the popular browser-based connectors (`https://claude.ai`, `https://claude.com`, `https://chatgpt.com`, `https://vscode.dev`, `https://github.dev`), so web connectors work out of the box even when `WEB_SERVER_ALLOWED_ORIGINS` is locked down. Requests with no `Origin` (CLI and other non-browser clients) always pass — the OAuth bearer token is the security boundary. The origin gate and the `Access-Control-Allow-Origin` response share one allowlist, so they never disagree.
 
 ## Session Management
 
@@ -297,6 +298,7 @@ When messages are broadcast through the PubSub system (e.g., chat messages sent 
 | -------------------- | -------------------------- | ------------------- | ---------------------------------------- |
 | `enabled`            | `MCP_SERVER_ENABLED`       | `false`             | Enable the MCP server                    |
 | `route`              | `MCP_SERVER_ROUTE`         | `"/mcp"`            | URL path for the MCP endpoint            |
+| `allowedOrigins`     | `MCP_ALLOWED_ORIGINS`      | Claude/ChatGPT/VS Code Web | Browser origins allowed to reach the MCP endpoint |
 | `instructions`       | `MCP_SERVER_INSTRUCTIONS`  | package description | Instructions shown to MCP clients        |
 | `oauthClientTtl`     | `MCP_OAUTH_CLIENT_TTL`     | `2592000`           | OAuth client registration TTL (seconds)  |
 | `oauthCodeTtl`       | `MCP_OAUTH_CODE_TTL`       | `300`               | Authorization code TTL (seconds)         |

--- a/example/backend/.env.example
+++ b/example/backend/.env.example
@@ -17,6 +17,13 @@ WEB_SERVER_ALLOWED_METHODS="GET, POST, PUT, DELETE, OPTIONS"
 
 MCP_SERVER_ENABLED=true
 
+# Browser origins allowed to reach the MCP endpoint, in addition to
+# APPLICATION_URL and WEB_SERVER_ALLOWED_ORIGINS. Defaults to the popular
+# browser-based agent connectors below; override to add or restrict origins.
+# Non-browser clients (Claude Code CLI, Cursor, etc.) send no Origin and are
+# always allowed.
+# MCP_ALLOWED_ORIGINS="https://claude.ai,https://claude.com,https://chatgpt.com,https://vscode.dev,https://github.dev"
+
 # Enable only when behind a trusted reverse proxy that strips client-supplied
 # X-Forwarded-* headers. Required for OAuth/MCP metadata URLs to reflect the
 # external scheme/host when APPLICATION_URL is not set.

--- a/packages/keryx/__tests__/util/http.test.ts
+++ b/packages/keryx/__tests__/util/http.test.ts
@@ -4,23 +4,27 @@ import {
   appendHeaders,
   buildCorsHeaders,
   getExternalOrigin,
+  getMcpAllowedOrigins,
   isOriginAllowed,
 } from "../../util/http";
 
 let originalAllowedOrigins: string;
 let originalApplicationUrl: string;
 let originalOauthTrustProxy: boolean;
+let originalMcpAllowedOrigins: string;
 
 beforeAll(() => {
   originalAllowedOrigins = config.server.web.allowedOrigins;
   originalApplicationUrl = config.server.web.applicationUrl;
   originalOauthTrustProxy = config.server.mcp.oauthTrustProxy;
+  originalMcpAllowedOrigins = config.server.mcp.allowedOrigins;
 });
 
 afterAll(() => {
   config.server.web.allowedOrigins = originalAllowedOrigins;
   config.server.web.applicationUrl = originalApplicationUrl;
   config.server.mcp.oauthTrustProxy = originalOauthTrustProxy;
+  config.server.mcp.allowedOrigins = originalMcpAllowedOrigins;
 });
 
 describe("isOriginAllowed", () => {
@@ -43,6 +47,41 @@ describe("isOriginAllowed", () => {
   test("whitespace in list is trimmed", () => {
     config.server.web.allowedOrigins = " https://a.com , https://b.com ";
     expect(isOriginAllowed("https://b.com")).toBe(true);
+  });
+
+  test("extraAllowedOrigins permits an origin not in the web list", () => {
+    config.server.web.allowedOrigins = "https://a.com";
+    expect(isOriginAllowed("https://claude.ai", ["https://claude.ai"])).toBe(
+      true,
+    );
+    expect(isOriginAllowed("https://evil.com", ["https://claude.ai"])).toBe(
+      false,
+    );
+  });
+
+  test("wildcard short-circuits extraAllowedOrigins", () => {
+    config.server.web.allowedOrigins = "*";
+    expect(isOriginAllowed("https://anything.com", [])).toBe(true);
+  });
+});
+
+describe("getMcpAllowedOrigins", () => {
+  test("includes the applicationUrl origin and configured origins", () => {
+    config.server.web.applicationUrl = "https://myapp.example.com";
+    config.server.mcp.allowedOrigins = "https://claude.ai,https://claude.com";
+    const origins = getMcpAllowedOrigins();
+    expect(origins).toContain("https://myapp.example.com");
+    expect(origins).toContain("https://claude.ai");
+    expect(origins).toContain("https://claude.com");
+  });
+
+  test("trims whitespace and drops empty entries", () => {
+    config.server.web.applicationUrl = "https://myapp.example.com";
+    config.server.mcp.allowedOrigins = " https://claude.ai , , https://x.com ";
+    const origins = getMcpAllowedOrigins();
+    expect(origins).toContain("https://claude.ai");
+    expect(origins).toContain("https://x.com");
+    expect(origins).not.toContain("");
   });
 });
 
@@ -73,6 +112,15 @@ describe("buildCorsHeaders", () => {
     });
     expect(headers["Access-Control-Allow-Methods"]).toBe("GET, POST");
     expect(headers["Access-Control-Allow-Origin"]).toBe("*");
+  });
+
+  test("reflects an origin allowed only via extraAllowedOrigins", () => {
+    config.server.web.allowedOrigins = "https://app.com";
+    const headers = buildCorsHeaders("https://claude.ai", undefined, [
+      "https://claude.ai",
+    ]);
+    expect(headers["Access-Control-Allow-Origin"]).toBe("https://claude.ai");
+    expect(headers["Vary"]).toBe("Origin");
   });
 });
 

--- a/packages/keryx/__tests__/util/mcpServer.test.ts
+++ b/packages/keryx/__tests__/util/mcpServer.test.ts
@@ -225,4 +225,87 @@ describe("mcpServer utilities (integration)", () => {
       }
     });
   });
+
+  describe("origin gate", () => {
+    let originalApplicationUrl: string;
+    let originalAllowedOrigins: string;
+    let originalMcpAllowedOrigins: string;
+
+    beforeAll(() => {
+      originalApplicationUrl = config.server.web.applicationUrl;
+      originalAllowedOrigins = config.server.web.allowedOrigins;
+      originalMcpAllowedOrigins = config.server.mcp.allowedOrigins;
+      // Simulate a public deployment with a locked-down web CORS allowlist, so
+      // the MCP-specific allowlist is what admits browser connector origins.
+      config.server.web.applicationUrl = "https://api.example.com";
+      config.server.web.allowedOrigins = "https://app.example.com";
+      config.server.mcp.allowedOrigins = "https://claude.ai,https://claude.com";
+    });
+
+    afterAll(() => {
+      config.server.web.applicationUrl = originalApplicationUrl;
+      config.server.web.allowedOrigins = originalAllowedOrigins;
+      config.server.mcp.allowedOrigins = originalMcpAllowedOrigins;
+    });
+
+    test("request with no Origin passes (preflight 204)", async () => {
+      const res = await fetch(mcpUrl(), {
+        method: "OPTIONS",
+        headers: { "Access-Control-Request-Method": "POST" },
+      });
+      expect(res.status).toBe(204);
+    });
+
+    test("request with no Origin reaches auth (POST 401, not 403)", async () => {
+      const res = await fetch(mcpUrl(), { method: "POST" });
+      expect(res.status).toBe(401);
+    });
+
+    test("allowlisted origin passes preflight and reflects CORS", async () => {
+      const res = await fetch(mcpUrl(), {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://claude.ai",
+          "Access-Control-Request-Method": "POST",
+        },
+      });
+      expect(res.status).toBe(204);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://claude.ai",
+      );
+    });
+
+    test("allowlisted origin POST reaches auth (not 403)", async () => {
+      const res = await fetch(mcpUrl(), {
+        method: "POST",
+        headers: { Origin: "https://claude.ai" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    test("applicationUrl origin passes", async () => {
+      const res = await fetch(mcpUrl(), {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://api.example.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      });
+      expect(res.status).toBe(204);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://api.example.com",
+      );
+    });
+
+    test("non-allowlisted origin is rejected with 403", async () => {
+      const res = await fetch(mcpUrl(), {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://evil.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      });
+      expect(res.status).toBe(403);
+    });
+  });
 });

--- a/packages/keryx/config/server/mcp.ts
+++ b/packages/keryx/config/server/mcp.ts
@@ -4,6 +4,16 @@ import { loadFromEnvIfSet } from "../../util/config";
 export const configServerMcp = {
   enabled: await loadFromEnvIfSet("MCP_SERVER_ENABLED", false),
   route: await loadFromEnvIfSet("MCP_SERVER_ROUTE", "/mcp"),
+  allowedOrigins: await loadFromEnvIfSet(
+    "MCP_ALLOWED_ORIGINS",
+    [
+      "https://claude.ai", // Anthropic Claude web connector
+      "https://claude.com", // Anthropic Claude web connector
+      "https://chatgpt.com", // OpenAI ChatGPT connectors
+      "https://vscode.dev", // VS Code for the Web
+      "https://github.dev", // github.dev web editor
+    ].join(","),
+  ),
   instructions: await loadFromEnvIfSet(
     "MCP_SERVER_INSTRUCTIONS",
     pkg.description as string,

--- a/packages/keryx/initializers/mcp.ts
+++ b/packages/keryx/initializers/mcp.ts
@@ -6,7 +6,12 @@ import { Initializer } from "../classes/Initializer";
 import { ErrorType, TypedError } from "../classes/TypedError";
 import { config } from "../config";
 import { ansi } from "../util/ansi";
-import { buildCorsHeaders, getExternalOrigin } from "../util/http";
+import {
+  buildCorsHeaders,
+  getExternalOrigin,
+  getMcpAllowedOrigins,
+  isOriginAllowed,
+} from "../util/http";
 import {
   createMcpServer,
   formatToolName,
@@ -142,26 +147,29 @@ export class McpInitializer extends Initializer {
     ): Promise<Response> => {
       const method = req.method.toUpperCase();
       const requestOrigin = req.headers.get("origin") ?? undefined;
-      const corsHeaders = buildCorsHeaders(requestOrigin, {
-        "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-        "Access-Control-Allow-Headers":
-          "Content-Type, mcp-session-id, Authorization",
-        "Access-Control-Expose-Headers": "mcp-session-id",
-      });
+      const mcpAllowedOrigins = getMcpAllowedOrigins();
+      const corsHeaders = buildCorsHeaders(
+        requestOrigin,
+        {
+          "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+          "Access-Control-Allow-Headers":
+            "Content-Type, mcp-session-id, Authorization",
+          "Access-Control-Expose-Headers": "mcp-session-id",
+        },
+        mcpAllowedOrigins,
+      );
 
-      // Reject requests from unrecognized origins when APPLICATION_URL is set
-      if (requestOrigin) {
-        const appUrl = config.server.web.applicationUrl;
-        if (appUrl && !appUrl.startsWith("http://localhost")) {
-          const allowedOrigin = new URL(appUrl).origin;
-          if (requestOrigin !== allowedOrigin) {
-            return mcpJsonResponse(
-              { error: "Origin not allowed" },
-              403,
-              corsHeaders,
-            );
-          }
-        }
+      // Reject browser requests from unrecognized origins. Requests with no
+      // Origin (non-browser clients like the Claude Code CLI) always pass; the
+      // bearer token is the real security boundary for this public endpoint.
+      // Uses the same allowlist as buildCorsHeaders above so the 403 gate and
+      // the Access-Control-Allow-Origin reflection can never disagree.
+      if (requestOrigin && !isOriginAllowed(requestOrigin, mcpAllowedOrigins)) {
+        return mcpJsonResponse(
+          { error: "Origin not allowed" },
+          403,
+          corsHeaders,
+        );
       }
 
       // Handle OPTIONS for CORS preflight

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.34.1",
+  "version": "0.35.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/http.ts
+++ b/packages/keryx/util/http.ts
@@ -2,12 +2,49 @@ import { config } from "../config";
 
 /**
  * Check whether a request origin is permitted by the configured allowed-origins list.
+ *
+ * @param origin - The request `Origin` to check.
+ * @param extraAllowedOrigins - Additional origins to permit beyond
+ *                `WEB_SERVER_ALLOWED_ORIGINS`. Used by the MCP endpoint to admit
+ *                browser connector origins (see {@link getMcpAllowedOrigins}) so
+ *                the origin gate and CORS reflection share one allowlist. When
+ *                `WEB_SERVER_ALLOWED_ORIGINS` is `"*"`, all origins are allowed and
+ *                this list is not consulted.
  */
-export function isOriginAllowed(origin: string): boolean {
+export function isOriginAllowed(
+  origin: string,
+  extraAllowedOrigins: string[] = [],
+): boolean {
   const allowedOrigins = config.server.web.allowedOrigins;
   if (allowedOrigins === "*") return true;
   const allowed = allowedOrigins.split(",").map((o) => o.trim());
-  return allowed.includes(origin);
+  return allowed.includes(origin) || extraAllowedOrigins.includes(origin);
+}
+
+/**
+ * Compute the extra origins permitted to reach the MCP endpoint from a browser,
+ * on top of `WEB_SERVER_ALLOWED_ORIGINS`. Always includes the `applicationUrl`
+ * origin (the server's own domain) plus the configurable `MCP_ALLOWED_ORIGINS`
+ * list (defaults to the popular browser-based agent connector origins).
+ *
+ * Passed to both {@link buildCorsHeaders} and {@link isOriginAllowed} in the MCP
+ * request handler so the 403 origin gate and the CORS `Access-Control-Allow-Origin`
+ * reflection can never disagree.
+ */
+export function getMcpAllowedOrigins(): string[] {
+  const origins: string[] = [];
+  const appUrl = config.server.web.applicationUrl;
+  if (appUrl) origins.push(new URL(appUrl).origin);
+  const configured = config.server.mcp.allowedOrigins;
+  if (configured) {
+    origins.push(
+      ...configured
+        .split(",")
+        .map((o) => o.trim())
+        .filter(Boolean),
+    );
+  }
+  return origins;
 }
 
 /**
@@ -16,17 +53,24 @@ export function isOriginAllowed(origin: string): boolean {
  * @param requestOrigin - The `Origin` header from the incoming request (if any).
  * @param extra - Additional CORS headers to merge (e.g. `Access-Control-Allow-Methods`).
  *                Any key not already set will be added.
+ * @param extraAllowedOrigins - Additional origins to permit beyond
+ *                `WEB_SERVER_ALLOWED_ORIGINS` when deciding whether to reflect
+ *                `Access-Control-Allow-Origin` (see {@link isOriginAllowed}).
  */
 export function buildCorsHeaders(
   requestOrigin: string | undefined,
   extra?: Record<string, string>,
+  extraAllowedOrigins: string[] = [],
 ): Record<string, string> {
   const headers: Record<string, string> = { ...extra };
   const allowedOrigins = config.server.web.allowedOrigins;
 
   if (allowedOrigins === "*" && !requestOrigin) {
     headers["Access-Control-Allow-Origin"] = "*";
-  } else if (requestOrigin && isOriginAllowed(requestOrigin)) {
+  } else if (
+    requestOrigin &&
+    isOriginAllowed(requestOrigin, extraAllowedOrigins)
+  ) {
     headers["Access-Control-Allow-Origin"] = requestOrigin;
     headers["Vary"] = "Origin";
   }


### PR DESCRIPTION
The MCP endpoint hard-rejected any request whose `Origin` did not exactly match `APPLICATION_URL`, so browser MCP clients (claude.ai/claude.com) always got a `403 {"error":"Origin not allowed"}` on the preflight before OAuth could even start, while non-browser clients (Claude Code CLI) that send no `Origin` connected fine. This replaces the hardcoded `applicationUrl`-only gate with a configurable allowlist via the new `MCP_ALLOWED_ORIGINS` env var, pre-seeded with the popular browser connectors (`https://claude.ai`, `https://claude.com`, `https://chatgpt.com`, `https://vscode.dev`, `https://github.dev`) plus the `applicationUrl` origin and `WEB_SERVER_ALLOWED_ORIGINS`. Both the 403 gate and the CORS `Access-Control-Allow-Origin` reflection now flow through the same `isOriginAllowed` logic so they can never disagree, and no-Origin requests still pass since the OAuth bearer token is the real security boundary. Adds unit tests for the new `extraAllowedOrigins` param / `getMcpAllowedOrigins`, integration tests covering no-Origin/allowlisted/applicationUrl/rejected origins, docs, and bumps the package to 0.35.0.

closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)