### PR TITLE
fix(mcp): escape `</script>` in inlined MCP App client bundle

### DIFF
--- a/packages/keryx/__tests__/fixtures/mcpAppClient.ts
+++ b/packages/keryx/__tests__/fixtures/mcpAppClient.ts
@@ -2,3 +2,9 @@
 // Intentionally DOM-free so it also typechecks under the framework's Bun tsconfig.
 export const marker = "MCP_APP_FIXTURE_MARKER";
 Reflect.set(globalThis, "__mcpAppFixtureMarker", marker);
+// String literals containing the sequences that would prematurely close the inline
+// <script> tag (mirrors react-dom's `innerHTML="<script></script>"`). The bundler must
+// HTML-escape these so the module tag survives; see issue #516.
+export const breakout = "<script></script>";
+export const escapedComment = "<!-- not a real comment -->";
+Reflect.set(globalThis, "__mcpAppFixtureBreakout", breakout + escapedComment);

--- a/packages/keryx/__tests__/util/mcpAppBundler.test.ts
+++ b/packages/keryx/__tests__/util/mcpAppBundler.test.ts
@@ -3,6 +3,7 @@ import { config } from "../../config";
 import {
   bundleMcpAppClient,
   DEFAULT_MCP_APP_SHELL,
+  escapeScriptForInlineHtml,
   injectThemeCss,
   resolveMcpAppHtml,
 } from "../../util/mcpAppBundler";
