### PR TITLE
Populate typed structuredContent for the status:app MCP App

### DIFF
--- a/docs/guide/mcp-apps.md
+++ b/docs/guide/mcp-apps.md
@@ -93,6 +93,8 @@ new UIResponse(structuredContent, { text: "optional model-facing summary" });
 
 Over non-MCP transports (HTTP, WebSocket, CLI) a `UIResponse` serializes to its `structuredContent` via `toJSON()`, so the same action still returns useful JSON everywhere. A `GET` to the action's web route returns the structured object directly.
 
+`UIResponse` is generic over the shape of `structuredContent`. When you build one from an object literal, the field types are inferred and flow through to `run()`'s return type — and from there into the generated OpenAPI/MCP response schema, so the app UI has a fully-typed payload to bind against rather than an opaque object.
+
 ## The UI side
 
 Inside the HTML, talk to the host with the [`@modelcontextprotocol/ext-apps`](https://github.com/modelcontextprotocol/ext-apps) `App` class (a thin wrapper over the `ui/` `postMessage` protocol):

--- a/example/backend/__tests__/actions/mcp.test.ts
+++ b/example/backend/__tests__/actions/mcp.test.ts
@@ -69,11 +69,18 @@ describe("status:app (MCP App)", () => {
       version: string;
       uptime: number;
       consumedMemoryMB: number;
+      healthy: boolean;
+      checks: { database: boolean; redis: boolean };
     };
     expect(payload.name).toBeDefined();
     expect(typeof payload.pid).toBe("number");
     expect(payload.version).toBeDefined();
     expect(payload.uptime).toBeGreaterThanOrEqual(0);
     expect(payload.consumedMemoryMB).toBeGreaterThan(0);
+    // status:app now projects the same health field set as /status so the app
+    // UI has live runtime state to bind against, not just text.
+    expect(typeof payload.healthy).toBe("boolean");
+    expect(typeof payload.checks.database).toBe("boolean");
+    expect(typeof payload.checks.redis).toBe("boolean");
   });
 });

--- a/example/backend/__tests__/initializers/mcp.test.ts
+++ b/example/backend/__tests__/initializers/mcp.test.ts
@@ -599,9 +599,13 @@ describe("mcp initializer (enabled)", () => {
           "version",
           "uptime",
           "consumedMemoryMB",
+          "healthy",
+          "checks",
         ]) {
           expect(structured).toHaveProperty(key);
         }
