### PR TITLE
fix(scaffold): fresh `keryx new` apps pass their own `bun run lint`

### DIFF
--- a/packages/keryx/__tests__/scaffold.test.ts
+++ b/packages/keryx/__tests__/scaffold.test.ts
@@ -85,6 +85,24 @@ describe("scaffoldProject", () => {
     expect(pkg.dependencies["drizzle-orm"]).toBeDefined();
     expect(pkg.dependencies["drizzle-zod"]).toBeDefined();
     expect(pkg.devDependencies["drizzle-kit"]).toBeDefined();
+    // `lint`/`format` run `tsc`, so a fresh app must ship its own typescript (#510)
+    expect(pkg.devDependencies.typescript).toBeDefined();
+  });
+
+  test("tsconfig types match the @types/bun package (#510)", async () => {
+    await scaffoldProject("ts-project", targetDir("ts-project"), {
+      includeDb: true,
+      includeExample: true,
+    });
+
+    const tsconfig = JSON.parse(
+      fs.readFileSync(
+        path.join(targetDir("ts-project"), "tsconfig.json"),
+        "utf-8",
+      ),
+    );
+    // `@types/bun` provides the `bun` types package, not `bun-types`
+    expect(tsconfig.compilerOptions.types).toEqual(["bun"]);
   });
 
   test("skips db files when includeDb is false", async () => {

--- a/packages/keryx/initializers/actionts.ts
+++ b/packages/keryx/initializers/actionts.ts
@@ -676,7 +676,7 @@ export class Actions extends Initializer {
       details.queues[queue] = { length: length };
     }
 
-    details.leader = await api.resque.queue.leader();
+    details.leader = (await api.resque.queue.leader()) ?? "";
 
     return details;
   };

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/scaffold.ts
+++ b/packages/keryx/util/scaffold.ts
@@ -173,7 +173,7 @@ export function generateTsconfigContents(): string {
           target: "ESNext",
           module: "ESNext",
           moduleResolution: "bundler",
-          types: ["bun-types"],
+          types: ["bun"],
           strict: true,
           skipLibCheck: true,
           noEmit: true,
@@ -333,6 +333,7 @@ export async function scaffoldProject(
         devDependencies: {
           "@biomejs/biome": "^2.4.8",
           "@types/bun": "latest",
+          typescript: "^7.0.2",
           ...(options.includeDb ? { "drizzle-kit": "^0.31.10" } : {}),
         },
       },


### PR DESCRIPTION
A freshly scaffolded `keryx new` app could not pass its own `lint` (`tsc && biome check .`) out of the box: the generated `package.json` omitted a `typescript` devDependency even though `lint` runs `tsc`, and the generated `tsconfig.json` set `types: ["bun-types"]` while the devDeps ship `@types/bun` (which provides the `bun` types package), so `tsc` could not resolve the type definitions. This adds `typescript` to the scaffold's devDependencies and switches the generated tsconfig to `types: ["bun"]`, plus defensively coalesces `api.resque.queue.leader()` (historically `string | null`) to `""` in `taskDetails()`. New scaffold-test assertions cover the typescript devDep and the tsconfig `types` value; the stale `drizzle-kit` pin called out in the issue was already refreshed in #511. Version bumped 0.38.1 → 0.38.2.

closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)