### PR TITLE
fix(db): make generateMigrations a no-op when schema/ is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ example/frontend/dist
 actionhero
 packages/keryx/.env
 packages/keryx/drizzle
+packages/keryx/tmp-schema-*
 packages/keryx/README.md
 packages/keryx/assets/
 packages/plugins/tracing/.env

--- a/packages/keryx/__tests__/initializers/db.test.ts
+++ b/packages/keryx/__tests__/initializers/db.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
+import fs from "fs";
+import os from "os";
+import path from "path";
 import { Pool } from "pg";
 import { api } from "../../api";
 import { ErrorType, TypedError } from "../../classes/TypedError";
@@ -70,6 +73,82 @@ describe("DB initializer", () => {
       Bun.env.NODE_ENV = originalNodeEnv;
     }
   });
+
+  test(
+    "generateMigrations is a no-op when the project has no schema files",
+    async () => {
+      // api.rootDir is the framework package itself, which has no schema/ directory.
+      expect(fs.existsSync(path.join(api.rootDir, "schema"))).toBe(false);
+      await expect(api.db.generateMigrations()).resolves.toBeUndefined();
+      // The early return happens before the temp drizzle-kit config is written.
+      expect(
+        fs.existsSync(path.join(api.rootDir, "drizzle", "config.tmp.ts")),
+      ).toBe(false);
+    },
+    HOOK_TIMEOUT,
+  );
+
+  test(
+    "generateMigrations is a no-op when schema/ holds only placeholders",
+    async () => {
+      // Mirrors `keryx new --no-example`, which scaffolds schema/.gitkeep and nothing else.
+      const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "keryx-schema-"));
+      const originalRootDir = api.rootDir;
+      api.rootDir = tmpRoot;
+
+      try {
+        fs.mkdirSync(path.join(tmpRoot, "schema"));
+        fs.writeFileSync(path.join(tmpRoot, "schema", ".gitkeep"), "");
+        await expect(api.db.generateMigrations()).resolves.toBeUndefined();
+        expect(fs.existsSync(path.join(tmpRoot, "drizzle"))).toBe(false);
+      } finally {
+        api.rootDir = originalRootDir;
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    },
+    HOOK_TIMEOUT,
+  );
+
+  test(
+    "generateMigrations runs drizzle-kit when a schema file exists",
+    async () => {
+      // Inside the package so the generated schema file can resolve `drizzle-orm`.
+      const tmpRoot = fs.mkdtempSync(
+        path.join(import.meta.dir, "..", "..", "tmp-schema-"),
+      );
+      const originalRootDir = api.rootDir;
+      api.rootDir = tmpRoot;
+
+      try {
+        fs.mkdirSync(path.join(tmpRoot, "schema"));
+        fs.writeFileSync(
+          path.join(tmpRoot, "schema", "widgets.ts"),
+          [
+            `import { pgTable, serial, text } from "drizzle-orm/pg-core";`,
+            `export const widgets = pgTable("widgets", {`,
+            `  id: serial("id").primaryKey(),`,
+            `  name: text("name").notNull(),`,
+            `});`,
+          ].join("\n"),
+        );
+
+        await api.db.generateMigrations();
+
+        const generated = fs
+          .readdirSync(path.join(tmpRoot, "drizzle"))
+          .filter((f) => f.endsWith(".sql"));
+        expect(generated.length).toBeGreaterThan(0);
+        // The temp drizzle-kit config is always cleaned up.
+        expect(
+          fs.existsSync(path.join(tmpRoot, "drizzle", "config.tmp.ts")),
+        ).toBe(false);
+      } finally {
+        api.rootDir = originalRootDir;
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    },
+    HOOK_TIMEOUT,
+  );
 
   test("stop() is a no-op when pool was never initialized", async () => {
     // Verifies the `if (api.db.db && api.db.pool)` guard in DB.stop().

--- a/packages/keryx/initializers/db.ts
+++ b/packages/keryx/initializers/db.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { unlink } from "node:fs/promises";
-import { $ } from "bun";
+import { $, Glob } from "bun";
 import { type Config as DrizzleMigrateConfig } from "drizzle-kit";
 import { DefaultLogger, type LogWriter, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
@@ -17,6 +17,29 @@ import {
 } from "../util/connectionString";
 
 const namespace = "db";
+
+const SCHEMA_DIR = "schema";
+
+/**
+ * Check whether the project has any drizzle schema files to generate migrations from.
+ * A freshly-scaffolded project (or one whose last schema file was deleted) has an
+ * empty `schema/` directory, which `drizzle-kit generate` treats as a fatal error.
+ *
+ * @param schemaDir - Absolute path to the project's `schema/` directory. A missing
+ * directory counts as empty rather than an error.
+ * @returns `true` when at least one non-dotfile `.ts`/`.tsx`/`.js` file exists in the tree.
+ */
+async function hasSchemaFiles(schemaDir: string) {
+  if (!fs.existsSync(schemaDir)) return false;
+
+  const glob = new Glob("**/*.{ts,tsx,js,mjs,cjs}");
+  for await (const file of glob.scan(schemaDir)) {
+    if (path.basename(file).startsWith(".")) continue;
+    return true;
+  }
+
+  return false;
+}
 
 declare module "keryx" {
   export interface API {
@@ -107,32 +130,52 @@ export class DB extends Initializer {
   /**
    * Generate migrations for the database schema.
    * Learn more @ https://orm.drizzle.team/kit-docs/overview
+   *
+   * An empty `schema/` directory is a legitimate state for a new project, so this
+   * is a no-op (rather than an error) when there is nothing to generate from.
+   *
+   * @throws {TypedError} With `ErrorType.SERVER_INITIALIZATION` if `drizzle-kit generate` fails.
    */
   async generateMigrations() {
+    const schemaDir = path.join(api.rootDir, SCHEMA_DIR);
+    const migrationsDir = path.join(api.rootDir, "drizzle");
+
+    if (!(await hasSchemaFiles(schemaDir))) {
+      logger.info(
+        `no schema files found in ${SCHEMA_DIR}/ - nothing to generate`,
+      );
+      return;
+    }
+
+    // Paths stay relative — drizzle-kit concatenates `out` onto "./" when reading
+    // existing snapshots, so an absolute path breaks on any non-empty migrations
+    // folder. The child process is run with cwd set to the project root instead.
     const migrationConfig: DrizzleMigrateConfig = {
       dialect: "postgresql" as const,
-      schema: path.join("schema", "*"),
+      schema: path.join(SCHEMA_DIR, "*"),
       dbCredentials: {
         url: config.database.connectionString,
       },
-      out: path.join("drizzle"),
+      out: "drizzle",
     };
 
     const fileContent = `export default ${JSON.stringify(migrationConfig, null, 2)}`;
-    const tmpfilePath = path.join(api.rootDir, "drizzle", "config.tmp.ts");
+    const tmpfilePath = path.join(migrationsDir, "config.tmp.ts");
 
     try {
       await Bun.write(tmpfilePath, fileContent);
+      // .nothrow() so a failing drizzle-kit surfaces as a TypedError with its
+      // stderr, rather than a bare ShellError from the tagged template.
       const { exitCode, stdout, stderr } =
-        await $`bun drizzle-kit generate --config ${tmpfilePath}`;
+        await $`bun drizzle-kit generate --config ${tmpfilePath}`
+          .cwd(api.rootDir)
+          .nothrow();
       logger.trace(stdout.toString());
       if (exitCode !== 0) {
-        {
-          throw new TypedError({
-            message: `Failed to generate migrations: ${stderr.toString()}`,
-            type: ErrorType.SERVER_INITIALIZATION,
-          });
-        }
+        throw new TypedError({
+          message: `Failed to generate migrations: ${stderr.toString()}`,
+          type: ErrorType.SERVER_INITIALIZATION,
+        });
       }
     } finally {
       const filePointer = Bun.file(tmpfilePath);

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
closes #522

## Problem

`keryx new --no-example` scaffolds an empty `schema/` directory (just a `.gitkeep`) but still wires up the `migrations` script. The first thing you'd naturally run in a fresh project was broken:

```
Error  No schema files found for path config ['schema/*']
Error  If path represents a file - please make sure to use .ts or other extension in the path
error: "drizzle-kit" exited with code 1
```

...and the error text points at a config-path problem rather than the real cause: you have no tables yet.

## Fix

`generateMigrations()` now globs `schema/` (relative to `api.rootDir`) before doing anything else and returns early when there are no schema files:

```
no schema files found in schema/ - nothing to generate
```

This is the early-return option from the issue — it also covers a project whose last schema file was deleted, which a scaffolded placeholder file would not.

Two related fixes in the same code path:

- **cwd** — `drizzle-kit` now runs with cwd set to `api.rootDir`. The config's `schema`/`out` paths are relative and were being resolved against the *invoking* directory while the temp config was written under `api.rootDir`. (They must stay relative: `drizzle-kit` concatenates `out` onto `"./"` when reading existing snapshots, so an absolute `out` breaks on any non-empty migrations folder.)
- **`.nothrow()`** — the tagged shell template threw a bare `ShellError` before the `exitCode !== 0` check could run, so the intended `TypedError` (which includes stderr) was unreachable dead code. That's the `ShellError` in the issue's stack trace.

## Tests

Three new cases in `packages/keryx/__tests__/initializers/db.test.ts`:

- no-op when the project has no `schema/` directory at all
- no-op when `schema/` holds only a `.gitkeep` (the exact `--no-example` layout)
- still generates a `.sql` migration when a real schema file exists, and cleans up `config.tmp.ts`

Also verified end-to-end against the issue's repro with a locally-linked keryx:

| step | before | after |
| --- | --- | --- |
| `bun run migrations` on fresh `--no-example` | exit 1 | exit 0, logs the no-op |
| same, after adding `schema/widgets.ts` | — | generates `drizzle/0000_*.sql` |
| `bun run migrations` in `example/backend` | unchanged | unchanged (no diff vs. `main`) |

Full `bun test-package` failure set is identical to `main` on this machine (15 pre-existing local env failures — port/redis contention, unrelated to db).

🤖 Generated with [Claude Code](https://claude.com/claude-code)