### PR TITLE
fix(oauth): reflect browser connector origins on OAuth endpoints so claude.ai can connect

### DIFF
--- a/example/backend/__tests__/initializers/mcp.test.ts
+++ b/example/backend/__tests__/initializers/mcp.test.ts
@@ -176,8 +176,24 @@ describe("mcp initializer (enabled)", () => {
     const res = await fetch(mcpUrl(), { method: "OPTIONS" });
     expect(res.status).toBe(204);
     expect(res.headers.get("access-control-allow-methods")).toBeTruthy();
-    expect(res.headers.get("access-control-allow-headers")).toContain(
-      "mcp-session-id",
+    const allowHeaders = res.headers.get("access-control-allow-headers") ?? "";
+    expect(allowHeaders).toContain("mcp-session-id");
+    // Clients send MCP-Protocol-Version on every request after initialize;
+    // browser connectors preflight it, so it must be allow-listed.
+    expect(allowHeaders.toLowerCase()).toContain("mcp-protocol-version");
+  });
+
+  test("OPTIONS reflects a browser connector origin", async () => {
+    const res = await fetch(mcpUrl(), {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://claude.ai",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://claude.ai",
     );
   });
 

--- a/packages/keryx/__tests__/initializers/oauth.test.ts
+++ b/packages/keryx/__tests__/initializers/oauth.test.ts
@@ -95,6 +95,64 @@ describe("oauth initializer", () => {
       expect(res).not.toBeNull();
       expect(res!.status).toBe(204);
     });
+
+    test("reflects browser connector origins even when WEB_SERVER_ALLOWED_ORIGINS is restrictive", async () => {
+      // Simulate a production deploy where WEB_SERVER_ALLOWED_ORIGINS is a
+      // specific allowlist that does NOT include the connector. Browser-based
+      // MCP clients (e.g. claude.ai) fetch the OAuth discovery/registration/
+      // token endpoints cross-origin, so those responses must still carry
+      // Access-Control-Allow-Origin for the connector origin — otherwise the
+      // browser blocks them and the connector silently fails to connect.
+      const original = config.server.web.allowedOrigins;
+      config.server.web.allowedOrigins = "https://app.example.com";
+      try {
+        // claude.ai is in the default MCP_ALLOWED_ORIGINS list.
+        const connectorOrigin = "https://claude.ai";
+        for (const path of [
+          "/.well-known/oauth-protected-resource/mcp",
+          "/.well-known/oauth-authorization-server",
+        ]) {
+          const res = await oauthRequest(path, {
+            method: "GET",
+            headers: { Origin: connectorOrigin },
+          });
+          expect(res).not.toBeNull();
+          expect(res!.headers.get("Access-Control-Allow-Origin")).toBe(
+            connectorOrigin,
+          );
+        }
+
+        // Preflight for dynamic client registration must reflect it too.
+        const preflight = await oauthRequest("/oauth/register", {
+          method: "OPTIONS",
+          headers: {
+            Origin: connectorOrigin,
+            "Access-Control-Request-Method": "POST",
+          },
+        });
+        expect(preflight!.status).toBe(204);
+        expect(preflight!.headers.get("Access-Control-Allow-Origin")).toBe(
+          connectorOrigin,
+        );
+      } finally {
+        config.server.web.allowedOrigins = original;
+      }
+    });
+
+    test("does not reflect a non-allowlisted origin when WEB_SERVER_ALLOWED_ORIGINS is restrictive", async () => {
+      const original = config.server.web.allowedOrigins;
+      config.server.web.allowedOrigins = "https://app.example.com";
+      try {
+        const res = await oauthRequest(
+          "/.well-known/oauth-authorization-server",
+          { method: "GET", headers: { Origin: "https://evil.example.org" } },
+        );
+        expect(res).not.toBeNull();
+        expect(res!.headers.get("Access-Control-Allow-Origin")).toBeNull();
+      } finally {
+        config.server.web.allowedOrigins = original;
+      }
+    });
   });
 
   describe("client registration", () => {

--- a/packages/keryx/initializers/mcp.ts
+++ b/packages/keryx/initializers/mcp.ts
@@ -152,8 +152,11 @@ export class McpInitializer extends Initializer {
         requestOrigin,
         {
           "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+          // MCP-Protocol-Version is sent by clients on every request after
+          // initialize (spec 2025-06-18+). Browser connectors preflight it, so
+          // it must be allow-listed or those requests are silently blocked.
           "Access-Control-Allow-Headers":
-            "Content-Type, mcp-session-id, Authorization",
+            "Content-Type, mcp-session-id, mcp-protocol-version, Authorization",
           "Access-Control-Expose-Headers": "mcp-session-id",
         },
         mcpAllowedOrigins,

--- a/packages/keryx/initializers/oauth.ts
+++ b/packages/keryx/initializers/oauth.ts
@@ -6,6 +6,7 @@ import {
   appendHeaders,
   buildCorsHeaders,
   getExternalOrigin,
+  getMcpAllowedOrigins,
 } from "../util/http";
 import {
   handleAuthorizeGet,
@@ -60,10 +61,21 @@ export class OAuthInitializer extends Initializer {
       const method = req.method.toUpperCase();
       const origin = getExternalOrigin(req, url);
       const requestOrigin = req.headers.get("origin") ?? undefined;
-      const corsHeaders = buildCorsHeaders(requestOrigin, {
-        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type, Authorization",
-      });
+      // OAuth discovery, dynamic client registration, and token exchange are
+      // performed as browser fetches by browser-based MCP connectors (e.g.
+      // claude.ai). Reflect Access-Control-Allow-Origin for the same connector
+      // origins the MCP endpoint admits, or the browser blocks the responses
+      // (the requests still return 2xx, so nothing errors server-side) and the
+      // connector silently fails to complete. These endpoints are public by
+      // design — protected by PKCE and registration, not by Origin.
+      const corsHeaders = buildCorsHeaders(
+        requestOrigin,
+        {
+          "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+          "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        },
+        getMcpAllowedOrigins(),
+      );
 
       // Handle CORS preflight for OAuth endpoints
       if (

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Problem

Follow-up to #499. That PR fixed the `/mcp` route's CORS + origin gate, but browser-based MCP connectors (e.g. **claude.ai**) still could not connect — and **no error surfaced** anywhere.

Root cause: claude.ai runs the OAuth handshake — **discovery → dynamic client registration → token exchange** — as **browser fetches**. Those responses were built with `buildCorsHeaders(requestOrigin, {...})` with no `extraAllowedOrigins`, so they only reflected `Access-Control-Allow-Origin` for `WEB_SERVER_ALLOWED_ORIGINS` (which, on a real deploy, does not include `claude.ai`). The requests return 200/201 on the wire — so nothing errors server-side and `curl` works — but the browser's CORS layer blocks the JS from reading them, and the connector silently fails.

Verified against the live demo (`api.demo.keryxjs.com`) after #499:

| Endpoint (`Origin: https://claude.ai`) | Wire status | `Access-Control-Allow-Origin` |
|---|---|---|
| `/mcp` | 204 / 401 | ✅ `https://claude.ai` |
| `/.well-known/oauth-protected-resource/mcp` | 200 | ❌ missing |
| `/.well-known/oauth-authorization-server` | 200 | ❌ missing |
| `/oauth/register` (DCR) | 201 | ❌ missing |

## Fix

- **`oauth.ts`**: pass `getMcpAllowedOrigins()` to `buildCorsHeaders` so the OAuth discovery/registration/token endpoints reflect the same connector origins the `/mcp` route admits. These endpoints are public by design (protected by PKCE + registration, not by Origin).
- **`mcp.ts`**: add `mcp-protocol-version` to `Access-Control-Allow-Headers`. Clients send `MCP-Protocol-Version` on every request after `initialize` (spec 2025-06-18+); browser connectors preflight it, so it must be allow-listed or those requests are silently blocked — the next failure after the OAuth CORS fix.

## Tests

- OAuth endpoints reflect `Access-Control-Allow-Origin` for a connector origin even when `WEB_SERVER_ALLOWED_ORIGINS` is restrictive, and do **not** reflect a non-allowlisted origin.
- `/mcp` preflight allow-lists `mcp-protocol-version` and reflects the connector origin.

Version bumped to `0.35.1`.

Re #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)