### PR TITLE
feat(mcp): advertise the io.modelcontextprotocol/ui capability during initialize

### DIFF
--- a/docs/guide/mcp-apps.md
+++ b/docs/guide/mcp-apps.md
@@ -31,6 +31,8 @@ tool call ─▶ UIResponse ─▶ { content: [text], structuredContent: {…} }
                              model context          app rendering
 ```
 
+Keryx advertises the `io.modelcontextprotocol/ui` extension capability during `initialize` (when any action declares `mcp.ui`) so compliant hosts negotiate UI support.
+
 ## Declaring a UI
 
 Add a `ui` block to an action's `mcp` config. The only required field is `html` — a self-contained HTML document for the app.
@@ -162,6 +164,10 @@ To see an app render you need a host that supports MCP Apps. Two easy options:
 - **Claude** — expose your local server with a tunnel (e.g. `npx cloudflared tunnel --url http://localhost:8080`) and add it as a [custom connector](https://support.anthropic.com/en/articles/11175166).
 
 For automated tests, assert the wiring over a normal MCP session: the tool's `_meta.ui.resourceUri` appears in `tools/list`, the `ui://` resource reads back HTML with the `text/html;profile=mcp-app` MIME type, and a `tools/call` returns `structuredContent`. See `example/backend/__tests__/initializers/mcp.test.ts`.
+
+::: warning Rendering is up to the host
+Whether an app actually renders is controlled entirely by the host. MCP Apps is new, and support varies — some clients gate it behind a server-side flag or have version-specific regressions (e.g. a host may negotiate the `io.modelcontextprotocol/ui` capability and list the `ui://` resource, yet never call `resources/read`, falling back to raw text). If a compliant host like the ext-apps basic-host renders your app but another client doesn't, the gap is on the client side, not in your server.
+:::
 
 ## See also
 

--- a/example/backend/__tests__/initializers/mcp.test.ts
+++ b/example/backend/__tests__/initializers/mcp.test.ts
@@ -174,6 +174,41 @@ describe("mcp initializer (enabled)", () => {
     expect(sessionId).toBeTruthy();
   });
 
