### PR TITLE
chore(deps): upgrade TypeScript to 7.0.2, refresh drizzle pins

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@types/bun": "^1.3.12",
         "drizzle-kit": "^0.31.10",
-        "typescript": "^6.0.3",
+        "typescript": "^7.0.2",
       },
     },
     "example/frontend": {
@@ -66,13 +66,13 @@
         "bootstrap": "^5.3.3",
         "bootswatch": "^5.3.3",
         "sass": "^1.99.0",
-        "typescript": "^6.0.3",
+        "typescript": "^7.0.2",
         "vite": "^8.0.9",
       },
     },
     "packages/keryx": {
       "name": "keryx",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "bin": {
         "keryx": "keryx.ts",
       },
@@ -88,7 +88,7 @@
         "node-resque": "^9.5.2",
         "pg": "^8.20.0",
         "ts-morph": "^28.0.0",
-        "typescript": "^6.0.3",
+        "typescript": "^7.0.2",
       },
       "devDependencies": {
         "@types/bun": "^1.3.12",
@@ -110,7 +110,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.12",
-        "typescript": "^6.0.3",
+        "typescript": "^7.0.2",
         "zod": "^4.3.6",
       },
       "peerDependencies": {
@@ -122,7 +122,7 @@
       "version": "0.1.3",
       "devDependencies": {
         "@types/bun": "^1.3.12",
-        "typescript": "^6.0.3",
+        "typescript": "^7.0.2",
         "zod": "^4.3.6",
       },
       "peerDependencies": {
@@ -135,7 +135,7 @@
       "version": "0.1.4",
       "devDependencies": {
         "@types/bun": "^1.3.12",
-        "typescript": "^6.0.3",
+        "typescript": "^7.0.2",
         "zod": "^4.3.6",
       },
       "peerDependencies": {
@@ -158,7 +158,7 @@
         "@opentelemetry/api": "^1.9.1",
         "@types/bun": "^1.3.12",
         "ioredis": "^5.10.1",
-        "typescript": "^6.0.3",
+        "typescript": "^7.0.2",
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -693,6 +693,46 @@
     "@types/warning": ["@types/warning@3.0.4", "", {}, "sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg=="],
 
     "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
@@ -1544,7 +1584,7 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -1727,6 +1767,8 @@
     "make-asynchronous/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "neverpanic/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 

--- a/example/backend/package.json
+++ b/example/backend/package.json
@@ -36,6 +36,6 @@
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@types/bun": "^1.3.12",
     "drizzle-kit": "^0.31.10",
-    "typescript": "^6.0.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/example/frontend/package.json
+++ b/example/frontend/package.json
@@ -28,7 +28,7 @@
     "bootstrap": "^5.3.3",
     "bootswatch": "^5.3.3",
     "sass": "^1.99.0",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vite": "^8.0.9"
   }
 }

--- a/example/frontend/src/pages/HomePage.tsx
+++ b/example/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,3 @@
-import { Button } from "react-bootstrap";
 import { Link } from "react-router-dom";
 
 import { useAuth } from "../hooks/useAuth";
@@ -15,22 +14,17 @@ export default function HomePage() {
         for realtime AI, CLI, and web applications.
       </p>
       {user ? (
-        <Button as={Link as never} to="/chat" variant="primary" size="lg">
+        <Link to="/chat" className="btn btn-primary btn-lg">
           Open Chat
-        </Button>
+        </Link>
       ) : (
         <div className="d-flex gap-3 justify-content-center">
-          <Button as={Link as never} to="/sign-in" variant="primary" size="lg">
+          <Link to="/sign-in" className="btn btn-primary btn-lg">
             Sign In
-          </Button>
-          <Button
-            as={Link as never}
-            to="/sign-up"
-            variant="outline-primary"
-            size="lg"
-          >
+          </Link>
+          <Link to="/sign-up" className="btn btn-outline-primary btn-lg">
             Sign Up
-          </Button>
+          </Link>
         </div>
       )}
     </div>

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",
@@ -92,7 +92,7 @@
     "node-resque": "^9.5.2",
     "pg": "^8.20.0",
     "ts-morph": "^28.0.0",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "commander": "^14.0.3",
     "@types/mustache": "^4.2.6",
     "@types/pg": "^8.20.0"

--- a/packages/keryx/util/scaffold.ts
+++ b/packages/keryx/util/scaffold.ts
@@ -325,7 +325,7 @@ export async function scaffoldProject(
           zod: "^4.3.6",
           ...(options.includeDb
             ? {
-                "drizzle-orm": "^0.45.1",
+                "drizzle-orm": "^0.45.2",
                 "drizzle-zod": "^0.8.3",
               }
             : {}),
@@ -333,7 +333,7 @@ export async function scaffoldProject(
         devDependencies: {
           "@biomejs/biome": "^2.4.8",
           "@types/bun": "latest",
-          ...(options.includeDb ? { "drizzle-kit": "^0.20.18" } : {}),
+          ...(options.includeDb ? { "drizzle-kit": "^0.31.10" } : {}),
         },
       },
       null,

--- a/packages/mcpApp/package.json
+++ b/packages/mcpApp/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.12",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "zod": "^4.3.6"
   },
   "scripts": {

--- a/packages/plugins/csrf/package.json
+++ b/packages/plugins/csrf/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.12",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "zod": "^4.3.6"
   },
   "scripts": {

--- a/packages/plugins/resque-admin/package.json
+++ b/packages/plugins/resque-admin/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.12",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "zod": "^4.3.6"
   },
   "scripts": {

--- a/packages/plugins/tracing/package.json
+++ b/packages/plugins/tracing/package.json
@@ -54,7 +54,7 @@
     "@opentelemetry/api": "^1.9.1",
     "@types/bun": "^1.3.12",
     "ioredis": "^5.10.1",
-    "typescript": "^6.0.3"
+    "typescript": "^7.0.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Upgrades `typescript` `^6.0.3` → `^7.0.2` (TS 7, the native compiler) across every workspace; TypeScript is used purely as a type-checker (`tsc`, `noEmit`), so this only affects the lint/typecheck gate. Drizzle is already at its latest stable (`drizzle-orm@0.45.2`, `drizzle-kit@0.31.10`, `drizzle-zod@0.8.3`), so this also refreshes the stale drizzle versions baked into the scaffold generator (`drizzle-orm ^0.45.1`→`^0.45.2`, `drizzle-kit ^0.20.18`→`^0.31.10`). Running `tsc` under TS 7 surfaced pre-existing frontend type errors on `HomePage`, where `as={Link as never}` on a react-bootstrap `Button` silently disabled prop checking — replaced with a React Router `Link` styled via Bootstrap `.btn` classes (type-safe, identical client-side routing and styling). Bumps `keryx` to `0.38.1`. `bun lint` (tsc + biome) passes clean across all workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)