### PR TITLE
feat(mcp): cluster-wide Streamable HTTP sessions + 404 for unknown/expired sessions

### DIFF
--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -241,9 +241,31 @@ The OAuth implementation includes several hardening measures:
 
 ## Session Management
 
-Each authenticated MCP connection creates its own `McpServer` instance. Sessions are tracked via the `mcp-session-id` header — the MCP SDK generates a UUID per session and includes it in all subsequent requests.
+Each authenticated MCP connection creates its own `McpServer` instance. Sessions are tracked via the `mcp-session-id` header — the MCP SDK generates a UUID per session at `initialize` and the client includes it on every subsequent request.
 
-When a session closes, the transport and server instance are cleaned up automatically.
+### Cluster-wide sessions (multi-node)
+
+Sessions are recorded in a **shared Redis registry** (`mcp:session:<id>`), so any node in a cluster can serve any session — the same way keryx already scales WebSocket clients using the shared session store and Redis PubSub. When you run more than one keryx process behind a load balancer:
+
+- **Source of truth is Redis, not local memory.** Every request validates the `mcp-session-id` against the registry. The live transport/`McpServer` objects stay node-local (like a WebSocket socket — they can't move), but they're a cache, not the authority.
+- **Lazy adoption.** If a request lands on a node that doesn't hold the transport (the load balancer routed it elsewhere), that node re-materializes the session locally from the shared record and serves the request. No sticky-session configuration is required.
+- **Idle TTL.** The registry entry has a TTL (`MCP_SESSION_TTL`, default 24h) that is refreshed on every request, so idle sessions are reclaimed automatically.
+- **`DELETE` is cluster-wide.** An HTTP `DELETE` to the MCP route removes the shared record, so every node then returns `404` for that session id.
+- **The standalone `GET` SSE stream** is held by whichever node the client's `GET` lands on; because PubSub notifications already fan out across the cluster, notifications reach that node regardless of where the session was created.
+
+### Error semantics (per the Streamable HTTP spec)
+
+- **Unknown or expired `mcp-session-id` → `404 Not Found`** (JSON, no SSE stream is opened). This is the client's cue to re-`initialize` and recover automatically — for example after the session's TTL lapses or a `DELETE`.
+- **A non-`initialize` `POST` with no `mcp-session-id` → `400 Bad Request`.** Only `initialize` may open a new session.
+- **A session id owned by a different OAuth client → `403 Forbidden`.**
+
+### Lifecycle hooks in a cluster
+
+- `onConnect` fires **once**, on the node that runs the real `initialize` handshake. Adopting a session on another node does not re-fire it.
+- `onDisconnect` fires **once cluster-wide**, on the node whose `DELETE` (or true teardown) removes the shared record. A node shutting down does **not** fire it — the session may still be live and adoptable elsewhere.
+- `onMessage` fires per inbound request, on whichever node handles it.
+
+> **Tip:** sticky sessions (session affinity) are still a useful optimization — they keep a client on the node that already holds its transport and avoid re-adoption — but they are not required for correctness.
 
 ## OAuth Templates
 
@@ -301,6 +323,7 @@ When messages are broadcast through the PubSub system (e.g., chat messages sent 
 | `instructions`       | `MCP_SERVER_INSTRUCTIONS`  | package description | Instructions shown to MCP clients        |
 | `oauthClientTtl`     | `MCP_OAUTH_CLIENT_TTL`     | `2592000`           | OAuth client registration TTL (seconds)  |
 | `oauthCodeTtl`       | `MCP_OAUTH_CODE_TTL`       | `300`               | Authorization code TTL (seconds)         |
+| `sessionTtl`         | `MCP_SESSION_TTL`          | `86400`             | Shared MCP session registry TTL, refreshed on activity (seconds) |
 | `markdownDepthLimit` | `MCP_MARKDOWN_DEPTH_LIMIT` | `5`                 | Max nesting depth for markdown rendering |
 
 ## Testing

--- a/example/backend/__tests__/initializers/mcp.test.ts
+++ b/example/backend/__tests__/initializers/mcp.test.ts
@@ -1282,6 +1282,213 @@ describe("mcp initializer (enabled)", () => {
   });
 });
 
