### PR TITLE
fix(mcp): don't leak an McpServer if session adoption fails partway

### DIFF
--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/mcpServer.ts
+++ b/packages/keryx/util/mcpServer.ts
@@ -324,21 +324,29 @@ export async function adoptMcpSession(
   const promise = (async () => {
     const mcpServer = createMcpServer();
     api.mcp.mcpServers.push(mcpServer);
+    try {
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: () => sessionId,
+        enableJsonResponse: true,
+        // Local registration only — no hooks, no registry write (see doc above).
+        onsessioninitialized: (sid) => {
+          api.mcp.transports.set(sid, { transport, clientId });
+        },
+        onsessionclosed: (sid) => terminateMcpSession(sid, mcpServer),
+      });
+      transport.onclose = () =>
+        forgetMcpSession(transport.sessionId, mcpServer);
 
-    const transport = new WebStandardStreamableHTTPServerTransport({
-      sessionIdGenerator: () => sessionId,
-      enableJsonResponse: true,
-      // Local registration only — no hooks, no registry write (see doc above).
-      onsessioninitialized: (sid) => {
-        api.mcp.transports.set(sid, { transport, clientId });
-      },
-      onsessionclosed: (sid) => terminateMcpSession(sid, mcpServer),
-    });
-    transport.onclose = () => forgetMcpSession(transport.sessionId, mcpServer);
-
-    await mcpServer.connect(transport);
-    await driveSyntheticInitialize(transport, protocolVersion);
-    return transport;
+      await mcpServer.connect(transport);
+      await driveSyntheticInitialize(transport, protocolVersion);
+      return transport;
+    } catch (e) {
+      // Adoption failed partway (e.g. the synthetic initialize errored) — drop
+      // the McpServer we optimistically registered so it can't linger in the
+      // broadcast list nor leave a half-initialized transport behind.
+      forgetMcpSession(sessionId, mcpServer);
+      throw e;
+    }
   })();
 
   adoptionsInFlight.set(sessionId, promise);


### PR DESCRIPTION
Small robustness follow-up to #504 (multi-node MCP sessions).

## Problem

`adoptMcpSession` pushes the newly-created `McpServer` onto `api.mcp.mcpServers` (the broadcast list used for PubSub notifications) *before* it connects the transport and drives the synthetic `initialize`. If either step throws — e.g. the synthetic initialize errors — the `McpServer` is left dangling in that list forever, and a half-initialized transport could remain.

## Fix

Wrap the adoption body in a `try/catch` that calls `forgetMcpSession(sessionId, mcpServer)` on failure (dropping it from both `mcpServers` and `transports`) before re-throwing. Happy path is unchanged.

This is an edge case — the synthetic initialize against a fresh in-process `McpServer` does not fail under normal operation — but it keeps a partial failure from leaking.

## Testing
- `example/backend` MCP suite: 64 pass / 0 fail; `packages/keryx` typecheck + biome clean.

Version bump 0.36.0 → 0.36.1 (patch, bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)