### PR TITLE
fix(resque): start tasks only after DB migrations have run

### DIFF
--- a/docs/guide/initializers.md
+++ b/docs/guide/initializers.md
@@ -52,7 +52,7 @@ Unknown dependency names or cycles cause a startup failure with a clear, actiona
 | `channels`      | `["redis", "pubsub"]`                                    | Discovers and registers PubSub channels            |
 | `servers`       | `["actions", "hooks"]`                                   | Auto-discovers and loads transport servers         |
 | `mcp`           | `["hooks", "actions", "oauth", "connections", "pubsub"]` | MCP server — exposes actions as tools              |
-| `resque`        | `["redis", "actions", "process", "hooks"]`               | Background task queue                              |
+| `resque`        | `["redis", "db", "actions", "process", "hooks"]`         | Background task queue                              |
 
 When the server starts, it renders the resolved graph to the logs so the order is visible at a glance:
 

--- a/docs/reference/initializers.md
+++ b/docs/reference/initializers.md
@@ -87,6 +87,6 @@ Each framework initializer declares what it depends on:
 | `channels`      | `["redis", "pubsub"]`                                    |
 | `servers`       | `["actions", "hooks"]`                                   |
 | `mcp`           | `["hooks", "actions", "oauth", "connections", "pubsub"]` |
-| `resque`        | `["redis", "actions", "process", "hooks"]`               |
+| `resque`        | `["redis", "db", "actions", "process", "hooks"]`         |
 
 The resolved graph is rendered to the logs at startup. See the [initializers guide](../guide/initializers.md) for sample output.

--- a/packages/keryx/__tests__/initializers/resque.test.ts
+++ b/packages/keryx/__tests__/initializers/resque.test.ts
@@ -106,6 +106,16 @@ test("actions can be enqueued later", async () => {
   expect(delayed[0]).toBeGreaterThan(Date.now() / 1000);
 });
 
+describe("boot order", () => {
+  test("resque depends on db so tasks never start before migrations run", () => {
+    const resque = api.initializers.find((i) => i.name === "resque");
+    expect(resque?.dependsOn).toContain("db");
+
+    const names = api.initializers.map((i) => i.name);
+    expect(names.indexOf("db")).toBeLessThan(names.indexOf("resque"));
+  });
+});
+
 describe("with workers and scheduler", () => {
   afterEach(async () => {
     await api.resque.stopWorkers();

--- a/packages/keryx/initializers/resque.ts
+++ b/packages/keryx/initializers/resque.ts
@@ -97,7 +97,7 @@ let SERVER_JOB_COUNTER = 1;
 export class Resque extends Initializer {
   constructor() {
     super(namespace);
-    this.dependsOn = ["redis", "actions", "process", "hooks"];
+    this.dependsOn = ["redis", "db", "actions", "process", "hooks"];
   }
 
   /** Create and connect the resque `Queue` instance (used for enqueuing jobs). */

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Problem

The `resque` initializer declared `dependsOn = ["redis", "actions", "process", "hooks"]` — no `db`. The `db` initializer is what runs drizzle migrations at boot (when `config.database.autoMigrate` is on), so nothing in the dependency graph guaranteed migrations finished before workers started polling.

The correct order held only *incidentally*: both are framework initializers, `db` has zero dependencies and sorts earlier by insertion-order tie-breaking in Kahn's algorithm. Any plugin or user initializer that shifted the graph could silently reorder them, and a job picked up mid-migration would run against a stale schema.

## Fix

Add `db` to the resque initializer's `dependsOn`, making the ordering explicit. The queue, scheduler, and workers now all start after migrations by construction, not by accident.

```
this.dependsOn = ["redis", "db", "actions", "process", "hooks"];
```

## Tests

New boot-order test in `packages/keryx/__tests__/initializers/resque.test.ts` asserting both that the dependency is declared and that `db` precedes `resque` in the resolved graph.

- `bun test-package` — 925 pass, 0 fail
- `bun test-example-backend` — 288 pass, 0 fail
- `bun lint` — clean

Docs dependency tables updated in `docs/guide/initializers.md` and `docs/reference/initializers.md`. Version bumped to 0.41.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)