### PR TITLE
feat(web): raw request bodies via web.rawBody, short-circuiting beforeRequest

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -38,7 +38,7 @@ That's a fully functioning HTTP endpoint, CLI command, and WebSocket handler. Hi
 | `name`        | `string`                | Unique identifier (e.g., `"user:create"`)                                      |
 | `description` | `string`                | Human-readable description, shows up in CLI `--help` and Swagger               |
 | `inputs`      | `z.ZodType`             | Zod schema — validation happens automatically                                  |
-| `web`         | `{ route, method }`     | HTTP routing. Routes are strings with `:param` placeholders or RegExp patterns |
+| `web`         | `{ route, method, … }`  | HTTP routing. Routes are strings with `:param` placeholders or RegExp patterns |
 | `task`        | `{ queue, frequency? }` | Makes this action schedulable as a background job                              |
 | `middleware`  | `ActionMiddleware[]`    | Runs before/after the action (auth, logging, etc.)                             |
 | `mcp`         | `McpActionConfig`       | Controls MCP exposure: tool, resource, and/or prompt (tool enabled by default) |
@@ -97,6 +97,53 @@ web = { route: "/user/:id", method: HTTP_METHOD.GET };
 Routes support `:param` path parameters (like Express) and can also be RegExp patterns. There's no separate `routes.ts` file — the route lives on the action itself, right next to the handler that serves it.
 
 Available methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`.
+
+## Raw Request Bodies
+
+For HTTP connections, `connection.rawRequest` is the underlying `Request` — read headers, the URL, or the method straight off it:
+
+```ts
+async run(params: ActionParams<Webhook>, connection: Connection) {
+  const signature = connection.rawRequest?.headers.get("x-signature");
+}
+```
+
+The **body** is a different story. Keryx reads it to build `params`, so by the time `run()` is called it's already consumed. When you need the bytes exactly as they arrived — proxying a request upstream, verifying a webhook signature over the payload, accepting a binary upload — set `web.rawBody` and Keryx won't touch the body at all:
+
+```ts
+export class ProxyUpstream implements Action {
+  name = "proxy";
+  web = {
+    route: "/proxy/:target",
+    method: HTTP_METHOD.POST,
+    rawBody: true,
+  };
+  inputs = z.object({ target: z.string() });
+
+  async run(params: ActionParams<ProxyUpstream>, connection: Connection) {
+    // The body is untouched — stream it upstream without buffering it here
+    return fetch(`https://${params.target}/v1/messages`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${process.env.UPSTREAM_KEY}` },
+      body: connection.rawRequest!.body,
+      // @ts-expect-error — Bun supports duplex streaming request bodies
+      duplex: "half",
+    });
+  }
+}
+```
+
+Three things follow from `rawBody: true`:
+
+- **`params` come from path and query params only.** Nothing is merged in from the body, so a body key can't shadow a path param — which matters when that path segment is a routing target or a credential.
+- **You own the body.** Read it once, with whatever's appropriate: `.text()`, `.json()`, `.arrayBuffer()`, `.formData()`, or `.body` for a `ReadableStream` you never buffer.
+- **You own the size limit past the headers.** `config.server.web.maxBodySize` is still enforced against `Content-Length`, but Keryx isn't reading the stream, so it can't stop a chunked upload that lies about its size. Enforce that yourself if you accept chunked bodies.
+
+Content types are matched on the base media type, so `application/json` and `application/json; charset=utf-8` behave identically — the charset doesn't change whether a body gets parsed into `params`.
+
+`rawRequest` only exists for HTTP — it's `undefined` over WebSocket, CLI, background tasks, and MCP, where there's no request to speak of. An action built around raw bytes is an HTTP endpoint first; guard on `connection.rawRequest` if the same action can be reached another way.
+
+Swagger documents a `rawBody` endpoint's request body as opaque bytes (`*/*`), and any Zod inputs that aren't path params as query params — because that's where they have to come from.
 
 ## Raw Response Passthrough
 

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -226,6 +226,19 @@ api.hooks.web.afterRequest((_req, _res, _ctx, outcome) => {
 });
 ```
 
+A `beforeRequest` hook that returns a `Response` **short-circuits** the request: later `beforeRequest` hooks and all routing are skipped, and that response goes to the client. `afterRequest` hooks still fire (with `outcome.actionName` unset), and the response is still compressed. Use this for concerns that have to answer before routing — health checks, a maintenance mode, blocklists:
+
+```ts
+api.hooks.web.beforeRequest((req) => {
+  if (maintenanceMode) {
+    return new Response("Down for maintenance", { status: 503 });
+  }
+  // Return nothing to let the request continue
+});
+```
+
+Reading the request body in a hook consumes it — the action or handler downstream then sees an empty body. If an action needs the bytes, have it declare [`web.rawBody`](/guide/actions#raw-request-bodies) and read `connection.rawRequest` instead.
+
 **WebSocket hooks** — `api.hooks.ws.onConnect` fires when a WebSocket is accepted (after the `Connection` is constructed); `onMessage` fires for each inbound message before parsing; `onDisconnect` fires when the socket closes, before channel presence cleanup. All three receive the persistent per-session `Connection` instance:
 
 ```ts

--- a/docs/reference/classes.md
+++ b/docs/reference/classes.md
@@ -75,6 +75,12 @@ class Connection<
   /** The underlying transport object (Bun Request, WebSocket, etc.) */
   rawConnection?: any;
 
+  /**
+   * The underlying `Request` for HTTP connections. Headers are always readable;
+   * the body only when the action declares `web.rawBody`.
+   */
+  rawRequest?: Request;
+
   /** Request correlation ID for distributed tracing */
   correlationId?: string;
 

--- a/docs/reference/servers.md
+++ b/docs/reference/servers.md
@@ -34,17 +34,20 @@ The built-in web server uses `Bun.serve` to handle HTTP requests and WebSocket c
 When an HTTP request comes in, the server:
 
 1. Checks for a WebSocket upgrade — if the client is requesting a WebSocket connection, it upgrades transparently
-2. Tries to serve a static file (if `staticFiles.enabled` is `true` and the path matches)
-3. Matches the request path and method against registered action routes
-4. Extracts params from path segments (`:param`), query string, and request body
-5. Creates a `Connection`, calls `connection.act()` with the action name and params
-6. Returns the JSON response with appropriate headers and status codes
+2. Runs `beforeRequest` hooks — a hook that returns a `Response` answers the request here, skipping every step below it
+3. Tries to serve a static file (if `staticFiles.enabled` is `true` and the path matches)
+4. Matches the request path and method against registered action routes
+5. Extracts params from path segments (`:param`), query string, and request body
+6. Creates a `Connection`, calls `connection.act()` with the action name and params
+7. Returns the JSON response with appropriate headers and status codes
 
 Param loading order matters — later sources override earlier ones:
 
 1. **Path params** (e.g., `/user/:id` → `{ id: "123" }`)
 2. **Query params** (e.g., `?limit=10`)
 3. **Body params** (JSON or FormData)
+
+Body parsing keys off the base media type, so `application/json` and `application/json; charset=utf-8` are treated the same. Actions that declare [`web.rawBody`](/guide/actions#raw-request-bodies) skip step 5's body read entirely — they get path and query params only, and read the untouched body themselves via `connection.rawRequest`.
 
 ### WebSocket Message Flow
 

--- a/packages/keryx/__tests__/classes/Action.test.ts
+++ b/packages/keryx/__tests__/classes/Action.test.ts
@@ -30,13 +30,14 @@ describe("Action constructor defaults", () => {
     expect(action.timeout).toBeUndefined();
   });
 
-  test("web defaults to GET at /${name} with streaming off", () => {
+  test("web defaults to GET at /${name} with streaming and rawBody off", () => {
     const action = new MinimalAction({ name: "status" });
 
     expect(action.web).toEqual({
       route: "/status",
       method: HTTP_METHOD.GET,
       streaming: false,
+      rawBody: false,
     });
   });
 
@@ -114,6 +115,25 @@ describe("Action constructor overrides", () => {
       route: "/streaming/counter",
       method: HTTP_METHOD.POST,
       streaming: true,
+      rawBody: false,
+    });
+  });
+
+  test("rawBody is preserved when set", () => {
+    const action = new ConfiguredAction({
+      name: "proxy",
+      web: {
+        route: "/proxy/:target",
+        method: HTTP_METHOD.POST,
+        rawBody: true,
+      },
+    });
+
+    expect(action.web).toEqual({
+      route: "/proxy/:target",
+      method: HTTP_METHOD.POST,
+      streaming: false,
+      rawBody: true,
     });
   });
 

--- a/packages/keryx/__tests__/servers/web.test.ts
+++ b/packages/keryx/__tests__/servers/web.test.ts
@@ -545,6 +545,157 @@ describe("raw Response passthrough", () => {
   });
 });
 
+describe("raw request bodies", () => {
+  beforeAll(() => {
+    // Opts into `web.rawBody`: reads the body itself, bytes exactly as sent
+    const rawBodyAction = {
+      name: "test:rawBody",
+      inputs: z.object({ target: z.string() }),
+      web: {
+        route: "/test/raw-body/:target",
+        method: HTTP_METHOD.POST,
+        rawBody: true,
+      },
+      run: async (
+        params: { target: string },
+        connection: { rawRequest?: Request },
+      ) => {
+        const body = await connection.rawRequest!.text();
+        return {
+          target: params.target,
+          body,
+          bytes: new TextEncoder().encode(body).byteLength,
+          contentType: connection.rawRequest!.headers.get("content-type"),
+        };
+      },
+    } as unknown as Action;
+
+    // No `rawBody`: the framework parses the body into params as usual
+    const parsedBodyAction = {
+      name: "test:parsedBody",
+      inputs: z.object({ hello: z.string() }),
+      web: { route: "/test/parsed-body", method: HTTP_METHOD.POST },
+      run: async (
+        params: { hello: string },
+        connection: { rawRequest?: Request },
+      ) => ({
+        hello: params.hello,
+        rawRequestPresent: connection.rawRequest !== undefined,
+        bodyUsed: connection.rawRequest!.bodyUsed,
+        header: connection.rawRequest!.headers.get("x-custom-header"),
+      }),
+    } as unknown as Action;
+
+    api.actions.actions.push(rawBodyAction, parsedBodyAction);
+  });
+
+  test("hands the action an unread JSON body", async () => {
+    const res = await fetch(getUrl() + "/api/test/raw-body/from-path", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { body: string; bytes: number };
+    expect(body.body).toBe('{"hello":"world"}');
+    expect(body.bytes).toBe(17);
+  });
+
+  test("hands the action an unread body when a charset is present", async () => {
+    const res = await fetch(getUrl() + "/api/test/raw-body/from-path", {
+      method: "POST",
+      headers: { "content-type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ hello: "world" }),
+    });
+    const body = (await res.json()) as { body: string; contentType: string };
+    expect(body.body).toBe('{"hello":"world"}');
+    expect(body.contentType).toBe("application/json; charset=utf-8");
+  });
+
+  test("preserves non-JSON bodies byte-for-byte", async () => {
+    const payload = "0032want 74730d10\n00000009done\n";
+    const res = await fetch(getUrl() + "/api/test/raw-body/from-path", {
+      method: "POST",
+      headers: { "content-type": "application/x-git-upload-pack-request" },
+      body: payload,
+    });
+    const body = (await res.json()) as { body: string };
+    expect(body.body).toBe(payload);
+  });
+
+  test("a body key cannot override a path param", async () => {
+    const res = await fetch(getUrl() + "/api/test/raw-body/from-path", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ target: "from-body" }),
+    });
+    const body = (await res.json()) as { target: string };
+    expect(body.target).toBe("from-path");
+  });
+
+  test("form-encoded bodies are left unread too", async () => {
+    const res = await fetch(getUrl() + "/api/test/raw-body/from-path", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "name=Alice",
+    });
+    const body = (await res.json()) as { body: string };
+    expect(body.body).toBe("name=Alice");
+  });
+
+  test("actions without rawBody still get params, and headers via rawRequest", async () => {
+    const res = await fetch(getUrl() + "/api/test/parsed-body", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-custom-header": "keryx",
+      },
+      body: JSON.stringify({ hello: "world" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      hello: string;
+      rawRequestPresent: boolean;
+      bodyUsed: boolean;
+      header: string;
+    };
+    expect(body.hello).toBe("world");
+    expect(body.rawRequestPresent).toBe(true);
+    expect(body.bodyUsed).toBe(true);
+    expect(body.header).toBe("keryx");
+  });
+
+  test("a JSON body with a charset is parsed into params", async () => {
+    const res = await fetch(getUrl() + "/api/test/parsed-body", {
+      method: "POST",
+      headers: { "content-type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ hello: "world" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { hello: string };
+    expect(body.hello).toBe("world");
+  });
+
+  test("swagger documents a raw-body endpoint as opaque bytes", async () => {
+    const res = await fetch(getUrl() + "/api/swagger");
+    const doc = (await res.json()) as {
+      paths: Record<string, Record<string, any>>;
+    };
+    const operation = doc.paths["/test/raw-body/{target}"].post;
+    expect(operation.requestBody.content["*/*"].schema).toEqual({
+      type: "string",
+      format: "binary",
+    });
+    // `target` is a path param, so it is not also documented as a query param
+    expect(
+      operation.parameters.filter((p: any) => p.in === "query"),
+    ).toHaveLength(0);
+    expect(operation.parameters).toContainEqual(
+      expect.objectContaining({ name: "target", in: "path", required: true }),
+    );
+  });
+});
+
 describe("compression", () => {
   // The /api/swagger endpoint returns a large OpenAPI spec (well above 1024 bytes)
   test("returns gzip-compressed response when Accept-Encoding: gzip", async () => {
@@ -674,6 +825,56 @@ describe("request hooks", () => {
     const res = await fetch(getUrl() + "/.well-known/does-not-exist");
     expect(res.status).toBe(404);
     expect(fired).toBe(2);
+  });
+
+  test("a beforeRequest hook that returns a Response short-circuits routing", async () => {
+    resetHooks();
+    let laterHookRan = false;
+    api.hooks.web.beforeRequest(
+      () =>
+        new Response(JSON.stringify({ intercepted: true }), {
+          status: 418,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    api.hooks.web.beforeRequest(() => {
+      laterHookRan = true;
+    });
+
+    const res = await fetch(getUrl() + "/api/status");
+    expect(res.status).toBe(418);
+    const body = (await res.json()) as { intercepted: boolean };
+    expect(body.intercepted).toBe(true);
+    expect(laterHookRan).toBe(false);
+  });
+
+  test("afterRequest still fires for a short-circuited request", async () => {
+    resetHooks();
+    let outcome: { status: number; actionName?: string } | undefined;
+    api.hooks.web.beforeRequest((_req, ctx) => {
+      ctx.metadata.marker = "short-circuit";
+      return new Response("nope", { status: 403 });
+    });
+    api.hooks.web.afterRequest((_req, res, ctx, o) => {
+      outcome = { status: o.status, actionName: o.actionName };
+      expect(ctx.metadata.marker).toBe("short-circuit");
+      expect(res.status).toBe(403);
+    });
+
+    const res = await fetch(getUrl() + "/api/status");
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe("nope");
+    expect(outcome?.status).toBe(403);
+    expect(outcome?.actionName).toBeUndefined();
+  });
+
+  test("returning a non-Response value does not short-circuit", async () => {
+    resetHooks();
+    // @ts-expect-error — hooks may only return a Response or nothing
+    api.hooks.web.beforeRequest(() => "not-a-response");
+
+    const res = await fetch(getUrl() + "/api/status");
+    expect(res.status).toBe(200);
   });
 
   test("multiple beforeRequest hooks run in registration order", async () => {

--- a/packages/keryx/__tests__/util/webRouting.test.ts
+++ b/packages/keryx/__tests__/util/webRouting.test.ts
@@ -250,6 +250,99 @@ describe("parseRequestParams", () => {
       expect(params.tag).toEqual(["a", "b", "c"]);
     });
   });
+
+  describe("content-type matching", () => {
+    test("parses JSON when the content type carries a charset", async () => {
+      const req = new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "content-type": "application/json; charset=utf-8" },
+        body: JSON.stringify({ hello: "world" }),
+      });
+      const params = await parseRequestParams(req, parsedUrl());
+      expect(params.hello).toBe("world");
+      expect(req.bodyUsed).toBe(true);
+    });
+
+    test("parses JSON regardless of header casing and whitespace", async () => {
+      const req = new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "content-type": "  Application/JSON ;charset=UTF-8" },
+        body: JSON.stringify({ hello: "world" }),
+      });
+      const params = await parseRequestParams(req, parsedUrl());
+      expect(params.hello).toBe("world");
+    });
+
+    test("parses form-urlencoded bodies with a charset", async () => {
+      const req = new Request("http://localhost/test", {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded; charset=utf-8",
+        },
+        body: "name=Alice",
+      });
+      const params = await parseRequestParams(req, parsedUrl());
+      expect(params.name).toBe("Alice");
+    });
+
+    test("ignores bodies with an unrecognized content type", async () => {
+      const req = new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body: "some-bytes",
+      });
+      const params = await parseRequestParams(req, parsedUrl());
+      expect(Object.keys(params)).toHaveLength(0);
+      expect(req.bodyUsed).toBe(false);
+      expect(await req.text()).toBe("some-bytes");
+    });
+  });
+
+  describe("rawBody option", () => {
+    test("leaves a JSON body unread for the caller to consume", async () => {
+      const req = jsonRequest({ hello: "world" });
+      const params = await parseRequestParams(req, parsedUrl(), undefined, {
+        rawBody: true,
+      });
+      expect(Object.keys(params)).toHaveLength(0);
+      expect(req.bodyUsed).toBe(false);
+      expect(await req.text()).toBe('{"hello":"world"}');
+    });
+
+    test("leaves a form-encoded body unread", async () => {
+      const req = formUrlencodedRequest("name=Alice");
+      const params = await parseRequestParams(req, parsedUrl(), undefined, {
+        rawBody: true,
+      });
+      expect(Object.keys(params)).toHaveLength(0);
+      expect(await req.text()).toBe("name=Alice");
+    });
+
+    test("still populates path and query params", async () => {
+      const req = jsonRequest({ target: "from-body" });
+      const params = await parseRequestParams(
+        req,
+        parsedUrl("limit=10"),
+        { target: "from-path" },
+        { rawBody: true },
+      );
+      expect(params.target).toBe("from-path");
+      expect(params.limit).toBe("10");
+    });
+
+    test("does not throw on a body that is not valid JSON", async () => {
+      const req = new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not valid json{",
+      });
+      const params = await parseRequestParams(req, parsedUrl(), undefined, {
+        rawBody: true,
+      });
+      expect(Object.keys(params)).toHaveLength(0);
+      expect(await req.text()).toBe("not valid json{");
+    });
+  });
 });
 
 describe("checkBodySize", () => {

--- a/packages/keryx/actions/swagger.ts
+++ b/packages/keryx/actions/swagger.ts
@@ -129,11 +129,13 @@ export class Swagger implements Action {
         });
       }
 