+  test("initialize advertises the MCP Apps UI extension capability", async () => {
+    const res = await fetch(mcpUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "1.0.0" },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      result?: {
+        capabilities?: {
+          extensions?: Record<string, { mimeTypes?: string[] }>;
+        };
+      };
+    };
+    const ext = body.result?.capabilities?.extensions;
+    expect(ext?.["io.modelcontextprotocol/ui"]).toBeTruthy();
+    expect(ext?.["io.modelcontextprotocol/ui"]?.mimeTypes).toContain(
+      "text/html;profile=mcp-app",
+    );
+  });
+
   test("OPTIONS returns 204 with CORS headers", async () => {
     const res = await fetch(mcpUrl(), { method: "OPTIONS" });
     expect(res.status).toBe(204);
@@ -574,6 +609,10 @@ describe("mcp initializer (enabled)", () => {
         }>;
         expect(content[0].type).toBe("text");
         expect(content[0].text).toContain("is running");
+
+        // ext-apps hosts render the UI from `_meta.ui.resourceUri` + the `ui://`
+        // resource, so the content array stays text-only (no embedded resource).
+        expect(content.every((c) => c.type === "text")).toBe(true);
       });
     });
   });

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/mcpServer.ts
+++ b/packages/keryx/util/mcpServer.ts
@@ -363,9 +363,24 @@ export async function adoptMcpSession(
  * Actions with `mcp.tool === false` are excluded from tool registration.
  */
 export function createMcpServer(): McpServer {
+  // Advertise the MCP Apps UI extension so hosts negotiate UI support during
+  // `initialize` (spec 2026-01-26, SEP-1724). Only declared when at least one
+  // action ships a UI, keeping the capability surface minimal.
+  const hasUiActions = api.actions.actions.some((a: Action) => a.mcp?.ui);
   const mcpServer = new McpServer(
     { name: pkg.name, version: pkg.version },
-    { instructions: config.server.mcp.instructions },
+    {
+      instructions: config.server.mcp.instructions,
+      ...(hasUiActions
+        ? {
+            capabilities: {
+              extensions: {
+                [UI_EXTENSION_ID]: { mimeTypes: [MCP_APP_MIME_TYPE] },
+              },
+            },
+          }
+        : {}),
+    },
   );
 
   registerTools(mcpServer);
@@ -375,6 +390,12 @@ export function createMcpServer(): McpServer {
 
   return mcpServer;
 }
+
+/**
+ * MCP Apps extension identifier used for capability negotiation during `initialize`.
+ * @see https://github.com/modelcontextprotocol/ext-apps
+ */
+const UI_EXTENSION_ID = "io.modelcontextprotocol/ui";
 
 /**
  * Compute the `ui://` resource URI for an action's MCP App.
@@ -496,6 +517,8 @@ function registerTools(mcpServer: McpServer) {
 
           // MCP App responses carry both a text block (added to model context)
           // and structuredContent (delivered to the app UI for rendering).
+          // ext-apps hosts render the UI from the tool's `_meta.ui.resourceUri`
+          // and the separate `ui://` resource — the content array stays text-only.
           if (response instanceof UIResponse) {
             return {
               content: [{ type: "text" as const, text: response.text }],


### PR DESCRIPTION
## What & why

MCP App tools already declare `_meta.ui.resourceUri` and register a `ui://` HTML resource, but the server never advertised support for the **MCP Apps UI extension** during `initialize` — so it wasn't participating in capability negotiation (spec 2026-01-26, SEP-1724).

`createMcpServer()` now declares `capabilities.extensions["io.modelcontextprotocol/ui"]` (with the `text/html;profile=mcp-app` MIME) whenever at least one action declares `mcp.ui`, and stays minimal otherwise.

## Background (investigation)

This started from "MCP App UI doesn't render in Claude.app / Cursor." Findings:

- **Returning both `text` and `structuredContent` from `UIResponse` is not the cause** — that's the spec-intended shape; hosts render off `_meta.ui.resourceUri`, not the content array.
- **Cursor's non-render is a confirmed Cursor-side issue**, not ours: Cursor negotiates `io.modelcontextprotocol/ui` and lists the `ui://` resource but [never calls `resources/read`](https://forum.cursor.com/t/mcp-apps-client-stopped-issuing-resources-read-ui-widgets-dont-mount-regression-in-3-9-16/165222), falling back to raw text. Cursor's team confirmed inline rendering is server-side-flagged off for most sessions. Works in Cursor ≤ 3.9.8, the ext-apps basic-host, and Codex.
- An earlier revision of this PR also emitted the UI as an embedded `type:"resource"` content block (mcp-ui compatibility). **Reverted** — Cursor (and any client that stringifies unknown content blocks) dumps the raw HTML as visible text, which is strictly worse. keryx's ext-apps wiring is already correct; the gap is client-side.

So this PR keeps the correct ext-apps path untouched and only closes the capability-negotiation gap, plus documents that rendering is host-controlled.

## Changes

- `createMcpServer()` advertises the `io.modelcontextprotocol/ui` extension when any action has `mcp.ui`.
- Docs: a "Rendering is up to the host" note in the MCP Apps guide covering host-side gating / client regressions.
- Test: `initialize` advertises the capability with the correct MIME type.
- `keryx` `0.36.1 → 0.36.2`.

## Testing

- `bun lint` (tsc + biome) clean across all workspaces.
- `example/backend` MCP suite: **65 pass**.

## References

- [MCP Apps spec 2026-01-26](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx)
- [Cursor `resources/read` regression thread](https://forum.cursor.com/t/mcp-apps-client-stopped-issuing-resources-read-ui-widgets-dont-mount-regression-in-3-9-16/165222)
- [ext-apps #671 — Claude fetches but doesn't render](https://github.com/modelcontextprotocol/ext-apps/issues/671)

🤖 Generated with [Claude Code](https://claude.com/claude-code)