@@ -31,6 +32,25 @@ describe("mcpAppBundler", () => {
       expect(html).toContain("MCP_APP_FIXTURE_MARKER");
       // The empty module script placeholder was replaced with the bundle.
       expect(html).not.toMatch(EMPTY_MODULE_SCRIPT);
+    });
+
+    test("escapes </script> in the bundle so the module tag survives (issue #516)", async () => {
+      // The fixture contains a `"<script></script>"` string literal, so its minified
+      // bundle carries a literal `</script>` that would otherwise close the tag early.
+      const html = await resolveMcpAppHtml({ client: fixture });
+      // Exactly one `</script>` — the one closing the inlined module tag.
+      expect(html.match(/<\/script>/gi)).toHaveLength(1);
+      // The bundle's literal was neutralized (escaped), not stripped.
+      expect(html).toContain("<\\/script");
+      // ...and the app still runs end-to-end.
+      expect(html).toContain("MCP_APP_FIXTURE_MARKER");
+    });
+
+    test("escapes </script> when inlining into a provided shell", async () => {
+      const shell =
+        '<html><body><main>custom</main><script type="module"></script></body></html>';
+      const html = await resolveMcpAppHtml({ client: fixture, html: shell });
+      expect(html.match(/<\/script>/gi)).toHaveLength(1);
     });
 
     test("inlines the bundle into a provided shell's empty module script", async () => {
@@ -79,6 +99,37 @@ describe("mcpAppBundler", () => {
       await expect(
         bundleMcpAppClient("/nonexistent/does-not-exist.ts"),
       ).rejects.toThrow(/Failed to build MCP App client/);
+    });
+  });
+
+  describe("escapeScriptForInlineHtml", () => {
+    test("escapes </script> case-insensitively", () => {
+      expect(escapeScriptForInlineHtml('a="</script>"')).toBe(
+        'a="<\\/script>"',
+      );
+      expect(escapeScriptForInlineHtml('a="</SCRIPT>"')).toBe(
+        'a="<\\/SCRIPT>"',
+      );
+      expect(escapeScriptForInlineHtml('a="</Script >"')).toBe(
+        'a="<\\/Script >"',
+      );
+    });
+
+    test("escapes <!-- comment openers", () => {
+      expect(escapeScriptForInlineHtml('a="<!-- x"')).toBe('a="<\\!-- x"');
+    });
+
+    test("escapes every occurrence", () => {
+      expect(escapeScriptForInlineHtml("</script></script>")).toBe(
+        "<\\/script><\\/script>",
+      );
+    });
+
+    test("leaves unrelated JS untouched", () => {
+      expect(escapeScriptForInlineHtml("if (a < b) {}")).toBe("if (a < b) {}");
+      expect(escapeScriptForInlineHtml("x = '<div></div>'")).toBe(
+        "x = '<div></div>'",
+      );
     });
   });
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/mcpAppBundler.ts
+++ b/packages/keryx/util/mcpAppBundler.ts
@@ -35,6 +35,30 @@ const COMMENT_PLACEHOLDER = "/* MCP_APP_CLIENT */";
 const THEME_PLACEHOLDER = "/* MCP_APP_THEME */";
 /** Matches an empty `<script type="module">` tag (the preferred, declarative injection point). */
 const EMPTY_MODULE_SCRIPT = /<script\s+type=["']module["']>\s*<\/script>/;
+/**
+ * Matches the sequences that let bundled JS prematurely terminate (or corrupt) the inline
+ * `<script>` element it is embedded in: a closing `</script` tag (case-insensitive) and an
+ * `<!--` comment opener (which flips the HTML parser into "script data escaped" state).
+ */
+const SCRIPT_BREAKOUT = /<(\/script|!--)/gi;
+
+/**
+ * Make bundled JS safe to inline inside an HTML `<script>` element. HTML parsers end a
+ * script at the first literal `</script>` (and `<!--` can start an escaped state that hides
+ * a later real `</script>`), so an unescaped bundle terminates the tag early and the rest
+ * renders as page text. Backslash-escaping the `<` neutralizes both without changing JS
+ * semantics: `<\/script` is identical to `</script` in every JS context, and `<\!--` is an
+ * identity escape inside the string literals where `<!--` appears in minified bundles.
+ *
+ * @param script - The bundled client JS to embed.
+ * @returns The JS with `</script`/`<!--` sequences backslash-escaped.
+ */
+export function escapeScriptForInlineHtml(script: string): string {
+  return script.replace(
+    SCRIPT_BREAKOUT,
+    (_match, tail: string) => `<\\${tail}`,
+  );
+}
 
 /** Resolved HTML per UI action, computed once at boot by {@link resolveMcpAppUiResources}. */
 const resolvedUiHtml = new Map<Action, string>();
@@ -67,9 +91,12 @@ export async function bundleMcpAppClient(
  * `<script type="module"></script>`, then a `MCP_APP_CLIENT` placeholder comment,
  * then just before `</body>`, and finally appends as a last resort.
  *
- * Uses replacer functions so `$`-sequences in the bundled JS are inserted literally.
+ * The bundle is HTML-escaped ({@link escapeScriptForInlineHtml}) first so `</script>`
+ * sequences inside the JS cannot close the module tag early. Uses replacer functions so
+ * `$`-sequences in the bundled JS are inserted literally.
  */
-function injectClientScript(shell: string, script: string): string {
+function injectClientScript(shell: string, rawScript: string): string {
+  const script = escapeScriptForInlineHtml(rawScript);
   if (EMPTY_MODULE_SCRIPT.test(shell)) {
     return shell.replace(
       EMPTY_MODULE_SCRIPT,


### PR DESCRIPTION
## Summary

`injectClientScript` inlined the bundled MCP App client into `<script type="module">…</script>` **without escaping** `</script>` sequences inside the JS. HTML parsers close the script element at the first literal `</script>` in the bundle — common once React is in the graph (`react-dom` ships `W.innerHTML="<script></script>"`) — so the rest of the bundle rendered as page text and the app failed to run in every MCP Apps host (confirmed in Cursor against Agent Query's Recharts chart app).

## Fix

- Add `escapeScriptForInlineHtml` in `packages/keryx/util/mcpAppBundler.ts`, which backslash-escapes `</script` (case-insensitive) and `<!--` before embedding. `<\/script` and `<\!--` are identical to the originals in JS but can no longer terminate the tag or flip the parser into "script data escaped" state.
- Applied once at the top of `injectClientScript`, so every injection path (empty module script, placeholder comment, before-`</body>`, append) is covered.

## Tests

- Fixture (`mcpAppClient.ts`) now carries a `"<script></script>"` string literal, so the real `bun build --minify` path exercises the bug end-to-end.
- Assert the resolved HTML contains **exactly one** `</script>` (the module tag's), that the bundle's literal survives in escaped form, and that the app still runs (`MCP_APP_FIXTURE_MARKER` present).
- Focused unit tests for `escapeScriptForInlineHtml` (case-insensitivity, `<!--`, multiple occurrences, no false positives on `a < b` / `<div></div>`).

Version bumped `0.39.1` → `0.39.2`.

closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)