-      // For GET/HEAD, convert remaining Zod inputs into query parameters
-      if (
-        (method === "get" || method === "head") &&
-        Object.keys(zodProperties).length > 0
-      ) {
+      // Endpoints whose inputs never come from the body: GET/HEAD, and raw-body
+      // actions (whose bodies Keryx hands to the action instead of parsing).
+      const inputsFromQuery =
+        method === "get" || method === "head" || action.web?.rawBody === true;
+
+      // Convert remaining Zod inputs into query parameters
+      if (inputsFromQuery && Object.keys(zodProperties).length > 0) {
         const fullSchema = z.toJSONSchema(action.inputs!, {
           io: "input",
           unrepresentable: "any",
@@ -157,7 +159,13 @@ export class Swagger implements Action {
 
       // Build requestBody if Zod inputs exist and method supports body
       let requestBody: Record<string, unknown> | undefined = undefined;
-      if (
+      if (action.web?.rawBody && method !== "get" && method !== "head") {
+        // The body is opaque to the framework — document it as arbitrary bytes
+        requestBody = {
+          required: false,
+          content: { "*/*": { schema: { type: "string", format: "binary" } } },
+        };
+      } else if (
         action.inputs &&
         typeof action.inputs.parse === "function" &&
         method !== "get" &&

--- a/packages/keryx/classes/Action.ts
+++ b/packages/keryx/classes/Action.ts
@@ -168,6 +168,22 @@ export type ActionConstructorInputs = {
      * set this when the action hands back a raw `Response` wrapping a stream.
      */
     streaming?: boolean;
+    /**
+     * When true, the framework never reads the request body. `params` are built
+     * from path and query params only, and the action reads the untouched body
+     * itself via `connection.rawRequest` (`.text()`, `.arrayBuffer()`,
+     * `.body` for a stream). Use this for proxies, webhook signature
+     * verification, and binary uploads — anything that needs the bytes exactly
+     * as sent, or needs to avoid buffering them twice.
+     *
+     * Because the body is never merged into `params`, a body key that collides
+     * with a path param cannot override it.
+     *
+     * `config.server.web.maxBodySize` is still enforced against the
+     * `Content-Length` header, but not while the action reads the stream — an
+     * action consuming a chunked body owns that limit itself.
+     */
+    rawBody?: boolean;
   };
 
   /** Per-action timeout in ms (overrides global `config.actions.timeout`; 0 disables) */
@@ -232,6 +248,7 @@ export abstract class Action {
     route: RegExp | string;
     method: HTTP_METHOD;
     streaming?: boolean;
+    rawBody?: boolean;
   };
   timeout?: number;
   task?: {
@@ -251,6 +268,7 @@ export abstract class Action {
       route: args.web?.route ?? `/${this.name}`,
       method: args.web?.method ?? HTTP_METHOD.GET,
       streaming: args.web?.streaming ?? false,
+      rawBody: args.web?.rawBody ?? false,
     };
     this.task = {
       frequency: args.task?.frequency,

--- a/packages/keryx/classes/Connection.ts
+++ b/packages/keryx/classes/Connection.ts
@@ -112,6 +112,16 @@ export class Connection<
   sessionLoaded: boolean;
   /** The underlying transport handle (e.g., Bun `ServerWebSocket`). */
   rawConnection?: any;
+  /**
+   * The underlying `Request` for HTTP connections (`type === CONNECTION_TYPE.WEB`),
+   * giving actions access to headers, URL, and body. `undefined` for every other
+   * transport.
+   *
+   * The **body** is only readable when the action declares `web.rawBody: true` —
+   * otherwise the framework has already consumed it to build `params`, and
+   * `rawRequest.text()` resolves to `""`. Headers are always safe to read.
+   */
+  rawRequest?: Request;
   /** Rate-limit metadata populated by the rate-limit middleware. */
   rateLimitInfo?: RateLimitInfo;
   /** Request correlation ID for distributed tracing. Propagated from the incoming `X-Request-Id` header when `config.server.web.correlationId.trustProxy` is enabled. */

--- a/packages/keryx/initializers/hooks.ts
+++ b/packages/keryx/initializers/hooks.ts
@@ -60,6 +60,10 @@ export class Hooks extends Initializer {
          * Register a hook to run at the start of every HTTP request, before
          * routing. Covers static files, OAuth, MCP, metrics, and actions.
          * Does not fire for WebSocket upgrades.
+         *
+         * A hook that returns a `Response` answers the request itself: later
+         * `beforeRequest` hooks and all routing are skipped, while
+         * `afterRequest` hooks still fire.
          */
         beforeRequest(hook: BeforeRequestHook): void {
           self.webBeforeRequest.push(hook);

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.41.3",
+  "version": "0.42.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/servers/web.ts
+++ b/packages/keryx/servers/web.ts
@@ -70,11 +70,17 @@ export interface RequestOutcome {
  * Runs at the start of every HTTP request, before any routing or static file handling.
  * WebSocket upgrades do not fire this hook. Throwing an error propagates out of the
  * request handler. Hooks run sequentially in registration order.
+ *
+ * Returning a `Response` **short-circuits** the request: no later `beforeRequest` hook
+ * runs, routing (static files, OAuth, MCP, metrics, actions) is skipped, and the returned
+ * response is what the client receives. `afterRequest` hooks still fire, with
+ * `outcome.actionName` unset, and the response is still compressed. Return nothing — the
+ * common case — to let the request continue down the pipeline.
  */
 export type BeforeRequestHook = (
   req: Request,
   ctx: RequestContext,
-) => Promise<void> | void;
+) => Promise<Response | void> | Response | void;
 
 /**
  * Runs after the `Response` is built and before compression. Receives the same `ctx`
@@ -232,7 +238,8 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
 
   /**
    * Main request handler passed to `Bun.serve({ fetch })`. Dispatches to WebSocket upgrade,
-   * static files, OAuth, MCP, or REST action handling in that order.
+   * static files, OAuth, MCP, or REST action handling in that order. A `beforeRequest` hook
+   * that returns a `Response` short-circuits everything after it.
    */
   async handleIncomingConnection(
     req: Request,
@@ -268,16 +275,24 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
 
     const ctx: RequestContext = { ip, id, metadata: {} };
     const requestStart = Date.now();
+
+    // A `beforeRequest` hook that returns a Response answers the request itself —
+    // remaining hooks and all routing are skipped, but `afterRequest` still fires.
+    let response: Response | undefined;
+    let actionName: string | undefined;
     for (const hook of api.hooks.web.beforeRequestHooks) {
-      await hook(req, ctx);
+      const hookResponse = await hook(req, ctx);
+      if (hookResponse instanceof Response) {
+        response = hookResponse;
+        break;
+      }
     }
 
-    const { response, actionName } = await this.handleHttpRequest(
-      req,
-      server,
-      ip,
-      id,
-    );
+    if (!response) {
+      const routed = await this.handleHttpRequest(req, server, ip, id);
+      response = routed.response;
+      actionName = routed.actionName;
+    }
 
     const outcome: RequestOutcome = {
       method: req.method.toUpperCase(),
@@ -537,6 +552,10 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
 
     const connection = new Connection(CONNECTION_TYPE.WEB, ip, id);
 
+    // Expose the underlying request so actions can read headers and — when the
+    // action declares `web.rawBody` — the untouched body.
+    connection.rawRequest = req;
+
     if (
       config.server.web.correlationId.header &&
       config.server.web.correlationId.trustProxy
@@ -574,9 +593,17 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
     );
     if (!actionName) errorStatusCode = 404;
 
+    // Actions that opt into `web.rawBody` read the body themselves off
+    // `connection.rawRequest`, so param parsing must leave it unread.
+    const rawBody =
+      api.actions.actions.find((a) => a.name === actionName)?.web?.rawBody ===
+      true;
+
     let params: Record<string, unknown>;
     try {
-      params = await parseRequestParams(req, url, pathParams ?? undefined);
+      params = await parseRequestParams(req, url, pathParams ?? undefined, {
+        rawBody,
+      });
     } catch (e) {
       if (
         e instanceof TypedError &&

--- a/packages/keryx/util/webRouting.ts
+++ b/packages/keryx/util/webRouting.ts
@@ -113,6 +113,21 @@ async function readBodyWithLimit(req: Request): Promise<string> {
 }
 
 /**
+ * Extract the base media type from a request's `Content-Type` header — the
+ * `type/subtype` with parameters stripped, trimmed, and lowercased. So
+ * `"application/json; charset=utf-8"` and `"Application/JSON"` both yield
+ * `"application/json"`.
+ *
+ * @param req - The incoming HTTP request.
+ * @returns The base media type, or `null` when the header is absent.
+ */
+export function baseMediaType(req: Request): string | null {
+  const header = req.headers.get("content-type");
+  if (header === null) return null;
+  return header.split(";")[0].trim().toLowerCase();
+}
+
+/**
  * Merge a value into the params object under `key`, appending to any existing
  * value rather than replacing it. If `key` is not set, assigns `value` as-is.
  * If it is set, produces an array containing the existing value(s) followed by
@@ -134,6 +149,17 @@ function appendParam(
     : [params[key], ...incoming];
 }
 
+/** Options for {@link parseRequestParams}. */
+export type ParseRequestParamsOptions = {
+  /**
+   * Skip body parsing entirely, leaving `req.body` unread so the action can
+   * consume it itself via `connection.rawRequest`. Path params and query params
+   * still populate. Set by the web server when the routed action declares
+   * `web.rawBody: true`.
+   */
+  rawBody?: boolean;
+};
+
 /**
  * Parse request parameters from path params, request body (JSON or form-data),
  * and query string into a single plain object.
@@ -141,17 +167,26 @@ function appendParam(
  * JSON bodies are preserved with full type fidelity (nested objects, arrays,
  * booleans, numbers). FormData bodies (multipart/form-data and
  * application/x-www-form-urlencoded) are converted to a plain object where
- * repeated keys become arrays and `File` values are preserved.
+ * repeated keys become arrays and `File` values are preserved. Content types are
+ * matched on the base media type, so parameters like `; charset=utf-8` do not
+ * change how a body is handled.
  *
  * @param req - The incoming HTTP request.
  * @param url - The parsed URL (for query string).
  * @param pathParams - Path parameters extracted by route matching.
+ * @param options - Parsing options. Pass `{ rawBody: true }` to leave the body
+ *   unread — nothing is consumed off `req`, so a later reader (typically the
+ *   action, via `connection.rawRequest`) still sees the bytes exactly as sent.
  * @returns A plain object containing all merged parameters.
+ * @throws {TypedError} With type {@link ErrorType.CONNECTION_ACTION_RUN} when a
+ *   JSON body cannot be parsed, or when the body exceeds
+ *   {@link config.server.web.maxBodySize}.
  */
 export async function parseRequestParams(
   req: Request,
   url: ReturnType<typeof parse>,
   pathParams?: Record<string, string>,
+  options?: ParseRequestParamsOptions,
 ): Promise<Record<string, unknown>> {
   // param load order: path params -> body params -> query params
   const params: Record<string, unknown> = {};
@@ -163,10 +198,11 @@ export async function parseRequestParams(
     }
   }
 
-  if (
-    req.method !== "GET" &&
-    req.headers.get("content-type") === "application/json"
-  ) {
+  // Raw-body actions own the body — resolve the content type to null so both
+  // body-reading branches are skipped and `req.body` is left untouched.
+  const contentType = options?.rawBody ? null : baseMediaType(req);
+
+  if (req.method !== "GET" && contentType === "application/json") {
     try {
       // Use streaming reader that aborts early if the body exceeds the
       // configured limit — never allocates the full oversized payload.
@@ -186,10 +222,8 @@ export async function parseRequestParams(
     }
   } else if (
     req.method !== "GET" &&
-    (req.headers.get("content-type")?.includes("multipart/form-data") ||
-      req.headers
-        .get("content-type")
-        ?.includes("application/x-www-form-urlencoded"))
+    (contentType === "multipart/form-data" ||
+      contentType === "application/x-www-form-urlencoded")
   ) {
     // For form data without a Content-Length header, stream-read the clone
     // to enforce the body size limit before handing off to the FormData parser.


### PR DESCRIPTION
Actions had no way to see the bytes a client sent. `parseRequestParams` read JSON bodies off the **original** request, so the documented escape hatch — retaining the `Request` in a `beforeRequest` hook — handed the action a drained body, and did it silently.

closes #526

## What changed

| Change | Where |
| --- | --- |
| `web.rawBody?: boolean` on an action — the framework never reads the body | `classes/Action.ts`, `util/webRouting.ts`, `servers/web.ts` |
| `connection.rawRequest` — the underlying `Request`, set for every HTTP connection | `classes/Connection.ts` |
| `beforeRequest` hooks may return `Response \| void` to answer before routing | `servers/web.ts`, `initializers/hooks.ts` |
| Content types match on the base media type | `util/webRouting.ts` |
| Swagger documents raw-body endpoints as opaque bytes | `actions/swagger.ts` |

### `web.rawBody`

```ts
web = { route: "/proxy/:target", method: HTTP_METHOD.POST, rawBody: true };

async run(params: ActionParams<Proxy>, connection: Connection) {
  return fetch(`https://${params.target}/v1/messages`, {
    method: "POST",
    body: connection.rawRequest!.body, // unread stream — never buffered here
    // @ts-expect-error — Bun supports duplex streaming request bodies
    duplex: "half",
  });
}
```

- `params` come from path and query params only. Nothing merges in from the body, so a body key **cannot** shadow a path param — the sharp edge that mattered when the path segment is a routing target or a credential.
- The action owns the body: `.text()`, `.json()`, `.arrayBuffer()`, `.formData()`, or `.body` for a stream it never buffers.
- Opt-in, so no existing behavior changes.

### `connection.rawRequest`

Set for every HTTP connection, which also closes the "actions can't see headers" half of the issue. Headers are always readable; the **body** only under `rawBody` — otherwise the framework has already consumed it and `.text()` resolves to `""`. `undefined` on WebSocket, CLI, task, and MCP connections.

### Short-circuiting `beforeRequest`

A hook returning a `Response` skips later hooks and all routing (static files, OAuth, MCP, metrics, actions). `afterRequest` hooks still fire — with `outcome.actionName` unset — and compression still applies. Returning anything else, including nothing, continues the pipeline as before.

### Content-type matching

`application/json; charset=utf-8` is now parsed like `application/json`; previously the strict `===` skipped it, leaving a body unparsed depending on whether a client SDK added a charset. Form-data matching moved from `.includes()` to base-type equality at the same time.

## On the ask, in order

1. **`web.rawBody`** — implemented as requested. No hook-plus-`Map` dance, no second `JSON.parse`, no double buffering.
2. **`beforeRequest` returning `Response`** — implemented too, since it solves a different problem.
3. **`req.clone()`** — deliberately skipped. It's the peak-memory cost the issue flagged, and `rawBody` makes it unnecessary.

**Body-over-path-param precedence** is fixed for `rawBody` routes but left as-is framework-wide: it's documented behavior, and flipping it silently would break apps relying on it. Worth its own issue — path params arguably should win everywhere.

## Sharp edges worth knowing

- `config.server.web.maxBodySize` is still enforced against `Content-Length`, but the framework isn't reading the stream, so it can't stop a chunked upload that lies about its size. A raw-body action accepting chunked bodies owns that limit.
- `rawRequest` is HTTP-only, so a raw-body action is an HTTP endpoint first. Guard on it if the same action is reachable over another transport.

## Tests

34 new tests; `bun run ci` clean locally.

- `__tests__/util/webRouting.test.ts` — charset/casing/whitespace content-type matching, unrecognized types left unread, `rawBody` leaving JSON + form bodies untouched while path/query params still populate.
- `__tests__/servers/web.test.ts` — end-to-end raw bodies (JSON, charset, `application/x-git-*` byte-for-byte, form-encoded), a body key failing to override a path param, `rawRequest` header access on a normal action, short-circuiting (including that later hooks don't run and `afterRequest` still sees `ctx.metadata`), and the generated Swagger for a raw-body route.
- `__tests__/classes/Action.test.ts` — `rawBody` constructor default and override.

Also verified: tracing, csrf, and resque-admin plugin suites, 288 example-backend tests, docs tests, lint.

## Docs

`guide/actions.md` (new "Raw Request Bodies" section), `guide/plugins.md` (short-circuit + the body-consumption caveat for hooks), `reference/servers.md` (request flow and param loading), `reference/classes.md` (`Connection.rawRequest`).

Version bumped 0.41.2 → 0.42.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)