+describe("mcp multi-node sessions", () => {
+  let accessToken: string;
+
+  beforeAll(async () => {
+    config.server.mcp.enabled = true;
+    config.rateLimit.enabled = false;
+    await api.start();
+    accessToken = await getAccessToken();
+  }, HOOK_TIMEOUT);
+
+  afterAll(async () => {
+    const keys = await api.redis.redis.keys("mcp:session:*");
+    if (keys.length > 0) await api.redis.redis.del(...keys);
+    await api.stop();
+    config.server.mcp.enabled = false;
+    config.rateLimit.enabled = true;
+  }, HOOK_TIMEOUT);
+
+  const jsonHeaders = (token: string, sessionId?: string) => ({
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+    Authorization: `Bearer ${token}`,
+    "mcp-protocol-version": "2025-03-26",
+    ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+  });
+
+  const toolsListBody = (id: number) =>
+    JSON.stringify({ jsonrpc: "2.0", id, method: "tools/list", params: {} });
+
+  /** Initialize a fresh MCP session and return its server-assigned session id. */
+  async function initSession(token: string): Promise<string> {
+    const res = await fetch(mcpUrl(), {
+      method: "POST",
+      headers: jsonHeaders(token),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "1.0.0" },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const sessionId = res.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+    return sessionId!;
+  }
+
+  test("non-initialize POST without a session id returns 400 without leaking an McpServer", async () => {
+    const before = api.mcp.mcpServers.length;
+    const res = await fetch(mcpUrl(), {
+      method: "POST",
+      headers: jsonHeaders(accessToken),
+      body: toolsListBody(1),
+    });
+    expect(res.status).toBe(400);
+    // No SSE stream — the error is delivered as JSON, the client's cue to re-initialize.
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(res.headers.get("content-type") ?? "").not.toContain(
+      "text/event-stream",
+    );
+    // The orphan-McpServer leak (create-before-initialize) must not happen.
+    expect(api.mcp.mcpServers.length).toBe(before);
+  });
+
+  test("malformed JSON without a session id returns 400", async () => {
+    const res = await fetch(mcpUrl(), {
+      method: "POST",
+      headers: jsonHeaders(accessToken),
+      body: "{ not valid json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("unknown session id returns 404 as JSON, never an SSE stream", async () => {
+    const res = await fetch(mcpUrl(), {
+      method: "POST",
+      headers: jsonHeaders(accessToken, "does-not-exist"),
+      body: toolsListBody(1),
+    });
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(res.headers.get("content-type") ?? "").not.toContain(
+      "text/event-stream",
+    );
+  });
+
+  test("initialize writes a shared session record to Redis", async () => {
+    const sessionId = await initSession(accessToken);
+    const raw = await api.redis.redis.get(`mcp:session:${sessionId}`);
+    expect(raw).toBeTruthy();
+    const record = JSON.parse(raw!) as {
+      clientId: string;
+      protocolVersion?: string;
+      createdAt: number;
+    };
+    expect(typeof record.clientId).toBe("string");
+    expect(record.createdAt).toBeNumber();
+    expect(record.protocolVersion).toBe("2025-03-26");
+  });
+
+  test("a request on a node without the local transport adopts the session and succeeds", async () => {
+    const sessionId = await initSession(accessToken);
+    // Simulate the request landing on a different node: drop this node's live
+    // transport, leaving only the shared Redis record behind.
+    expect(api.mcp.transports.has(sessionId)).toBe(true);
+    api.mcp.transports.delete(sessionId);
+
+    const res = await fetch(mcpUrl(), {
+      method: "POST",
+      headers: jsonHeaders(accessToken, sessionId),
+      body: toolsListBody(2),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { result?: { tools?: unknown } };
+    expect(Array.isArray(json.result?.tools)).toBe(true);
+    // Adoption re-materialized a local transport for the session.
+    expect(api.mcp.transports.has(sessionId)).toBe(true);
+  });
+
+  test("adoption still enforces client ownership (403 for a different client's token)", async () => {
+    const sessionId = await initSession(accessToken);
+    api.mcp.transports.delete(sessionId);
+    const attackerToken = await getAccessToken();
+
+    const res = await fetch(mcpUrl(), {
+      method: "POST",
+      headers: jsonHeaders(attackerToken, sessionId),
+      body: toolsListBody(2),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("DELETE removes the shared record so every node then returns 404", async () => {
+    const sessionId = await initSession(accessToken);
+
+    const del = await fetch(mcpUrl(), {
+      method: "DELETE",
+      headers: jsonHeaders(accessToken, sessionId),
+    });
+    expect(del.status).toBe(200);
+    expect(await api.redis.redis.get(`mcp:session:${sessionId}`)).toBeNull();
+
+    const res = await fetch(mcpUrl(), {
+      method: "POST",
+      headers: jsonHeaders(accessToken, sessionId),
+      body: toolsListBody(3),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("a stale local transport cannot bypass the shared 404", async () => {
+    const sessionId = await initSession(accessToken);
+    expect(api.mcp.transports.has(sessionId)).toBe(true);
+    // Kill the shared record but leave the local transport in place.
+    await api.redis.redis.del(`mcp:session:${sessionId}`);
+
+    const res = await fetch(mcpUrl(), {
+      method: "POST",
+      headers: jsonHeaders(accessToken, sessionId),
+      body: toolsListBody(4),
+    });
+    expect(res.status).toBe(404);
+    // The stale transport was evicted so it can never serve a dead session.
+    expect(api.mcp.transports.has(sessionId)).toBe(false);
+  });
+
+  test("onConnect fires once at creation (not on adoption); onDisconnect once on DELETE", async () => {
+    let connects = 0;
+    let disconnects = 0;
+    const connectedSids: string[] = [];
+    api.hooks.mcp.onConnect((sid) => {
+      connects++;
+      connectedSids.push(sid);
+    });
+    api.hooks.mcp.onDisconnect(() => {
+      disconnects++;
+    });
+
+    const sessionId = await initSession(accessToken);
+    expect(connectedSids).toContain(sessionId);
+    const connectsAfterCreate = connects;
+
+    // Adopt on a "foreign node" — must NOT re-fire onConnect.
+    api.mcp.transports.delete(sessionId);
+    const adopted = await fetch(mcpUrl(), {
+      method: "POST",
+      headers: jsonHeaders(accessToken, sessionId),
+      body: toolsListBody(5),
+    });
+    expect(adopted.status).toBe(200);
+    expect(connects).toBe(connectsAfterCreate);
+
+    // Explicit DELETE terminates the session cluster-wide exactly once.
+    const disconnectsBefore = disconnects;
+    const del = await fetch(mcpUrl(), {
+      method: "DELETE",
+      headers: jsonHeaders(accessToken, sessionId),
+    });
+    expect(del.status).toBe(200);
+    expect(disconnects).toBe(disconnectsBefore + 1);
+  });
+});
+
 // --- Helper functions ---
 
 function randomString(length: number): string {

--- a/packages/keryx/config/server/mcp.ts
+++ b/packages/keryx/config/server/mcp.ts
@@ -29,4 +29,10 @@ export const configServerMcp = {
   ), // 30 days, in seconds
   oauthTrustProxy: await loadFromEnvIfSet("MCP_OAUTH_TRUST_PROXY", false),
   markdownDepthLimit: await loadFromEnvIfSet("MCP_MARKDOWN_DEPTH_LIMIT", 5),
+  // TTL (seconds) for the shared MCP session registry in Redis. Every MCP
+  // request refreshes it, so this is an idle timeout: a session is reclaimed
+  // once no node has served a request for it within this window. Because the
+  // registry is shared, any node in a cluster can serve any session until it
+  // expires. Defaults to 24 hours.
+  sessionTtl: await loadFromEnvIfSet("MCP_SESSION_TTL", 60 * 60 * 24),
 };

--- a/packages/keryx/initializers/mcp.ts
+++ b/packages/keryx/initializers/mcp.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "crypto";
 import { api, logger } from "../api";
 import { Initializer } from "../classes/Initializer";
@@ -13,13 +14,19 @@ import {
   isOriginAllowed,
 } from "../util/http";
 import {
+  adoptMcpSession,
   createMcpServer,
+  forgetMcpSession,
   formatToolName,
   handleTransportRequest,
   type McpAuthInfo,
   mcpJsonResponse,
   parseToolName,
+  readMcpSessionRecord,
+  refreshMcpSessionTtl,
   sanitizeSchemaForMcp,
+  terminateMcpSession,
+  writeMcpSessionRecord,
 } from "../util/mcpServer";
 import type { PubSubMessage } from "./pubsub";
 
@@ -49,6 +56,24 @@ export type OnMcpMessageHook = (
 export type OnMcpDisconnectHook = (sessionId: string) => Promise<void> | void;
 
 const namespace = "mcp";
+
+/**
+ * Pull the negotiated `protocolVersion` out of an `initialize` request body
+ * (single message or batch) so it can be stored in the shared session registry
+ * and replayed when the session is adopted on another node.
+ */
+function extractInitProtocolVersion(body: unknown): string | undefined {
+  const messages = Array.isArray(body) ? body : [body];
+  for (const message of messages) {
+    if (isInitializeRequest(message)) {
+      const protocolVersion = (
+        message as { params?: { protocolVersion?: unknown } }
+      ).params?.protocolVersion;
+      if (typeof protocolVersion === "string") return protocolVersion;
+    }
+  }
+  return undefined;
+}
 
 declare module "keryx" {
   export interface API {
@@ -217,6 +242,28 @@ export class McpInitializer extends Initializer {
       const sessionId = req.headers.get("mcp-session-id");
 
       if (method === "POST" && !sessionId) {
+        // Only an `initialize` request may create a new session. Any other
+        // request without a session id is a protocol error → 400. We must gate
+        // here rather than delegating, otherwise a non-initialize POST spins up
+        // an McpServer that never initializes and leaks into `mcpServers`.
+        let body: unknown;
+        try {
+          body = await req.clone().json();
+        } catch {
+          return mcpJsonResponse({ error: "Invalid JSON" }, 400, corsHeaders);
+        }
+        const isInit = Array.isArray(body)
+          ? body.some(isInitializeRequest)
+          : isInitializeRequest(body);
+        if (!isInit) {
+          return mcpJsonResponse(
+            { error: "Mcp-Session-Id header required" },
+            400,
+            corsHeaders,
+          );
+        }
+        const protocolVersion = extractInitProtocolVersion(body);
+
         // New session — create a new McpServer + transport
         const mcpServer = createMcpServer();
         mcpServers.push(mcpServer);
@@ -226,29 +273,26 @@ export class McpInitializer extends Initializer {
           sessionIdGenerator: () => randomUUID(),
           enableJsonResponse: true,
           onsessioninitialized: async (sid) => {
+            // Publish to the shared registry first so any node in the cluster
+            // can validate/adopt the session, then register locally + fire
+            // onConnect (once, on this originating node only).
+            await writeMcpSessionRecord(sid, {
+              clientId: sessionClientId,
+              protocolVersion,
+              createdAt: Date.now(),
+            });
             transports.set(sid, { transport, clientId: sessionClientId });
             for (const hook of api.hooks.mcp.onConnectHooks) {
               await hook(sid);
             }
           },
-          onsessionclosed: (sid) => {
-            transports.delete(sid);
-            const idx = mcpServers.indexOf(mcpServer);
-            if (idx !== -1) mcpServers.splice(idx, 1);
-          },
+          // Fires on explicit client DELETE: terminate the session cluster-wide.
+          onsessionclosed: (sid) => terminateMcpSession(sid, mcpServer),
         });
-
-        transport.onclose = async () => {
-          const sid = transport.sessionId;
-          if (sid) {
-            transports.delete(sid);
-            for (const hook of api.hooks.mcp.onDisconnectHooks) {
-              await hook(sid);
-            }
-          }
-          const idx = mcpServers.indexOf(mcpServer);
-          if (idx !== -1) mcpServers.splice(idx, 1);
-        };
+        // Fires on any close (incl. server shutdown): local cleanup only, so a
+        // node bouncing never removes a session other nodes may still serve.
+        transport.onclose = () =>
+          forgetMcpSession(transport.sessionId, mcpServer);
 
         await mcpServer.connect(transport);
 
@@ -259,8 +303,18 @@ export class McpInitializer extends Initializer {
       }
 
       if (sessionId) {
-        const session = transports.get(sessionId);
-        if (!session) {
+        // The shared Redis registry — not the node-local map — is the source of
+        // truth for session existence and ownership, so a request that a load
+        // balancer routes to any node resolves consistently.
+        const record = await readMcpSessionRecord(sessionId);
+        if (!record) {
+          // Unknown/expired session → 404 (the client's cue to re-`initialize`).
+          // Evict any stale local transport so it can never bypass this gate.
+          const stale = transports.get(sessionId);
+          if (stale) {
+            transports.delete(sessionId);
+            void stale.transport.close();
+          }
           return mcpJsonResponse(
             { error: "Session not found" },
             404,
@@ -268,7 +322,7 @@ export class McpInitializer extends Initializer {
           );
         }
 
-        if (session.clientId !== authInfo.clientId) {
+        if (record.clientId !== authInfo.clientId) {
           return mcpJsonResponse(
             { error: "Token does not match session" },
             403,
@@ -276,15 +330,23 @@ export class McpInitializer extends Initializer {
           );
         }
 
+        // Use the live local transport, or adopt the session onto this node by
+        // re-materializing it from the shared record.
+        let transport = transports.get(sessionId)?.transport;
+        if (!transport) {
+          transport = await adoptMcpSession(
+            sessionId,
+            record.clientId,
+            record.protocolVersion,
+          );
+        }
+
+        await refreshMcpSessionTtl(sessionId);
+
         for (const hook of api.hooks.mcp.onMessageHooks) {
           await hook(sessionId);
         }
-        return handleTransportRequest(
-          session.transport,
-          req,
-          authInfo,
-          corsHeaders,
-        );
+        return handleTransportRequest(transport, req, authInfo, corsHeaders);
       }
 
       // GET/DELETE without session ID

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.35.3",
+  "version": "0.36.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/mcpServer.ts
+++ b/packages/keryx/util/mcpServer.ts
@@ -2,11 +2,13 @@ import {
   McpServer,
   ResourceTemplate,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type {
-  ServerNotification,
-  ServerRequest,
+import {
+  DEFAULT_NEGOTIATED_PROTOCOL_VERSION,
+  type ServerNotification,
+  type ServerRequest,
+  SUPPORTED_PROTOCOL_VERSIONS,
 } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "crypto";
 import * as z4mini from "zod/v4-mini";
@@ -121,6 +123,230 @@ export function mcpJsonResponse(
       ...extraHeaders,
     },
   });
+}
+
+/**
+ * A record in the shared (Redis-backed) MCP session registry. This is the
+ * cluster-wide source of truth for whether a Streamable HTTP session exists and
+ * which OAuth client owns it. The live transport/`McpServer` objects are
+ * node-local (like a WebSocket socket) and are re-materialized on demand via
+ * {@link adoptMcpSession} when a request lands on a node that doesn't hold them.
+ */
+export interface McpSessionRecord {
+  /** OAuth client id bound to the session; enforced on every request (403 on mismatch). */
+  clientId: string;
+  /** Protocol version negotiated at `initialize`, replayed when adopting on another node. */
+  protocolVersion?: string;
+  /** Creation timestamp (ms since epoch). */
+  createdAt: number;
+}
+
+/** Redis key for a session registry record. */
+export function mcpSessionKey(sessionId: string): string {
+  return `mcp:session:${sessionId}`;
+}
+
+/**
+ * Write (or overwrite) a session registry record with the configured TTL.
+ * Called once, on the node that runs the real `initialize` handshake.
+ *
+ * @param sessionId - The transport session id (`Mcp-Session-Id`).
+ * @param record - The record to persist.
+ */
+export async function writeMcpSessionRecord(
+  sessionId: string,
+  record: McpSessionRecord,
+): Promise<void> {
+  await api.redis.redis.set(
+    mcpSessionKey(sessionId),
+    JSON.stringify(record),
+    "EX",
+    config.server.mcp.sessionTtl,
+  );
+}
+
+/**
+ * Read a session registry record. Returns `null` when the session is unknown or
+ * expired — the caller must treat that as a 404 (the client's cue to re-`initialize`).
+ *
+ * @param sessionId - The transport session id (`Mcp-Session-Id`).
+ */
+export async function readMcpSessionRecord(
+  sessionId: string,
+): Promise<McpSessionRecord | null> {
+  const raw = await api.redis.redis.get(mcpSessionKey(sessionId));
+  return raw ? (JSON.parse(raw) as McpSessionRecord) : null;
+}
+
+/**
+ * Refresh the TTL on a session registry record. Called on every request so the
+ * TTL behaves as an idle timeout across the cluster.
+ *
+ * @param sessionId - The transport session id (`Mcp-Session-Id`).
+ */
+export async function refreshMcpSessionTtl(sessionId: string): Promise<void> {
+  await api.redis.redis.expire(
+    mcpSessionKey(sessionId),
+    config.server.mcp.sessionTtl,
+  );
+}
+
+/**
+ * Delete a session registry record.
+ *
+ * @param sessionId - The transport session id (`Mcp-Session-Id`).
+ * @returns The number of keys removed (`1` if this call actually deleted the
+ *   record, `0` if it was already gone) — used to fire `onDisconnect` hooks
+ *   exactly once across the cluster.
+ */
+export async function deleteMcpSessionRecord(
+  sessionId: string,
+): Promise<number> {
+  return api.redis.redis.del(mcpSessionKey(sessionId));
+}
+
+/**
+ * Local teardown of an MCP session: drop the transport and its `McpServer` from
+ * this node's in-memory maps. Does NOT touch the shared Redis registry, because
+ * this also runs on server shutdown (`transport.close()` → `onclose`), where the
+ * session may still be live and adoptable on other nodes.
+ *
+ * @param sessionId - The transport session id, or `undefined` if never initialized.
+ * @param mcpServer - The `McpServer` bound to the closing transport.
+ */
+export function forgetMcpSession(
+  sessionId: string | undefined,
+  mcpServer: McpServer,
+): void {
+  if (sessionId) api.mcp.transports.delete(sessionId);
+  const idx = api.mcp.mcpServers.indexOf(mcpServer);
+  if (idx !== -1) api.mcp.mcpServers.splice(idx, 1);
+}
+
+/**
+ * Full teardown triggered by an explicit client `DELETE` (`onsessionclosed`):
+ * drop local state, delete the shared Redis record (so every node then 404s),
+ * and — exactly once across the cluster, gated on the delete actually removing
+ * the key — run the `onDisconnect` hooks.
+ *
+ * @param sessionId - The transport session id being terminated.
+ * @param mcpServer - The `McpServer` bound to the closing transport.
+ */
+export async function terminateMcpSession(
+  sessionId: string,
+  mcpServer: McpServer,
+): Promise<void> {
+  forgetMcpSession(sessionId, mcpServer);
+  const removed = await deleteMcpSessionRecord(sessionId);
+  if (removed === 1) {
+    for (const hook of api.hooks.mcp.onDisconnectHooks) {
+      await hook(sessionId);
+    }
+  }
+}
+
+/**
+ * Drive a synthetic `initialize` request through a freshly-created transport so
+ * it enters `{ sessionId, initialized: true }` state without a real client
+ * round-trip. The initialize response is discarded; awaiting it guarantees the
+ * connected `McpServer` finished its handshake before the caller dispatches the
+ * real request. Uses only the SDK's public `handleRequest` API.
+ *
+ * @param transport - A connected transport whose `sessionIdGenerator` returns the target session id.
+ * @param protocolVersion - The version negotiated on the originating node, if known.
+ */
+async function driveSyntheticInitialize(
+  transport: WebStandardStreamableHTTPServerTransport,
+  protocolVersion: string | undefined,
+): Promise<void> {
+  const negotiatedVersion =
+    protocolVersion &&
+    (SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(protocolVersion)
+      ? protocolVersion
+      : DEFAULT_NEGOTIATED_PROTOCOL_VERSION;
+
+  const initBody = {
+    jsonrpc: "2.0" as const,
+    id: `keryx-adopt-${randomUUID()}`,
+    method: "initialize",
+    params: {
+      protocolVersion: negotiatedVersion,
+      capabilities: {},
+      clientInfo: { name: "keryx-adopt", version: pkg.version },
+    },
+  };
+
+  // Accept must list both content types and Content-Type must be JSON, or the
+  // SDK rejects the POST before it ever inspects the (pre-parsed) body.
+  const req = new Request("http://keryx.internal/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+  });
+
+  await transport.handleRequest(req, { parsedBody: initBody });
+}
+
+/** In-flight adoptions, keyed by session id, so concurrent requests for the same
+ * not-yet-local session share one transport instead of racing to build several. */
+const adoptionsInFlight = new Map<
+  string,
+  Promise<WebStandardStreamableHTTPServerTransport>
+>();
+
+/**
+ * Re-materialize a session that exists in the shared registry but has no live
+ * transport on this node (e.g. a load balancer routed a later request to a
+ * different node than the one that ran `initialize`). Creates a fresh
+ * `McpServer` + transport bound to `sessionId`, drives a synthetic `initialize`
+ * to bring it to initialized state, registers it locally, and returns it ready
+ * to serve the real request.
+ *
+ * Adopted transports intentionally do NOT re-run `onConnect` hooks or re-write
+ * the Redis record — those already happened on the originating node. They DO
+ * wire teardown so a `DELETE` routed here still terminates the session cluster-wide.
+ *
+ * @param sessionId - The transport session id to adopt.
+ * @param clientId - The OAuth client id that owns the session (from the registry record).
+ * @param protocolVersion - The negotiated protocol version from the registry record, if any.
+ * @returns The connected, initialized transport (also registered in `api.mcp.transports`).
+ */
+export async function adoptMcpSession(
+  sessionId: string,
+  clientId: string,
+  protocolVersion: string | undefined,
+): Promise<WebStandardStreamableHTTPServerTransport> {
+  const inFlight = adoptionsInFlight.get(sessionId);
+  if (inFlight) return inFlight;
+
+  const promise = (async () => {
+    const mcpServer = createMcpServer();
+    api.mcp.mcpServers.push(mcpServer);
+
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: () => sessionId,
+      enableJsonResponse: true,
+      // Local registration only — no hooks, no registry write (see doc above).
+      onsessioninitialized: (sid) => {
+        api.mcp.transports.set(sid, { transport, clientId });
+      },
+      onsessionclosed: (sid) => terminateMcpSession(sid, mcpServer),
+    });
+    transport.onclose = () => forgetMcpSession(transport.sessionId, mcpServer);
+
+    await mcpServer.connect(transport);
+    await driveSyntheticInitialize(transport, protocolVersion);
+    return transport;
+  })();
+
+  adoptionsInFlight.set(sessionId, promise);
+  try {
+    return await promise;
+  } finally {
+    adoptionsInFlight.delete(sessionId);
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #503.

## Problem

A Streamable HTTP request carrying an unknown or expired `Mcp-Session-Id` needs to return **HTTP 404** so a compliant MCP client re-`initialize`s and recovers. The original report also surfaced a deeper limitation: sessions were tracked only in a **node-local `Map`**, so in a cluster a request that a load balancer routed to a different node would 404 even though the session was live.

## What changed

**Multi-node sessions (the main change).** MCP transport sessions are now recorded in a **shared Redis registry** (`mcp:session:<id>`), the cluster-wide source of truth for session existence and OAuth-client ownership. This reuses the same machinery keryx already uses to scale WebSocket clients — the shared session store pattern (`initializers/session.ts`) and cross-node Redis PubSub — rather than adding a parallel system. The only piece that wasn't already cross-node was the transport-session UUID; that gap is now closed.

- **Redis-first validation:** every request validates `Mcp-Session-Id` against Redis. Live transport/`McpServer` objects stay node-local (like a WebSocket socket — they can't move) and act as a cache.
- **Lazy adoption:** when a request lands on a node without the transport, that node re-materializes it locally by driving a synthetic `initialize` through the SDK's public `handleRequest` API (sets `{sessionId, initialized}` without a client round-trip). No sticky-session config required.
- **Idle TTL:** `MCP_SESSION_TTL` (default 24h), refreshed on every request.
- **`DELETE` is cluster-wide:** removes the shared record; all nodes then 404.

**Spec-compliant error semantics (#503 core):**
- Unknown/expired session → **404** JSON, **no SSE stream opened** (regression-tested by asserting `Content-Type: application/json`, never `text/event-stream`).
- Non-`initialize` POST with no session id → **400** (and no longer leaks an orphan `McpServer` — previously a non-init POST created a server that never initialized).
- Session owned by a different OAuth client → **403**.

**Lifecycle hooks in a cluster:** `onConnect` fires once at true creation (not on adoption); `onDisconnect` fires once cluster-wide on the node whose `DELETE` removes the shared record (a node shutting down does not fire it — the session may still be adoptable elsewhere); `onMessage` per request.

## Files
- `packages/keryx/initializers/mcp.ts` — `isInitializeRequest` gate; Redis-first existing-session branch with adoption; teardown split between `onsessionclosed` (DELETE → terminate cluster-wide) and `onclose` (local cleanup only).
- `packages/keryx/util/mcpServer.ts` — registry helpers + `adoptMcpSession` (synthetic-init adoption with in-flight dedupe).
- `packages/keryx/config/server/mcp.ts` — `sessionTtl` / `MCP_SESSION_TTL`.
- `example/backend/__tests__/initializers/mcp.test.ts` — new `mcp multi-node sessions` suite.
- `docs/guide/mcp.md` — Session Management rewrite + config table.
- Version bump `0.35.3` → `0.36.0`.

## Open question from the issue
Sessions are Redis-backed and cluster-wide, which is the answer to "in-process vs Redis." Not included (non-load-bearing): an eager cross-node eviction broadcast (the Redis-first check makes it unnecessary) and a periodic local-transport sweeper (mirrors today's leak-until-close; TTL reclaims the shared record).

## Testing
- `example/backend`: 272 pass / 0 fail; `packages/keryx`: 806 pass / 0 fail; `bun lint` clean.
- New suite covers: 400-no-leak, malformed-JSON 400, unknown-session 404-as-JSON-not-SSE, registry write on create, adoption success, adoption ownership 403, DELETE → cluster-wide 404, Redis-source-of-truth eviction of a stale local transport, and hook-count semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)