+        expect(structured.checks).toHaveProperty("database");
+        expect(structured.checks).toHaveProperty("redis");
 
         const content = result.content as Array<{
           type: string;

--- a/example/backend/actions/mcp.ts
+++ b/example/backend/actions/mcp.ts
@@ -1,6 +1,7 @@
 import { Action, type ActionParams, api, HTTP_METHOD, UIResponse } from "keryx";
 import { z } from "zod";
 import pkg from "../package.json";
+import { checkDependencies } from "./status";
 
 /**
  * Exposes server status as an MCP resource at `keryx://status`.
@@ -108,6 +109,7 @@ export class StatusDashboardApp implements Action {
   async run() {
     const consumedMemoryMB =
       Math.round((process.memoryUsage().heapUsed / 1024 / 1024) * 100) / 100;
+    const { healthy, checks } = await checkDependencies();
 
     return new UIResponse(
       {
@@ -116,6 +118,8 @@ export class StatusDashboardApp implements Action {
         version: pkg.version,
         uptime: new Date().getTime() - api.bootTime,
         consumedMemoryMB,
+        healthy,
+        checks,
       },
       { text: `Server ${api.process.name} is running (v${pkg.version}).` },
     );

--- a/example/backend/actions/status-app.html
+++ b/example/backend/actions/status-app.html
@@ -11,6 +11,8 @@
       header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
       h1 { font-size: 1.1rem; margin: 0; }
       .pill { font-size: .75rem; padding: 2px 8px; border-radius: 999px; background: rgba(127,127,127,.18); }
+      .pill.healthy { background: rgba(40,167,69,.22); color: #1e7e34; }
+      .pill.unhealthy { background: rgba(220,53,69,.22); color: #c82333; }
       dl { display: grid; grid-template-columns: auto 1fr; gap: 6px 16px; margin: 0; }
       dt { color: rgba(127,127,127,.9); }
       dd { margin: 0; font-variant-numeric: tabular-nums; text-align: right; }
@@ -24,10 +26,13 @@
     <main>
       <header><h1>Server Status</h1><span id="name" class="pill">&mdash;</span></header>
       <dl>
+        <dt>Health</dt><dd id="health">&mdash;</dd>
         <dt>Process ID</dt><dd id="pid">&mdash;</dd>
         <dt>Version</dt><dd id="version">&mdash;</dd>
         <dt>Uptime</dt><dd id="uptime">&mdash;</dd>
         <dt>Memory</dt><dd id="memory">&mdash;</dd>
+        <dt>Database</dt><dd id="database">&mdash;</dd>
+        <dt>Redis</dt><dd id="redis">&mdash;</dd>
       </dl>
       <footer><button id="refresh">Refresh</button><span id="updated"></span></footer>
     </main>
@@ -45,6 +50,11 @@
         return `${h}h ${m}m ${s % 60}s`;
       }
 
+      function boolText(v) {
+        if (v == null) return "—";
+        return v ? "✓" : "✗";
+      }
+
       function render(data) {
         if (!data) return;
         el("name").textContent = data.name || "server";
@@ -53,6 +63,18 @@
         el("uptime").textContent = formatUptime(data.uptime);
         el("memory").textContent =
           data.consumedMemoryMB != null ? `${data.consumedMemoryMB} MB` : "—";
+
+        const health = el("health");
+        if (data.healthy == null) {
+          health.textContent = "—";
+          health.className = "pill";
+        } else {
+          health.textContent = data.healthy ? "Healthy" : "Unhealthy";
+          health.className = `pill ${data.healthy ? "healthy" : "unhealthy"}`;
+        }
+        el("database").textContent = boolText(data.checks?.database);
+        el("redis").textContent = boolText(data.checks?.redis);
+
         el("updated").textContent = `Updated ${new Date().toLocaleTimeString()}`;
       }
 

--- a/example/backend/actions/status.ts
+++ b/example/backend/actions/status.ts
@@ -3,7 +3,7 @@ import { Action, api, HTTP_METHOD, MCP_RESPONSE_FORMAT } from "keryx";
 import { z } from "zod";
 import pkg from "../package.json";
 
-async function checkDependencies() {
+export async function checkDependencies() {
   let databaseHealthy = false;
   try {
     if (api.db?.db) {

--- a/packages/keryx/__tests__/classes/UIResponse.test.ts
+++ b/packages/keryx/__tests__/classes/UIResponse.test.ts
@@ -29,4 +29,18 @@ describe("UIResponse", () => {
     // So HTTP/WS/CLI transports serialize the data, not { structuredContent, text }.
     expect(JSON.parse(JSON.stringify(res))).toEqual(data);
   });
+
+  test("infers the structuredContent shape as a type parameter", () => {
+    // The generic parameter flows the field types through to `run()`'s return
+    // type, which is what lets the swagger/MCP generator declare the fields.
+    const res = new UIResponse({ name: "server", pid: 42, healthy: true });
+    // Type-level check: these accesses only compile because T was inferred.
+    const name: string = res.structuredContent.name;
+    const pid: number = res.structuredContent.pid;
+    const healthy: boolean = res.structuredContent.healthy;
+    expect(name).toBe("server");
+    expect(pid).toBe(42);
+    expect(healthy).toBe(true);
+    expect(res.toJSON().name).toBe("server");
+  });
 });

--- a/packages/keryx/classes/UIResponse.ts
+++ b/packages/keryx/classes/UIResponse.ts
@@ -19,11 +19,18 @@
  * its `structuredContent` via {@link UIResponse.toJSON}, so the same action still
  * returns useful JSON everywhere.
  *
+ * The class is generic over the shape of `structuredContent`. When you construct a
+ * `UIResponse` from an object literal, `T` is inferred, so the field types flow through
+ * to the action's `run()` return type — and from there into the generated OpenAPI/MCP
+ * response schema, giving the app UI a fully-typed payload to bind against.
+ *
  * Use the static factory {@link UIResponse.from} or the constructor directly.
  */
-export class UIResponse {
+export class UIResponse<
+  T extends Record<string, unknown> = Record<string, unknown>,
+> {
   /** Structured data delivered to the app UI for rendering (not added to model context). */
-  readonly structuredContent: Record<string, unknown>;
+  readonly structuredContent: T;
   /**
    * Text representation added to the model's context. Defaults to
    * `JSON.stringify(structuredContent)` when not provided.
@@ -33,15 +40,12 @@ export class UIResponse {
   /**
    * @param structuredContent - The structured data the app UI will render. Must be a
    *   JSON-serializable object; it is delivered to the app verbatim and is not added to
-   *   the model's context.
+   *   the model's context. Its shape is captured as `T` so downstream schemas stay typed.
    * @param options - Optional model-facing text.
    * @param options.text - Text representation added to the model's context. When omitted,
    *   defaults to `JSON.stringify(structuredContent)`.
    */
-  constructor(
-    structuredContent: Record<string, unknown>,
-    options?: { text?: string },
-  ) {
+  constructor(structuredContent: T, options?: { text?: string }) {
     this.structuredContent = structuredContent;
     this.text = options?.text ?? JSON.stringify(structuredContent);
   }
@@ -51,12 +55,12 @@ export class UIResponse {
    *
    * @param structuredContent - The structured data the app UI will render.
    * @param options - Optional model-facing text (see the constructor).
-   * @returns A new `UIResponse`.
+   * @returns A new `UIResponse` whose `structuredContent` type is inferred from the argument.
    */
-  static from(
-    structuredContent: Record<string, unknown>,
+  static from<T extends Record<string, unknown>>(
+    structuredContent: T,
     options?: { text?: string },
-  ): UIResponse {
+  ): UIResponse<T> {
     return new UIResponse(structuredContent, options);
   }
 
@@ -66,7 +70,7 @@ export class UIResponse {
    *
    * @returns The `structuredContent` object.
    */
-  toJSON(): Record<string, unknown> {
+  toJSON(): T {
     return this.structuredContent;
   }
 }

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.36.2",
+  "version": "0.37.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/swaggerSchemaGenerator.ts
+++ b/packages/keryx/util/swaggerSchemaGenerator.ts
@@ -134,6 +134,10 @@ export function typeToJsonSchema(
 
       if (!propType) continue;
 
+      // Skip methods — they are not JSON-serializable data and would otherwise
+      // leak into the response schema as empty objects (e.g. a `toJSON` helper).
+      if (propType.getCallSignatures().length > 0) continue;
+
       properties[propName] = typeToJsonSchema(propType, newVisited);
 
       // Check if property is optional


### PR DESCRIPTION
## Problem

The `status:app` MCP App action returned a `UIResponse` whose `structuredContent` was typed as `Record<string, unknown>`. Two consequences:

1. The generated response schema had no declared properties, so `status_app_Response.structuredContent` in `/swagger` was an opaque object — the widget had nothing to bind beyond `text`.
2. `status:app` projected fewer fields than `/status` and `/status/markdown`, which return the full field set (`healthy`, `checks.{database,redis}`).

## Changes

- **`UIResponse` is now generic** over its `structuredContent` shape (`UIResponse<T extends Record<string, unknown>>`). When built from an object literal, `T` is inferred and flows through `run()`'s return type into the generated OpenAPI/MCP schema, so the app UI has a fully-typed payload to bind against. Backward compatible via the default type parameter.
- **`status:app` now projects the full health field set** (`healthy` + `checks`), matching `/status`. `checkDependencies()` is exported from the example `status` action and reused so there's a single source of truth.
- **The status-app widget binds the new fields** — it now renders a Healthy/Unhealthy pill plus Database and Redis check rows.
- **The swagger schema generator skips method-typed properties** (e.g. `toJSON`), which previously leaked into response schemas as empty objects.
- Bumped `keryx` to `0.37.0`.

### Verified schema (`status_app_Response.structuredContent`)

Regenerating the swagger schema against the example backend now yields declared properties for `name`, `pid`, `version`, `uptime`, `consumedMemoryMB`, `healthy`, and `checks` (with `database`/`redis`), all marked required.

## Tests

- `UIResponse.test.ts`: added a case asserting the inferred `structuredContent` type flows through.
- `mcp.test.ts` (actions + initializers): assert `status:app` returns `healthy` and `checks.{database,redis}` over both HTTP and MCP.

Framework and example-backend `tsc` both pass. Backend integration tests require Postgres/Redis and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Wn8aNn9x2rp3tYD78UG9F

---
_Generated by [Claude Code](https://claude.ai/code/session_013Wn8aNn9x2rp3tYD78UG9F)_