### PR TITLE
test(web): path-traversal exploit regression tests for static files

### DIFF
--- a/packages/keryx/__tests__/util/webStaticFiles.test.ts
+++ b/packages/keryx/__tests__/util/webStaticFiles.test.ts
@@ -51,6 +51,9 @@ beforeAll(() => {
     path.join(secretDir, "secret.txt"),
     path.join(staticDir, "evil-link.txt"),
   );
+  // A symlinked *directory* pointing outside staticDir — traversal must be
+  // caught when the escape happens mid-path, not just on a leaf file symlink.
+  fs.symlinkSync(secretDir, path.join(staticDir, "evil-dir"));
 });
 
 afterAll(() => {
@@ -68,6 +71,7 @@ afterAll(() => {
     force: true,
   });
   fs.rmSync(path.join(staticDir, "evil-link.txt"), { force: true });
+  fs.rmSync(path.join(staticDir, "evil-dir"), { force: true });
   fs.rmSync(secretDir, { recursive: true, force: true });
 });
 
@@ -199,6 +203,49 @@ describe("static file path traversal", () => {
     const body = await res.text();
     expect(res.status).toBe(404);
     expect(body).not.toContain(SECRET);
+  });
+
+  test("rejects symlinked directory escape (raw socket)", async () => {
+    // /evil-dir is a symlink to a directory outside staticDir. The escape
+    // happens mid-path, so the leaf exists but realpath resolution must catch it.
+    const res = await fetch(getUrl() + "/evil-dir/secret.txt");
+    const body = await res.text();
+    expect(res.status).toBe(404);
+    expect(body).not.toContain(SECRET);
+  });
+
+  test("rejects dot-dot-slash filter bypass ....// (raw socket)", async () => {
+    // Defeats naive `../` -> `` string strippers, which would leave `../`.
+    // Real canonicalization (path.resolve) treats `....` as a literal segment.
+    const { status, body } = await rawGet("/....//....//package.json");
+    expect(status).toBe(404);
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain('"name": "keryx"');
+  });
+
+  test("rejects overlong UTF-8 %c0%ae traversal (raw socket)", async () => {
+    // Classic IIS/Unicode overlong-encoding of `.`; keryx never percent-decodes,
+    // so the sequence stays literal and never forms `..`.
+    const { status, body } = await rawGet("/%c0%ae%c0%ae/package.json");
+    expect([400, 404]).toContain(status);
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain('"name": "keryx"');
+  });
+
+  test("rejects encoded backslash ..%5c traversal (raw socket)", async () => {
+    const { status, body } = await rawGet("/..%5c..%5cpackage.json");
+    expect(status).toBe(404);
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain('"name": "keryx"');
+  });
+
+  test("rejects the reported ActionHero-shaped payload (raw socket)", async () => {
+    // Mirrors the CVE PoC shape: <staticRoot>/../../etc/passwd. The path starts
+    // with the static dir name but the escape is caught after canonicalization.
+    const staticDirName = path.basename(staticDir);
+    const { status, body } = await rawGet(`/${staticDirName}/../../etc/passwd`);
+    expect(status).toBe(404);
+    expect(body).not.toContain("root:");
   });
 });
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/webStaticFiles.ts
+++ b/packages/keryx/util/webStaticFiles.ts
@@ -55,7 +55,10 @@ export async function handleStaticFile(
     const fullPath = path.resolve(path.join(staticDir, finalPath));
     const basePath = path.resolve(staticDir);
 
-    // Prevent path traversal attacks (e.g. symlinks or encoded sequences)
+    // Reject anything that escapes the static root after lexical normalization
+    // (path.resolve collapses `..`/`.` segments). Symlink escapes are caught
+    // separately by resolveWithinStaticRoot below; encoded sequences (e.g.
+    // %2e%2e) are never decoded, so they stay literal and cannot form `..`.
     if (!fullPath.startsWith(basePath + path.sep) && fullPath !== basePath) {
       return null;
     }


### PR DESCRIPTION
Adds path-traversal exploit regression tests confirming keryx's static file handler is **not** vulnerable to the ActionHero 29.3.4 WebSocket path-traversal class (CWE-22) — keryx has no WebSocket file vector, and its HTTP static handler canonicalizes with `path.resolve` before the containment check plus a `realpath` symlink guard. New negative tests cover a symlinked-directory escape, the `....//` filter bypass, overlong UTF-8 `%c0%ae`, encoded backslash, and the exact CVE-shaped `/<root>/../../etc/passwd` payload. Also clarifies the traversal-guard comment in `webStaticFiles.ts` and bumps the package to `0.39.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
