### PR TITLE
fix(security): opt-in MCP tools, authorize MCP notifications, safe wildcard CORS

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -190,9 +190,9 @@ The `-q` flag suppresses server logs so you can pipe the JSON output cleanly. Us
 
 ## MCP Tools
 
-When the MCP server is enabled, every action is automatically exposed as an [MCP](https://modelcontextprotocol.io) tool. AI agents can discover and call your actions through the Model Context Protocol — no extra configuration needed.
+When the MCP server is enabled, actions can be exposed as [MCP](https://modelcontextprotocol.io) tools that AI agents discover and call through the Model Context Protocol. Tools are **opt-in**: set `mcp = { tool: true }` to publish an action. Actions with no `mcp` config are never exposed, so internal or destructive actions stay private by default.
 
-To exclude an action from MCP tools, set `mcp = { tool: false }`. Actions can also be registered as MCP resources or prompts via `mcp.resource` and `mcp.prompt`. See the [MCP guide](/guide/mcp) for full details.
+Actions can also be registered as MCP resources or prompts via `mcp.resource` and `mcp.prompt`. See the [MCP guide](/guide/mcp) for full details.
 
 ## Task Scheduling
 

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -203,7 +203,7 @@ For authenticated tests, see the [MCP reference testing section](/guide/mcp#test
 
 ## Real-Time Notifications
 
-Agents aren't limited to request-response tool calls. When messages are broadcast through the [PubSub system](/guide/channels) (e.g., chat messages via Redis PubSub), they're forwarded to all connected MCP clients as MCP logging messages.
+Agents aren't limited to request-response tool calls. When messages are broadcast through the [PubSub system](/guide/channels) (e.g., chat messages via Redis PubSub), they're forwarded to MCP clients as MCP logging messages — but only to sessions whose authenticated user is authorized to subscribe to that channel. Notifications honor the same channel [authorization](/guide/channels) as WebSocket subscribers, so an agent never receives broadcasts for channels its user couldn't join.
 
 This enables reactive agent behavior — an agent can monitor a channel and respond when new data arrives, rather than polling.
 

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -28,9 +28,18 @@ Once enabled, the server listens at `http://localhost:8080/mcp` (or your configu
 
 ## How Actions Become Tools
 
-When the MCP server starts, it registers every action as an MCP tool automatically. No extra configuration needed — if an action exists, it becomes a tool.
+MCP tools are **opt-in**. An action is exposed as a tool only when it sets `mcp = { tool: true }` (or declares an [MCP App](./mcp-apps.md) via `mcp.ui`). Actions with no `mcp` config — including internal, destructive, or maintenance actions — are never reachable over MCP, so nothing is published to AI clients by accident.
 
-For each action:
+```ts
+export class Status implements Action {
+  name = "status";
+  description = "Server health and runtime information";
+  mcp = { tool: true }; // opt in to expose as an MCP tool
+  // ...
+}
+```
+
+For each opted-in action:
 
 1. **Name** — The action name is converted to a valid MCP tool name by replacing `:` with `-` (e.g., `user:create` → `user-create`)
 2. **Description** — The action's `description` property becomes the tool description
@@ -52,13 +61,22 @@ export class UserView implements Action {
 
 ## Controlling Exposure
 
-By default, all actions are exposed as MCP tools. To exclude an action from tool registration:
+Tools are opt-in, so actions stay private until you explicitly publish them. To expose an action as a tool:
+
+```ts
+export class PublicAction implements Action {
+  name = "reports:list";
+  mcp = { tool: true };
+  // ...
+}
+```
+
+An internal action simply omits `mcp` (or sets `mcp = { tool: false }`) and is never registered:
 
 ```ts
 export class InternalAction implements Action {
   name = "internal:cleanup";
-  mcp = { tool: false };
-  // ...
+  // no mcp config → not an MCP tool
 }
 ```
 
@@ -66,7 +84,7 @@ The full `mcp` property is of type `McpActionConfig`:
 
 | Property         | Type                  | Default | Description                                                                        |
 | ---------------- | --------------------- | ------- | ---------------------------------------------------------------------------------- |
-| `tool`           | `boolean`             | `true`  | Whether to expose this action as an MCP tool                                       |
+| `tool`           | `boolean`             | `false` | Opt in to expose this action as an MCP tool (tools are opt-in)                     |
 | `isLoginAction`  | `boolean`             | —       | Tag as the login action for the OAuth flow                                         |
 | `isSignupAction` | `boolean`             | —       | Tag as the signup action for the OAuth flow                                        |
 | `resource`       | `object`              | —       | Expose this action as an MCP resource (see [Resources](#resources) below)          |
@@ -87,7 +105,7 @@ import { Action, MCP_RESPONSE_FORMAT } from "keryx";
 
 export class StatusAction implements Action {
   name = "status";
-  mcp = { responseFormat: MCP_RESPONSE_FORMAT.MARKDOWN };
+  mcp = { tool: true, responseFormat: MCP_RESPONSE_FORMAT.MARKDOWN };
   // ...
 }
 ```
@@ -158,7 +176,7 @@ export class UserResource implements Action {
 }
 ```
 
-An action can be registered as both a tool and a resource by omitting `tool: false`.
+An action can be registered as both a tool and a resource by also setting `tool: true`.
 
 ## Prompts
 

--- a/example/backend/__tests__/initializers/mcp.test.ts
+++ b/example/backend/__tests__/initializers/mcp.test.ts
@@ -344,24 +344,33 @@ describe("mcp initializer (enabled)", () => {
       }
     });
 
-    test("tools/list returns actions as tools (excluding mcp.tool=false)", async () => {
+    test("tools/list returns only opt-in tools (mcp.tool === true or mcp.ui)", async () => {
       const result = await client.listTools();
       expect(result.tools.length).toBeGreaterThan(0);
 
       const toolNames = result.tools.map((t) => t.name);
       expect(toolNames).toContain("status");
 
-      // Actions with mcp.tool=false should NOT be listed
+      // Actions that never opted in should NOT be listed
       expect(toolNames).not.toContain("session-create");
       expect(toolNames).not.toContain("user-create");
+      // Destructive/maintenance actions must stay off unless explicitly opted in
+      expect(toolNames).not.toContain("messages-cleanup");
       // Resource/prompt example actions should NOT be tools
       expect(toolNames).not.toContain("status-resource");
       expect(toolNames).not.toContain("greeting-prompt");
 
-      // All registered actions with mcp.tool !== false should be tools
+      // Tools are opt-in: an action is a tool iff it set mcp.tool === true, or it
+      // declares an MCP App (mcp.ui) without opting out.
       for (const action of api.actions.actions) {
-        if (action.mcp?.tool === false) continue;
-        expect(toolNames).toContain(api.mcp.formatToolName(action.name));
+        const isTool =
+          action.mcp?.tool === true ||
+          (action.mcp?.ui != null && action.mcp?.tool !== false);
+        if (isTool) {
+          expect(toolNames).toContain(api.mcp.formatToolName(action.name));
+        } else {
+          expect(toolNames).not.toContain(api.mcp.formatToolName(action.name));
+        }
       }
     });
 

--- a/example/backend/actions/channel.ts
+++ b/example/backend/actions/channel.ts
@@ -11,6 +11,7 @@ import { SessionMiddleware } from "../middleware/session";
 
 export class ChannelMembers implements Action {
   name = "channel:members";
+  mcp = { tool: true };
   description =
     "Get the list of presence keys for members currently subscribed to a PubSub channel. Requires an active session.";
   middleware = [RateLimitMiddleware, SessionMiddleware];

--- a/example/backend/actions/message.ts
+++ b/example/backend/actions/message.ts
@@ -20,6 +20,7 @@ import type { SessionImpl } from "./session";
 
 export class MessageCreate implements Action {
   name = "message:create";
+  mcp = { tool: true };
   description =
     "Create a new chat message as the currently authenticated user. The message is persisted to the database and broadcast in real-time to all connected users via the 'messages' PubSub channel. Requires an active session. Returns the created message with its ID and timestamps.";
   middleware = [RateLimitMiddleware, SessionMiddleware, CsrfMiddleware];
@@ -65,6 +66,7 @@ export class MessageCreate implements Action {
 
 export class MessagesList implements Action {
   name = "messages:list";
+  mcp = { tool: true };
   description =
     "List chat messages in reverse chronological order (newest first) with pagination. Each message includes the author's name, message body, and timestamps. Requires an active session. Use 'limit' (1-100, default 10) and 'page' (default 1) to paginate through results.";
   middleware = [RateLimitMiddleware, SessionMiddleware];
@@ -103,6 +105,7 @@ export class MessagesList implements Action {
 
 export class MessageView implements Action {
   name = "message:view";
+  mcp = { tool: true };
   description =
     "Retrieve a single message by its ID. Returns the message body, author name, and timestamps. Requires an active session. The 'message' parameter accepts a numeric message ID.";
   middleware = [RateLimitMiddleware, SessionMiddleware];

--- a/example/backend/actions/status.ts
+++ b/example/backend/actions/status.ts
@@ -31,6 +31,7 @@ export class Status implements Action {
   description =
     "Returns server health and runtime information including the server name, process ID, package version, uptime in milliseconds, memory consumption in MB, and dependency health checks for the database and Redis. Does not require authentication.";
   inputs = z.object({});
+  mcp = { tool: true };
   web = { route: "/status", method: HTTP_METHOD.GET };
 
   async run() {
@@ -58,7 +59,7 @@ export class StatusMarkdown implements Action {
   name = "status:markdown";
   description = "Returns server status formatted as markdown.";
   inputs = z.object({});
-  mcp = { responseFormat: MCP_RESPONSE_FORMAT.MARKDOWN };
+  mcp = { tool: true, responseFormat: MCP_RESPONSE_FORMAT.MARKDOWN };
   web = { route: "/status/markdown", method: HTTP_METHOD.GET };
 
   async run() {

--- a/example/backend/actions/user.ts
+++ b/example/backend/actions/user.ts
@@ -80,6 +80,7 @@ export class UserCreate implements Action {
 
 export class UserEdit implements Action {
   name = "user:edit";
+  mcp = { tool: true };
   description =
     "Update the currently authenticated user's profile. All fields are optional — only provided fields will be updated. You can change the user's name, email, and/or password. Requires an active session. Returns the updated user profile.";
   web = { route: "/user", method: HTTP_METHOD.POST };
@@ -109,6 +110,7 @@ export class UserEdit implements Action {
 
 export class UserView implements Action {
   name = "user:view";
+  mcp = { tool: true };
   description =
     "Retrieve another user's public profile by their user ID. Returns public information only (ID, name, timestamps) — does not expose email or other private fields. Requires an active session.";
   middleware = [RateLimitMiddleware, SessionMiddleware];

--- a/packages/keryx/__tests__/classes/Action.test.ts
+++ b/packages/keryx/__tests__/classes/Action.test.ts
@@ -49,13 +49,13 @@ describe("Action constructor defaults", () => {
     });
   });
 
-  test("mcp defaults tool: true when mcp config omitted", () => {
+  test("mcp defaults tool: false when mcp config omitted (tools are opt-in)", () => {
     const action = new MinimalAction({ name: "minimal" });
 
-    expect(action.mcp).toEqual({ tool: true });
+    expect(action.mcp).toEqual({ tool: false });
   });
 
-  test("mcp merges tool: true default with user-provided fields", () => {
+  test("mcp merges tool: false default with user-provided fields", () => {
     const action = new ConfiguredAction({
       name: "status:resource",
       mcp: {
@@ -63,11 +63,20 @@ describe("Action constructor defaults", () => {
       },
     });
 
-    expect(action.mcp?.tool).toBe(true);
+    expect(action.mcp?.tool).toBe(false);
     expect(action.mcp?.resource).toEqual({
       uri: "keryx://status",
       mimeType: "application/json",
     });
+  });
+
+  test("mcp tool can be explicitly enabled", () => {
+    const action = new ConfiguredAction({
+      name: "status",
+      mcp: { tool: true },
+    });
+
+    expect(action.mcp?.tool).toBe(true);
   });
 
   test("mcp tool can be explicitly disabled", () => {

--- a/packages/keryx/__tests__/servers/web.test.ts
+++ b/packages/keryx/__tests__/servers/web.test.ts
@@ -180,18 +180,18 @@ describe("CORS headers", () => {
     }
   });
 
-  test("wildcard allowedOrigins with Origin header reflects origin and sets credentials", async () => {
+  test("wildcard allowedOrigins with Origin header returns literal * without credentials", async () => {
+    // Security: under "*", the server must NOT reflect the request origin or set
+    // credentials — that combination lets any site read authenticated responses.
     const original = config.server.web.allowedOrigins;
     (config.server.web as any).allowedOrigins = "*";
     try {
       const res = await fetch(getUrl() + "/api/status", {
         headers: { Origin: "http://example.com" },
       });
-      expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
-        "http://example.com",
-      );
-      expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
-      expect(res.headers.get("Vary")).toContain("Origin");
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+      expect(res.headers.get("Vary") ?? "").not.toContain("Origin");
     } finally {
       (config.server.web as any).allowedOrigins = original;
     }

--- a/packages/keryx/__tests__/util/http.test.ts
+++ b/packages/keryx/__tests__/util/http.test.ts
@@ -92,6 +92,16 @@ describe("buildCorsHeaders", () => {
     expect(headers["Access-Control-Allow-Origin"]).toBe("*");
   });
 
+  test("wildcard with a request origin returns literal * and never reflects the origin (no Vary)", () => {
+    // Regression: reflecting the origin under "*" set Vary, which downstream
+    // added Access-Control-Allow-Credentials — letting any site read credentialed
+    // cross-origin responses. Wildcard must stay a literal, credential-free "*".
+    config.server.web.allowedOrigins = "*";
+    const headers = buildCorsHeaders("https://evil.example");
+    expect(headers["Access-Control-Allow-Origin"]).toBe("*");
+    expect(headers["Vary"]).toBeUndefined();
+  });
+
   test("matching specific origin reflects it with Vary", () => {
     config.server.web.allowedOrigins = "https://app.com";
     const headers = buildCorsHeaders("https://app.com");

--- a/packages/keryx/__tests__/util/mcpServer.test.ts
+++ b/packages/keryx/__tests__/util/mcpServer.test.ts
@@ -11,7 +11,11 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { z } from "zod";
 import { api } from "../../api";
 import { Action, HTTP_METHOD } from "../../classes/Action";
+import { Channel } from "../../classes/Channel";
+import type { Connection } from "../../classes/Connection";
+import { ErrorType, TypedError } from "../../classes/TypedError";
 import { config } from "../../config";
+import { isMcpSessionAuthorizedForChannel } from "../../util/mcpServer";
 import { serverUrl, useTestServer } from "../setup";
 
 const mcpUrl = () => `${serverUrl()}${config.server.mcp.route}`;
@@ -307,5 +311,70 @@ describe("mcpServer utilities (integration)", () => {
       });
       expect(res.status).toBe(403);
     });
+  });
+});
+
+describe("isMcpSessionAuthorizedForChannel", () => {
+  // A channel that only authorizes sessions carrying a userId — the gate that
+  // stops MCP notification broadcasts from leaking to unauthorized sessions.
+  class AuthedNotifyChannel extends Channel {
+    constructor() {
+      super({ name: "authed-notify" });
+    }
+    async authorize(_channelName: string, connection: Connection) {
+      if (!connection.session?.data?.userId) {
+        throw new TypedError({
+          message: "Authentication required to join this channel",
+          type: ErrorType.CONNECTION_CHANNEL_AUTHORIZATION,
+        });
+      }
+    }
+  }
+
+  let channel: AuthedNotifyChannel;
+
+  useTestServer();
+
+  beforeAll(() => {
+    channel = new AuthedNotifyChannel();
+    api.channels.channels.push(channel);
+  });
+
+  afterAll(() => {
+    const idx = api.channels.channels.indexOf(channel);
+    if (idx !== -1) api.channels.channels.splice(idx, 1);
+  });
+
+  test("authorized when the session's user passes the channel authorize()", async () => {
+    const ok = await isMcpSessionAuthorizedForChannel(
+      { clientId: "client-1", userId: 123 },
+      "authed-notify",
+    );
+    expect(ok).toBe(true);
+  });
+
+  test("denied when the session has no user (fail closed)", async () => {
+    const ok = await isMcpSessionAuthorizedForChannel(
+      { clientId: "client-1" },
+      "authed-notify",
+    );
+    expect(ok).toBe(false);
+  });
+
+  test("denied for an unknown channel (fail closed)", async () => {
+    const ok = await isMcpSessionAuthorizedForChannel(
+      { clientId: "client-1", userId: 123 },
+      "no-such-channel",
+    );
+    expect(ok).toBe(false);
+  });
+
+  test("does not leave the probe connection registered", async () => {
+    const before = api.connections.connections.size;
+    await isMcpSessionAuthorizedForChannel(
+      { clientId: "client-1", userId: 123 },
+      "authed-notify",
+    );
+    expect(api.connections.connections.size).toBe(before);
   });
 });

--- a/packages/keryx/__tests__/util/webResponse.test.ts
+++ b/packages/keryx/__tests__/util/webResponse.test.ts
@@ -156,6 +156,22 @@ describe("buildHeaders", () => {
     expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
     expect(headers["Access-Control-Allow-Credentials"]).toBeUndefined();
   });
+
+  test("wildcard origins never emit Allow-Credentials, even with a request origin", () => {
+    // Regression for the CORS credentials leak: under "*", credentials must
+    // never be attached (browsers forbid "*" + credentials, and reflecting an
+    // arbitrary origin with credentials leaks authenticated responses).
+    const original = config.server.web.allowedOrigins;
+    config.server.web.allowedOrigins = "*";
+    try {
+      const headers = buildHeaders(undefined, "https://evil.example.com");
+      expect(headers["Access-Control-Allow-Origin"]).toBe("*");
+      expect(headers["Access-Control-Allow-Credentials"]).toBeUndefined();
+      expect(headers["Vary"]).toBeUndefined();
+    } finally {
+      config.server.web.allowedOrigins = original;
+    }
+  });
 });
 
 describe("buildResponse", () => {

--- a/packages/keryx/classes/Action.ts
+++ b/packages/keryx/classes/Action.ts
@@ -91,7 +91,11 @@ export type OAuthActionResponse = {
 };
 
 export type McpActionConfig = {
-  /** Expose this action as an MCP tool (default true) */
+  /**
+   * Expose this action as an MCP tool. Tools are **opt-in** (default `false`):
+   * set `tool: true` to publish the action to MCP clients. Declaring an MCP App
+   * via `ui` implies a tool unless `tool` is explicitly `false`.
+   */
   tool?: boolean;
   /** Tag as the OAuth login action */
   isLoginAction?: boolean;
@@ -147,7 +151,7 @@ export type ActionConstructorInputs = {
   /** Middleware hooks to run before/after `run()` */
   middleware?: ActionMiddleware[];
 
-  /** Expose this action via the MCP server (defaults to `{ tool: true }`) */
+  /** Expose this action via the MCP server. Tools are opt-in — set `mcp: { tool: true }` to publish one. */
   mcp?: McpActionConfig;
 
   /** Expose this action via HTTP (defaults: route `/${name}`, method `GET`) */
@@ -234,7 +238,9 @@ export abstract class Action {
     this.inputs = args.inputs;
     this.middleware = args.middleware ?? [];
     this.timeout = args.timeout;
-    this.mcp = { tool: true, ...args.mcp };
+    // MCP tools are opt-in — see the actions initializer for rationale. An action
+    // becomes a tool only when it sets `mcp.tool = true` (or declares `mcp.ui`).
+    this.mcp = { tool: false, ...args.mcp };
     this.web = {
       route: args.web?.route ?? `/${this.name}`,
       method: args.web?.method ?? HTTP_METHOD.GET,

--- a/packages/keryx/initializers/actionts.ts
+++ b/packages/keryx/initializers/actionts.ts
@@ -716,7 +716,12 @@ export class Actions extends Initializer {
 
     for (const a of actions) {
       if (!a.description) a.description = `An Action: ${a.name}`;
-      a.mcp = { tool: true, ...a.mcp };
+      // MCP tools are opt-in: an action is exposed as a tool only when it
+      // explicitly sets `mcp.tool = true` (or declares an MCP App via `mcp.ui`).
+      // Defaulting to `false` prevents actions — especially destructive or
+      // maintenance ones — from being silently reachable by any authenticated
+      // MCP client just because they exist.
+      a.mcp = { tool: false, ...a.mcp };
     }
 
     logger.info(

--- a/packages/keryx/initializers/mcp.ts
+++ b/packages/keryx/initializers/mcp.ts
@@ -20,7 +20,9 @@ import {
   forgetMcpSession,
   formatToolName,
   handleTransportRequest,
+  isMcpSessionAuthorizedForChannel,
   type McpAuthInfo,
+  type McpSessionAuth,
   mcpJsonResponse,
   parseToolName,
   readMcpSessionRecord,
@@ -85,11 +87,21 @@ declare module "keryx" {
 export class McpInitializer extends Initializer {
   constructor() {
     super(namespace);
-    this.dependsOn = ["hooks", "actions", "oauth", "connections", "pubsub"];
+    this.dependsOn = [
+      "hooks",
+      "actions",
+      "oauth",
+      "connections",
+      "pubsub",
+      "channels",
+    ];
   }
 
   async initialize() {
     const mcpServers: McpServer[] = [];
+    // Per-session auth context, so a broadcast is delivered only to sessions
+    // whose user is authorized for its channel (see sendNotification).
+    const mcpServerAuth = new Map<McpServer, McpSessionAuth>();
     const transports = new Map<
       string,
       {
@@ -98,8 +110,21 @@ export class McpInitializer extends Initializer {
       }
     >();
 
-    function sendNotification(payload: PubSubMessage) {
+    // Deliver a PubSub broadcast to MCP sessions as a logging notification, but
+    // ONLY to sessions whose user is authorized to subscribe to the broadcast's
+    // channel. Without this gate every session on the node would receive every
+    // broadcast — a cross-user/cross-tenant data leak — because MCP sessions
+    // have no per-channel subscription of their own. Sessions with no captured
+    // auth context are skipped (fail closed).
+    async function sendNotification(payload: PubSubMessage) {
       for (const server of mcpServers) {
+        const auth = mcpServerAuth.get(server);
+        if (!auth) continue;
+        const authorized = await isMcpSessionAuthorizedForChannel(
+          auth,
+          payload.channel,
+        );
+        if (!authorized) continue;
         try {
           server.server
             .sendLoggingMessage({
@@ -121,6 +146,7 @@ export class McpInitializer extends Initializer {
 
     return {
       mcpServers,
+      mcpServerAuth,
       transports,
       handleRequest: null as McpHandleRequest | null,
       sendNotification,
@@ -273,6 +299,13 @@ export class McpInitializer extends Initializer {
         // New session — create a new McpServer + transport
         const mcpServer = createMcpServer();
         mcpServers.push(mcpServer);
+        // Capture the session's auth context so channel-broadcast delivery can
+        // authorize this session (see sendNotification).
+        api.mcp.mcpServerAuth.set(mcpServer, {
+          clientId: authInfo.clientId,
+          userId: authInfo.extra?.userId,
+          ip,
+        });
 
         const sessionClientId = authInfo.clientId;
         const transport = new WebStandardStreamableHTTPServerTransport({
@@ -344,6 +377,7 @@ export class McpInitializer extends Initializer {
             sessionId,
             record.clientId,
             record.protocolVersion,
+            { userId: authInfo.extra?.userId, ip },
           );
         }
 
@@ -390,6 +424,7 @@ export class McpInitializer extends Initializer {
       }
     }
     api.mcp.mcpServers.length = 0;
+    api.mcp.mcpServerAuth.clear();
 
     api.mcp.handleRequest = null;
   }

--- a/packages/keryx/initializers/pubsub.ts
+++ b/packages/keryx/initializers/pubsub.ts
@@ -88,9 +88,11 @@ export class PubSub extends Initializer {
       }
     }
 
-    // Forward to MCP as notifications
+    // Forward to MCP as notifications (authorized per-session; fire-and-forget).
     if (config.server.mcp.enabled && api.mcp?.sendNotification) {
-      api.mcp.sendNotification(payload);
+      void api.mcp.sendNotification(payload).catch(() => {
+        // notification delivery is best-effort
+      });
     }
   }
 }

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.39.2",
+  "version": "0.40.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/http.ts
+++ b/packages/keryx/util/http.ts
@@ -65,7 +65,14 @@ export function buildCorsHeaders(
   const headers: Record<string, string> = { ...extra };
   const allowedOrigins = config.server.web.allowedOrigins;
 
-  if (allowedOrigins === "*" && !requestOrigin) {
+  if (allowedOrigins === "*") {
+    // Wildcard: always emit a literal "*" and never reflect the specific request
+    // origin. Reflecting the origin sets `Vary: Origin`, which downstream (see
+    // buildHeaders in webResponse.ts) adds `Access-Control-Allow-Credentials:
+    // true` — and reflecting an *arbitrary* origin together with credentials lets
+    // any website read a victim's authenticated cross-origin responses. A literal
+    // "*" can never carry credentials (browsers forbid the combination), so this
+    // stays a safe permissive default for public, non-credentialed endpoints.
     headers["Access-Control-Allow-Origin"] = "*";
   } else if (
     requestOrigin &&

--- a/packages/keryx/util/mcpServer.ts
+++ b/packages/keryx/util/mcpServer.ts
@@ -80,6 +80,61 @@ export async function createMcpConnection(extra: {
 }
 
 /**
+ * Auth context captured for a live MCP session (`McpServer`), used to authorize
+ * which channel broadcasts that session is allowed to receive. Keyed by
+ * `McpServer` in `api.mcp.mcpServerAuth`.
+ */
+export type McpSessionAuth = {
+  /** OAuth client id that owns the session. */
+  clientId: string;
+  /** Authenticated user id from the session's access token, if any. */
+  userId?: unknown;
+  /** Remote IP captured at session creation (best-effort). */
+  ip?: string;
+};
+
+/**
+ * Decide whether an MCP session's user is allowed to receive broadcasts for a
+ * channel. Runs the channel's real subscription authorization
+ * ({@link api.channels.authorizeSubscription}) against a throwaway in-memory
+ * probe connection so app-defined channel middleware/`authorize()` rules apply
+ * exactly as they do for WebSocket subscribers.
+ *
+ * The probe's session is populated in memory (never persisted to Redis) so this
+ * check adds no session writes on the broadcast hot path. Fails closed: returns
+ * `false` on any authorization error or unknown channel.
+ *
+ * @param auth - The session's captured auth context.
+ * @param channelName - The channel the broadcast targets.
+ * @returns `true` only if the session's user may subscribe to `channelName`.
+ */
+export async function isMcpSessionAuthorizedForChannel(
+  auth: McpSessionAuth,
+  channelName: string,
+): Promise<boolean> {
+  const probe = new Connection(
+    CONNECTION_TYPE.MCP,
+    auth.ip ?? "unknown",
+    randomUUID(),
+  );
+  probe.session = {
+    id: probe.sessionId,
+    cookieName: config.session.cookieName,
+    createdAt: new Date().getTime(),
+    data: auth.userId != null ? { userId: auth.userId } : {},
+  };
+  probe.sessionLoaded = true;
+  try {
+    await api.channels.authorizeSubscription(channelName, probe);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    probe.destroy();
+  }
+}
+
+/**
  * Forward a request to an MCP transport and return the response with CORS headers.
  * Handles the try/catch + error response pattern shared by new-session and existing-session paths.
  */
@@ -222,6 +277,7 @@ export function forgetMcpSession(
   if (sessionId) api.mcp.transports.delete(sessionId);
   const idx = api.mcp.mcpServers.indexOf(mcpServer);
   if (idx !== -1) api.mcp.mcpServers.splice(idx, 1);
+  api.mcp.mcpServerAuth.delete(mcpServer);
 }
 
 /**
@@ -312,12 +368,15 @@ const adoptionsInFlight = new Map<
  * @param sessionId - The transport session id to adopt.
  * @param clientId - The OAuth client id that owns the session (from the registry record).
  * @param protocolVersion - The negotiated protocol version from the registry record, if any.
+ * @param auth - The adopting request's user id / ip, captured so channel-broadcast
+ *   authorization ({@link isMcpSessionAuthorizedForChannel}) works for this session too.
  * @returns The connected, initialized transport (also registered in `api.mcp.transports`).
  */
 export async function adoptMcpSession(
   sessionId: string,
   clientId: string,
   protocolVersion: string | undefined,
+  auth?: Pick<McpSessionAuth, "userId" | "ip">,
 ): Promise<WebStandardStreamableHTTPServerTransport> {
   const inFlight = adoptionsInFlight.get(sessionId);
   if (inFlight) return inFlight;
@@ -325,6 +384,11 @@ export async function adoptMcpSession(
   const promise = (async () => {
     const mcpServer = createMcpServer();
     api.mcp.mcpServers.push(mcpServer);
+    api.mcp.mcpServerAuth.set(mcpServer, {
+      clientId,
+      userId: auth?.userId,
+      ip: auth?.ip,
+    });
     try {
       const transport = new WebStandardStreamableHTTPServerTransport({
         sessionIdGenerator: () => sessionId,
@@ -424,7 +488,13 @@ function buildUiMeta(ui: McpUiConfig): Record<string, unknown> {
 function registerTools(mcpServer: McpServer) {
   const registered = new Set<string>();
   for (const action of api.actions.actions) {
-    if (action.mcp?.tool === false) continue;
+    // Tools are opt-in: register only actions that explicitly set `mcp.tool =
+    // true`, or that declare an MCP App (`mcp.ui`) without opting out. Every
+    // other action — including those with no `mcp` config — is never exposed.
+    const isTool =
+      action.mcp?.tool === true ||
+      (action.mcp?.ui != null && action.mcp?.tool !== false);
+    if (!isTool) continue;
 
     const toolName = formatToolName(action.name);
     if (registered.has(toolName)) continue;

--- a/packages/keryx/util/webResponse.ts
+++ b/packages/keryx/util/webResponse.ts
@@ -29,8 +29,14 @@ export const buildHeaders = (
     "Access-Control-Allow-Methods": config.server.web.allowedMethods,
     "Access-Control-Allow-Headers": config.server.web.allowedHeaders,
   });
-  if (cors["Access-Control-Allow-Origin"] && cors["Vary"]) {
-    // Specific origin match (not wildcard) — allow credentials
+  // Only attach credentials for a specific, allow-listed origin — never for the
+  // wildcard "*". Browsers forbid combining "*" with credentials, and reflecting
+  // an arbitrary origin alongside credentials would let any site read a victim's
+  // authenticated responses (see buildCorsHeaders in util/http.ts).
+  if (
+    cors["Access-Control-Allow-Origin"] &&
+    cors["Access-Control-Allow-Origin"] !== "*"
+  ) {
     cors["Access-Control-Allow-Credentials"] = "true";
   }
   Object.assign(headers, cors);


### PR DESCRIPTION
Fixes three HIGH-severity issues found in a security audit of the framework.

- **CORS credential leak:** under the `*` default the server reflected the request origin *and* set `Access-Control-Allow-Credentials: true`, letting any site read a victim's authenticated cross-origin responses — wildcard now emits a literal, credential-free `*` and credentials are only sent for a specifically allow-listed origin.
- **MCP tools are now opt-in:** `mcp.tool` defaults to `false`, so an action is exposed to MCP clients only when it sets `mcp: { tool: true }` (or declares `mcp.ui`), preventing destructive/internal actions (e.g. `messages:cleanup`) from being silently reachable by any authenticated client.
- **MCP notification leak:** PubSub broadcasts forwarded to MCP sessions are now delivered only to sessions whose user is authorized to subscribe to that channel, closing a cross-user/cross-tenant data leak.

Bumps `keryx` to 0.40.0 and updates the example app, docs, and regression tests; full CI (lint + all workspace tests + docs) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)