### PR TITLE
fix(mcp): hydrate bundled status app dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "@keryxjs/csrf": "workspace:*",
         "@keryxjs/resque-admin": "workspace:*",
         "@keryxjs/tracing": "workspace:*",
+        "@modelcontextprotocol/ext-apps": "^1.7.4",
         "commander": "^14.0.3",
         "drizzle-orm": "^0.45.2",
         "drizzle-zod": "^0.8.3",
@@ -71,7 +72,7 @@
     },
     "packages/keryx": {
       "name": "keryx",
-      "version": "0.30.0",
+      "version": "0.37.1",
       "bin": {
         "keryx": "keryx.ts",
       },
@@ -102,7 +103,7 @@
     },
     "packages/plugins/csrf": {
       "name": "@keryxjs/csrf",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "devDependencies": {
         "@types/bun": "^1.3.12",
         "typescript": "^6.0.3",
@@ -115,7 +116,7 @@
     },
     "packages/plugins/resque-admin": {
       "name": "@keryxjs/resque-admin",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "devDependencies": {
         "@types/bun": "^1.3.12",
         "typescript": "^6.0.3",
@@ -128,7 +129,7 @@
     },
     "packages/plugins/tracing": {
       "name": "@keryxjs/tracing",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@kubiks/otel-drizzle": "^2.1.0",
         "@opentelemetry/core": "^1.30.0",
@@ -384,6 +385,8 @@
     "@lezer/yaml": ["@lezer/yaml@1.0.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.4.0" } }, "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw=="],
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
+
+    "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@1.7.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 

--- a/docs/guide/mcp-apps.md
+++ b/docs/guide/mcp-apps.md
@@ -104,19 +104,21 @@ import { App } from "@modelcontextprotocol/ext-apps";
 
 const app = new App({ name: "Server Status", version: "1.0.0" });
 
-// The host pushes this tool's structuredContent when the app first renders.
+// Register handlers BEFORE connect(). The host pushes this tool's result after
+// the ui/initialize handshake — but some hosts miss that window, so also hydrate
+// yourself once connect() resolves.
 app.ontoolresult = (result) => render(result.structuredContent);
 
-// Proactively call any tool on your Keryx server.
 async function refresh() {
   const result = await app.callServerTool({ name: "status", arguments: {} });
   render(result.structuredContent);
 }
 
-app.connect();
+await app.connect();
+await refresh(); // reliable first paint even if ontoolresult never fired
 ```
 
-Because every Keryx action is already a tool, your app can call any of them with `callServerTool` — no separate API to build.
+Because every Keryx action is already a tool, your app can call any of them with `callServerTool` — no separate API to build. JSON object tool results include `structuredContent` automatically, so apps can bind without `JSON.parse`.
 
 ## `McpUiConfig` options
 

--- a/example/backend/__tests__/initializers/mcp.test.ts
+++ b/example/backend/__tests__/initializers/mcp.test.ts
@@ -541,6 +541,14 @@ describe("mcp initializer (enabled)", () => {
       const parsed = JSON.parse(content[0].text!);
       expect(parsed).toHaveProperty("name");
       expect(typeof parsed).toBe("object");
+
+      // Plain object JSON tools also expose structuredContent so MCP Apps can
+      // bind without JSON.parse (e.g. status-app's Refresh button).
+      const structured = result.structuredContent as Record<string, unknown>;
+      expect(structured).toBeTruthy();
+      expect(structured).toHaveProperty("name");
+      expect(structured).toHaveProperty("pid");
+      expect(structured).toHaveProperty("healthy");
     });
 
     test("tool invocation with missing required param returns isError", async () => {
@@ -578,10 +586,12 @@ describe("mcp initializer (enabled)", () => {
         expect(content.mimeType).toBe("text/html;profile=mcp-app");
         const text = (content as { text: string }).text;
         expect(text).toContain("<!doctype html>");
-        expect(text).toContain("ext-apps");
+        expect(text).toContain("ui/initialize");
+        expect(text).not.toContain("STATUS_APP_CLIENT");
+        expect(text).not.toContain("https://esm.sh");
         const ui = (content._meta as any)?.ui;
         expect(ui?.prefersBorder).toBe(true);
-        expect(ui?.csp?.resourceDomains).toContain("https://esm.sh");
+        expect(ui?.csp).toBeUndefined();
       });
 
       test("app tool call returns structuredContent plus a text summary", async () => {

--- a/example/backend/actions/mcp.ts
+++ b/example/backend/actions/mcp.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { Action, type ActionParams, api, HTTP_METHOD, UIResponse } from "keryx";
 import { z } from "zod";
 import pkg from "../package.json";
@@ -68,20 +69,33 @@ export class GreetingPrompt implements Action {
 }
 
 /**
- * Self-contained HTML for the Server Status MCP App, loaded from a sibling `.html` file.
+ * Self-contained HTML for the Server Status MCP App.
  *
- * Keryx never reads files for you — a `UIResponse` action just needs an HTML string — so we
- * read it ourselves at module load. Keeping the UI in its own `.html` file gives you real
- * editor support (syntax highlighting, formatting) instead of a giant template literal.
- *
- * `status-app.html` uses the `@modelcontextprotocol/ext-apps` `App` class (loaded from a CDN,
- * hence the `csp.resourceDomains` allowance below) to talk to the host over postMessage.
- * Production apps typically bundle their UI (e.g. Vite + vite-plugin-singlefile) and read the
- * built single-file HTML here instead.
+ * Keryx accepts an HTML string and does not prescribe a build system. This example bundles
+ * the typed client and `@modelcontextprotocol/ext-apps` into its HTML at module load so the
+ * sandbox does not need network access or CSP allowances.
  */
-const STATUS_DASHBOARD_HTML = await Bun.file(
+const statusDashboardTemplate = await Bun.file(
   new URL("./status-app.html", import.meta.url),
 ).text();
+const statusClientBuild = await Bun.build({
+  entrypoints: [
+    fileURLToPath(new URL("../ui/status-app-client.ts", import.meta.url)),
+  ],
+  target: "browser",
+  format: "esm",
+  minify: true,
+});
+if (!statusClientBuild.success || !statusClientBuild.outputs[0]) {
+  throw new Error(
+    `Could not build status app client: ${statusClientBuild.logs.join("\n")}`,
+  );
+}
+const statusClientScript = await statusClientBuild.outputs[0].text();
+const STATUS_DASHBOARD_HTML = statusDashboardTemplate.replace(
+  "/* STATUS_APP_CLIENT */",
+  () => statusClientScript,
+);
 
 /**
  * An MCP App: a tool that renders live server status as an interactive dashboard.
@@ -99,8 +113,6 @@ export class StatusDashboardApp implements Action {
     tool: true,
     ui: {
       html: STATUS_DASHBOARD_HTML,
-      // The UI imports the ext-apps App class from a CDN, so allow it in the app's CSP.
-      csp: { resourceDomains: ["https://esm.sh"] },
       prefersBorder: true,
     },
   };

--- a/example/backend/actions/status-app.html
+++ b/example/backend/actions/status-app.html
@@ -20,6 +20,7 @@
       button { padding: 6px 12px; border-radius: 8px; border: 1px solid rgba(127,127,127,.4); background: transparent; color: inherit; cursor: pointer; }
       button:disabled { opacity: .5; cursor: default; }
       #updated { font-size: .75rem; color: rgba(127,127,127,.9); }
+      #updated.error { color: #c82333; }
     </style>
   </head>
   <body>
@@ -36,71 +37,6 @@
       </dl>
       <footer><button id="refresh">Refresh</button><span id="updated"></span></footer>
     </main>
-    <script type="module">
-      import { App } from "https://esm.sh/@modelcontextprotocol/ext-apps";
-
-      const app = new App({ name: "Server Status", version: "1.0.0" });
-      const el = (id) => document.getElementById(id);
-
-      function formatUptime(ms) {
-        if (ms == null) return "—";
-        const s = Math.floor(ms / 1000);
-        const h = Math.floor(s / 3600);
-        const m = Math.floor((s % 3600) / 60);
-        return `${h}h ${m}m ${s % 60}s`;
-      }
-
-      function boolText(v) {
-        if (v == null) return "—";
-        return v ? "✓" : "✗";
-      }
-
-      function render(data) {
-        if (!data) return;
-        el("name").textContent = data.name || "server";
-        el("pid").textContent = data.pid != null ? String(data.pid) : "—";
-        el("version").textContent = data.version || "—";
-        el("uptime").textContent = formatUptime(data.uptime);
-        el("memory").textContent =
-          data.consumedMemoryMB != null ? `${data.consumedMemoryMB} MB` : "—";
-
-        const health = el("health");
-        if (data.healthy == null) {
-          health.textContent = "—";
-          health.className = "pill";
-        } else {
-          health.textContent = data.healthy ? "Healthy" : "Unhealthy";
-          health.className = `pill ${data.healthy ? "healthy" : "unhealthy"}`;
-        }
-        el("database").textContent = boolText(data.checks?.database);
-        el("redis").textContent = boolText(data.checks?.redis);
-
-        el("updated").textContent = `Updated ${new Date().toLocaleTimeString()}`;
-      }
-
-      // The host pushes this tool's structuredContent when the app first renders.
-      app.ontoolresult = (result) => render(result.structuredContent);
-
-      // The Refresh button proactively re-calls the `status` tool on the server.
-      el("refresh").addEventListener("click", async () => {
-        el("refresh").disabled = true;
-        try {
-          const result = await app.callServerTool({ name: "status", arguments: {} });
-          let data = result.structuredContent;
-          if (!data && result.content && result.content[0]) {
-            try {
-              data = JSON.parse(result.content[0].text);
-            } catch {
-              data = null;
-            }
-          }
-          render(data);
-        } finally {
-          el("refresh").disabled = false;
-        }
-      });
-
-      app.connect();
-    </script>
+    <script type="module">/* STATUS_APP_CLIENT */</script>
   </body>
 </html>

--- a/example/backend/package.json
+++ b/example/backend/package.json
@@ -14,8 +14,8 @@
     "dev": "bun --watch keryx.ts start",
     "migrations": "bun run migrations.ts",
     "benchmark": "bun test __tests__/benchmark/",
-    "lint": "tsc && biome check .",
-    "format": "tsc && biome check --write ."
+    "lint": "tsc && tsc -p ui && biome check .",
+    "format": "tsc && tsc -p ui && biome check --write ."
   },
   "dependencies": {
     "@keryxjs/csrf": "workspace:*",

--- a/example/backend/package.json
+++ b/example/backend/package.json
@@ -21,10 +21,11 @@
     "@keryxjs/csrf": "workspace:*",
     "@keryxjs/resque-admin": "workspace:*",
     "@keryxjs/tracing": "workspace:*",
-    "keryx": "workspace:*",
+    "@modelcontextprotocol/ext-apps": "^1.7.4",
     "commander": "^14.0.3",
     "drizzle-orm": "^0.45.2",
     "drizzle-zod": "^0.8.3",
+    "keryx": "workspace:*",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/example/backend/ui/status-app-client.ts
+++ b/example/backend/ui/status-app-client.ts
@@ -1,0 +1,124 @@
+/// <reference lib="dom" />
+
+import { App } from "@modelcontextprotocol/ext-apps";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+type StatusData = {
+  name?: string;
+  pid?: number;
+  version?: string;
+  uptime?: number;
+  consumedMemoryMB?: number;
+  healthy?: boolean;
+  checks?: {
+    database?: boolean;
+    redis?: boolean;
+  };
+};
+
+const app = new App({ name: "Server Status", version: "1.0.0" });
+const element = (id: string) => document.getElementById(id)!;
+let rendered = false;
+
+function formatUptime(ms: number | undefined) {
+  if (ms == null) return "—";
+  const seconds = Math.floor(ms / 1000);
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  return `${hours}h ${minutes}m ${seconds % 60}s`;
+}
+
+function boolText(value: boolean | undefined) {
+  if (value == null) return "—";
+  return value ? "✓" : "✗";
+}
+
+function extractData(result: CallToolResult): StatusData | null {
+  if (
+    result.structuredContent &&
+    typeof result.structuredContent === "object"
+  ) {
+    return result.structuredContent as StatusData;
+  }
+
+  const content = result.content[0];
+  const text = content?.type === "text" ? content.text : undefined;
+  if (text) {
+    try {
+      const parsed: unknown = JSON.parse(text);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as StatusData;
+      }
+    } catch {
+      // The model-facing summary is not necessarily JSON.
+    }
+  }
+
+  return null;
+}
+
+function render(data: StatusData | null) {
+  if (!data) return false;
+  element("name").textContent = data.name || "server";
+  element("pid").textContent = data.pid != null ? String(data.pid) : "—";
+  element("version").textContent = data.version || "—";
+  element("uptime").textContent = formatUptime(data.uptime);
+  element("memory").textContent =
+    data.consumedMemoryMB != null ? `${data.consumedMemoryMB} MB` : "—";
+
+  const health = element("health");
+  if (data.healthy == null) {
+    health.textContent = "—";
+    health.className = "";
+  } else {
+    health.textContent = data.healthy ? "Healthy" : "Unhealthy";
+    health.className = `pill ${data.healthy ? "healthy" : "unhealthy"}`;
+  }
+  element("database").textContent = boolText(data.checks?.database);
+  element("redis").textContent = boolText(data.checks?.redis);
+
+  const updated = element("updated");
+  updated.className = "";
+  updated.textContent = `Updated ${new Date().toLocaleTimeString()}`;
+  rendered = true;
+  return true;
+}
+
+function showError(error: unknown) {
+  const updated = element("updated");
+  updated.className = "error";
+  updated.textContent =
+    error instanceof Error ? error.message : "Failed to load status";
+}
+
+async function fetchStatus() {
+  const result = await app.callServerTool({ name: "status", arguments: {} });
+  if (!render(extractData(result))) {
+    throw new Error("Status tool returned no renderable data");
+  }
+}
+
+// Register one-shot handlers before connect so the host cannot race them.
+app.ontoolresult = (result) => {
+  render(extractData(result));
+};
+app.onerror = showError;
+
+element("refresh").addEventListener("click", async () => {
+  element("refresh").setAttribute("disabled", "");
+  try {
+    await fetchStatus();
+  } catch (error) {
+    showError(error);
+  } finally {
+    element("refresh").removeAttribute("disabled");
+  }
+});
+
+try {
+  await app.connect();
+  // Cursor may not replay the original result after the app handshake.
+  if (!rendered) await fetchStatus();
+} catch (error) {
+  showError(error);
+}

--- a/example/backend/ui/status-app-client.ts
+++ b/example/backend/ui/status-app-client.ts
@@ -1,5 +1,3 @@
-/// <reference lib="dom" />
-
 import { App } from "@modelcontextprotocol/ext-apps";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 

--- a/example/backend/ui/tsconfig.json
+++ b/example/backend/ui/tsconfig.json
@@ -1,15 +1,16 @@
 {
+  // Browser code for MCP Apps. Kept as a separate TS project so the DOM lib
+  // doesn't leak into the server program (which uses Bun's WebSocket types).
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "types": ["bun"],
+    "types": [],
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "noImplicitAny": true,
@@ -17,9 +18,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "forceConsistentCasingInFileNames": true,
-    "allowImportingTsExtensions": true
+    "forceConsistentCasingInFileNames": true
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "drizzle", "ui"]
+  "include": ["**/*.ts"]
 }

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/mcpServer.ts
+++ b/packages/keryx/util/mcpServer.ts
@@ -534,8 +534,19 @@ function registerTools(mcpServer: McpServer) {
                 })
               : JSON.stringify(response);
 
+          // Promote plain object responses to structuredContent so MCP Apps can
+          // bind without JSON.parse (same shape UIResponse already provides).
+          const structuredContent =
+            format === MCP_RESPONSE_FORMAT.JSON &&
+            response !== null &&
+            typeof response === "object" &&
+            !Array.isArray(response)
+              ? (response as Record<string, unknown>)
+              : undefined;
+
           return {
             content: [{ type: "text" as const, text }],
+            ...(structuredContent ? { structuredContent } : {}),
           };
         } finally {
           connection.destroy();


### PR DESCRIPTION
## Summary
- bundle the MCP Apps browser client into the status dashboard so sandboxed hosts do not depend on a CDN
- self-hydrate after the app handshake and surface refresh/connect failures
- expose plain JSON object tool responses as `structuredContent` for app callers
- isolate the browser client in its own DOM-enabled TypeScript project so DOM types do not override Bun's server-side `WebSocket` types
- update MCP Apps guidance and bump Keryx to 0.37.1

## Testing
- `bun lint-package`
- `bun lint-example-backend`
- `cd example/backend && bun test __tests__/initializers/mcp.test.ts __tests__/actions/mcp.test.ts` (69 passed)
- `bun test-docs` (24 passed)
- `bun test-package` (804 passed; scaffold teardown timed out once)
- `cd packages/keryx && bun test __tests__/scaffold-e2e.test.ts` (3 passed on retry)
- manually verified `status-app` renders and hydrates in Cursor after reconnecting the MCP server