### PR TITLE
fix(web): stream non-SSE StreamingResponse bodies instead of buffering them

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -164,8 +164,8 @@ Key points:
 - **`StreamingResponse.sse()`** — SSE with `Content-Type: text/event-stream`, `Cache-Control: no-cache`. Use `send(data, { event?, id? })` to emit events and `close()` to end the stream.
 - **`StreamingResponse.stream(readableStream, { contentType? })`** — raw binary/chunked streaming for file downloads or proxied responses.
 - **`timeout = 0`** — streaming actions should disable the action timeout.
-- **`web.streaming = true`** — tells Swagger to document the endpoint as `text/event-stream` instead of JSON.
-- **Compression is skipped** for SSE responses automatically.
+- **`web.streaming = true`** — documents the endpoint as `text/event-stream` in Swagger, and tells the web server to treat the response as a stream: no compression, no idle timeout. Only needed when you return a raw `Response` wrapping a stream; a `StreamingResponse` gets that treatment on its own.
+- **Compression and the idle timeout are skipped** for streaming responses automatically — SSE and chunked binary alike.
 - **Connection cleanup is deferred** until the stream closes, so sessions and middleware state remain valid during streaming.
 
 ### Transport Behavior

--- a/docs/guide/streaming.md
+++ b/docs/guide/streaming.md
@@ -86,7 +86,7 @@ async run() {
 }
 ```
 
-This wraps any `ReadableStream<Uint8Array>` with the right headers and delivers it as a chunked HTTP response.
+This wraps any `ReadableStream<Uint8Array>` with the right headers and delivers it as a chunked HTTP response. Chunks go out as your stream produces them — nothing is buffered, so memory stays flat no matter how large the download is.
 
 ## What You Get for Free
 
@@ -98,7 +98,7 @@ Unlike raw `Response` passthrough, `StreamingResponse` gives you Keryx's standar
 - **Rate limit headers** — if rate limiting middleware ran before the stream started
 - **Correlation ID** — propagated from the incoming request
 
-Compression is automatically skipped for SSE responses — compressing a real-time event stream adds latency with no benefit.
+Compression and the idle timeout are automatically skipped for every `StreamingResponse` — SSE and chunked alike. Compressing a live stream would buffer chunks until the compressor had enough bytes to be worth a gzip block, which defeats the point, and Bun's idle timeout would cut a stream that goes quiet while an upstream is still computing.
 
 ## Transport Behavior
 

--- a/docs/reference/servers.md
+++ b/docs/reference/servers.md
@@ -64,7 +64,11 @@ The web server can serve static files from a configured directory (default: `ass
 
 ### HTTP Compression
 
-The web server compresses responses using Brotli or gzip when the client supports it (via `Accept-Encoding`). Compression is enabled by default for responses larger than 1024 bytes. The server prefers Brotli when available, falling back to gzip.
+The web server compresses responses using gzip when the client supports it (via `Accept-Encoding`). Compression is enabled by default for responses larger than 1024 bytes.
+
+Streaming responses are never compressed: anything built from a `StreamingResponse`, any `text/event-stream` response, and any response from an action declaring `web.streaming`. They also get Bun's idle timeout disabled, so a stream that pauses between chunks isn't cut.
+
+A response with no `Content-Length` has to be measured before the threshold can be applied. The server reads at most `threshold` bytes to decide, then either sends those bytes as-is or stream-compresses them plus the remainder — a large or slow body is never held in memory in full.
 
 Configure via `config.server.web.compression`:
 

--- a/packages/keryx/__tests__/servers/streaming.test.ts
+++ b/packages/keryx/__tests__/servers/streaming.test.ts
@@ -7,6 +7,9 @@ import { useTestServer } from "../setup";
 
 const getUrl = useTestServer();
 
+/** Delay between chunks of the slow non-SSE stream, in ms. */
+const CHUNK_DELAY = 250;
+
 beforeAll(() => {
   // SSE action that sends a configurable number of counter events
   const sseAction = {
@@ -50,6 +53,56 @@ beforeAll(() => {
     },
   } as unknown as Action;
 
+  // Non-SSE stream that trickles chunks out over time, with a compressible content type
+  // and no Content-Length — the shape that used to be buffered to completion (issue #525)
+  const slowStreamAction = {
+    name: "test:slowStream",
+    inputs: z.object({}),
+    web: { route: "/test/slow-stream", method: HTTP_METHOD.GET },
+    timeout: 0,
+    run: async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          for (let i = 0; i < 3; i++) {
+            controller.enqueue(encoder.encode(`chunk ${i}\n`));
+            await Bun.sleep(CHUNK_DELAY);
+          }
+          controller.close();
+        },
+      });
+      return StreamingResponse.stream(stream, { contentType: "text/plain" });
+    },
+  } as unknown as Action;
+
+  // Raw `Response` passthrough from an action that declares itself streaming — the
+  // declaration is the only signal available here, since a raw Response carries no mark
+  const rawPassthroughAction = {
+    name: "test:rawStream",
+    inputs: z.object({}),
+    web: {
+      route: "/test/raw-stream",
+      method: HTTP_METHOD.GET,
+      streaming: true,
+    },
+    timeout: 0,
+    run: async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          for (let i = 0; i < 3; i++) {
+            controller.enqueue(encoder.encode(`raw ${i}\n`));
+            await Bun.sleep(CHUNK_DELAY);
+          }
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        headers: { "Content-Type": "text/plain" },
+      });
+    },
+  } as unknown as Action;
+
   // SSE action that sends an error mid-stream
   const sseErrorAction = {
     name: "test:sseError",
@@ -66,7 +119,13 @@ beforeAll(() => {
     },
   } as unknown as Action;
 
-  api.actions.actions.push(sseAction, streamAction, sseErrorAction);
+  api.actions.actions.push(
+    sseAction,
+    streamAction,
+    slowStreamAction,
+    rawPassthroughAction,
+    sseErrorAction,
+  );
 });
 
 /**
@@ -96,6 +155,27 @@ function parseSSE(
   }
 
   return events;
+}
+
+/**
+ * Read a response body to completion, recording when each chunk arrived (ms since `start`).
+ */
+async function readWithTimings(res: Response, start: number) {
+  const decoder = new TextDecoder();
+  const arrivals: number[] = [];
+  let body = "";
+  const reader = res.body!.getReader();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value?.byteLength) {
+      arrivals.push(Date.now() - start);
+      body += decoder.decode(value, { stream: true });
+    }
+  }
+
+  return { body, arrivals };
 }
 
 describe("SSE streaming", () => {
@@ -155,5 +235,47 @@ describe("raw streaming", () => {
     expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
     const text = await res.text();
     expect(text).toBe("chunk1chunk2chunk3");
+  });
+
+  test("does not compress non-SSE streams", async () => {
+    const res = await fetch(getUrl() + "/api/test/stream", {
+      headers: { "Accept-Encoding": "gzip, br" },
+    });
+    expect(res.headers.get("Content-Encoding")).toBeNull();
+    expect(await res.text()).toBe("chunk1chunk2chunk3");
+  });
+
+  test("delivers chunks incrementally even when the client accepts gzip", async () => {
+    // Regression test for #525: a compressible, non-SSE stream used to be drained into
+    // memory by compressResponse, so the client got everything at once at the end.
+    const start = Date.now();
+    const res = await fetch(getUrl() + "/api/test/slow-stream", {
+      headers: { "Accept-Encoding": "gzip, br" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Encoding")).toBeNull();
+
+    const { body, arrivals } = await readWithTimings(res, start);
+
+    expect(body).toBe("chunk 0\nchunk 1\nchunk 2\n");
+    // The first bytes must land well before the stream finishes producing them.
+    expect(arrivals.length).toBeGreaterThan(1);
+    expect(arrivals[0]).toBeLessThan(CHUNK_DELAY);
+    expect(arrivals[arrivals.length - 1]).toBeGreaterThanOrEqual(CHUNK_DELAY);
+  });
+
+  test("web.streaming makes a raw Response passthrough stream too", async () => {
+    const start = Date.now();
+    const res = await fetch(getUrl() + "/api/test/raw-stream", {
+      headers: { "Accept-Encoding": "gzip, br" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Encoding")).toBeNull();
+
+    const { body, arrivals } = await readWithTimings(res, start);
+
+    expect(body).toBe("raw 0\nraw 1\nraw 2\n");
+    expect(arrivals.length).toBeGreaterThan(1);
+    expect(arrivals[0]).toBeLessThan(CHUNK_DELAY);
   });
 });

--- a/packages/keryx/__tests__/util/webCompression.test.ts
+++ b/packages/keryx/__tests__/util/webCompression.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, describe, expect, test } from "bun:test";
+import { StreamingResponse } from "../../classes/StreamingResponse";
 import { config } from "../../config";
 import { compressResponse } from "../../util/webCompression";
+import { markStreamingResponse } from "../../util/webStreaming";
 
 const originalThreshold = config.server.web.compression.threshold;
 const originalEnabled = config.server.web.compression.enabled;
@@ -199,5 +201,132 @@ describe("compressResponse", () => {
     const out = await compressResponse(res, reqWith("gzip"));
     expect(out.status).toBe(201);
     expect(out.headers.get("Content-Encoding")).toBe("gzip");
+  });
+});
+
+describe("compressResponse with streaming bodies", () => {
+  /** A stream of `count` chunks of `chunkSize` bytes, counting how many were pulled. */
+  function countingStream(count: number, chunkSize: number) {
+    const counter = { pulled: 0 };
+    let emitted = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (emitted >= count) return controller.close();
+        counter.pulled++;
+        emitted++;
+        controller.enqueue(new Uint8Array(chunkSize).fill(97)); // "a"
+      },
+    });
+    return { stream, counter, totalBytes: count * chunkSize };
+  }
+
+  test("returns a marked streaming response untouched", async () => {
+    const res = markStreamingResponse(
+      new Response(new Blob([LARGE_BODY]).stream(), {
+        headers: { "Content-Type": "application/octet-stream" },
+      }),
+    );
+    const out = await compressResponse(res, reqWith("gzip"));
+    expect(out).toBe(res);
+    expect(out.headers.get("Content-Encoding")).toBeNull();
+  });
+
+  test("returns a StreamingResponse.stream() response untouched", async () => {
+    // The exact shape of issue #525: a non-SSE stream with a compressible content type,
+    // requested by a client that advertises gzip.
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(LARGE_BODY));
+        controller.close();
+      },
+    });
+    const res = StreamingResponse.stream(stream, {
+      contentType: "text/plain",
+    }).toResponse({});
+
+    const out = await compressResponse(res, reqWith("gzip"));
+    expect(out).toBe(res);
+    expect(out.headers.get("Content-Encoding")).toBeNull();
+    expect(await out.text()).toBe(LARGE_BODY);
+  });
+
+  test("does not wait for an unclosed body to end before responding", async () => {
+    // Before the fix this called arrayBuffer(), which only settles when the stream closes —
+    // so a long-lived stream never produced a response at all.
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+        c.enqueue(new Uint8Array(4096).fill(98));
+      },
+    });
+    const res = new Response(stream, {
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    const out = await compressResponse(res, reqWith("gzip"));
+    expect(out.headers.get("Content-Encoding")).toBe("gzip");
+
+    controller.close();
+    await out.body!.cancel();
+  });
+
+  test("reads no more than the threshold before deciding to compress", async () => {
+    const { stream, counter } = countingStream(40, 512); // 20 KB total, 1 KB threshold
+    const res = new Response(stream, {
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    const out = await compressResponse(res, reqWith("gzip"));
+    expect(out.headers.get("Content-Encoding")).toBe("gzip");
+    // A couple of chunks clear the 1024-byte threshold; the other ~37 must still be
+    // unread, i.e. buffered memory is bounded by the threshold and not by body size.
+    expect(counter.pulled).toBeLessThanOrEqual(4);
+
+    await out.body!.cancel();
+  });
+
+  test("compressed chunked body round-trips with no bytes lost or duplicated", async () => {
+    // Exercises the seam between the chunks buffered for the threshold check and the
+    // remainder still in the reader.
+    const { stream, totalBytes } = countingStream(40, 512);
+    const res = new Response(stream, {
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    const out = await compressResponse(res, reqWith("gzip"));
+    const decompressed = new Response(
+      out.body!.pipeThrough(new DecompressionStream("gzip")),
+    );
+    const text = await decompressed.text();
+    expect(text.length).toBe(totalBytes);
+    expect(text).toBe("a".repeat(totalBytes));
+  });
+
+  test("a chunked body under the threshold is reassembled intact", async () => {
+    const { stream, totalBytes } = countingStream(3, 100); // 300 bytes, under threshold
+    const res = new Response(stream, {
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    const out = await compressResponse(res, reqWith("gzip"));
+    expect(out.headers.get("Content-Encoding")).toBeNull();
+    expect(await out.text()).toBe("a".repeat(totalBytes));
+  });
+
+  test("an empty chunked body is handled without throwing", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const res = new Response(stream, {
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    const out = await compressResponse(res, reqWith("gzip"));
+    expect(out.headers.get("Content-Encoding")).toBeNull();
+    expect(await out.text()).toBe("");
   });
 });

--- a/packages/keryx/__tests__/util/webStreaming.test.ts
+++ b/packages/keryx/__tests__/util/webStreaming.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { StreamingResponse } from "../../classes/StreamingResponse";
+import {
+  isStreamingResponse,
+  markStreamingResponse,
+} from "../../util/webStreaming";
+
+describe("webStreaming", () => {
+  test("an unmarked response is not streaming", () => {
+    const res = new Response("hello", {
+      headers: { "Content-Type": "text/plain" },
+    });
+    expect(isStreamingResponse(res)).toBe(false);
+  });
+
+  test("markStreamingResponse marks the response and returns it", () => {
+    const res = new Response("hello");
+    expect(markStreamingResponse(res)).toBe(res);
+    expect(isStreamingResponse(res)).toBe(true);
+  });
+
+  test("the mark does not leak into response headers", () => {
+    const res = markStreamingResponse(new Response("hello"));
+    const headerNames = [...res.headers.keys()];
+    expect(headerNames.some((h) => h.toLowerCase().includes("stream"))).toBe(
+      false,
+    );
+  });
+
+  test("the mark is per-response, not shared", () => {
+    markStreamingResponse(new Response("marked"));
+    expect(isStreamingResponse(new Response("other"))).toBe(false);
+  });
+
+  test("text/event-stream is streaming even without a mark", () => {
+    const res = new Response("data: hi\n\n", {
+      headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+    });
+    expect(isStreamingResponse(res)).toBe(true);
+  });
+
+  test("StreamingResponse.toResponse marks its output", () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const res = StreamingResponse.stream(stream, {
+      contentType: "application/octet-stream",
+    }).toResponse({});
+
+    expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(isStreamingResponse(res)).toBe(true);
+  });
+
+  test("SSE responses built by StreamingResponse are streaming too", () => {
+    const res = StreamingResponse.sse().toResponse({});
+    expect(isStreamingResponse(res)).toBe(true);
+  });
+});

--- a/packages/keryx/classes/Action.ts
+++ b/packages/keryx/classes/Action.ts
@@ -160,7 +160,13 @@ export type ActionConstructorInputs = {
     route?: RegExp | string;
     /** HTTP method to bind the route to */
     method?: HTTP_METHOD;
-    /** When true, Swagger documents this endpoint as returning `text/event-stream` instead of JSON */
+    /**
+     * Declares this endpoint as a stream. Swagger documents it as returning
+     * `text/event-stream` instead of JSON, and the web server passes the response body
+     * through untouched — no compression, no idle timeout — so chunks reach the client as
+     * they are produced. Returning a `StreamingResponse` gets that treatment on its own;
+     * set this when the action hands back a raw `Response` wrapping a stream.
+     */
     streaming?: boolean;
   };
 

--- a/packages/keryx/classes/StreamingResponse.ts
+++ b/packages/keryx/classes/StreamingResponse.ts
@@ -4,6 +4,8 @@
  * WebSocket (incremental messages), or MCP (logging messages + accumulated result).
  */
 
+import { markStreamingResponse } from "../util/webStreaming";
+
 const encoder = new TextEncoder();
 
 /**
@@ -71,6 +73,11 @@ export class StreamingResponse {
    * the provided base headers (CORS, security, session cookie, etc.) with
    * the streaming-specific headers.
    *
+   * The result is marked as a stream (see `markStreamingResponse`) so the web server
+   * passes the body through untouched — no compression, no idle timeout — regardless
+   * of content type. Without the mark, anything other than `text/event-stream` would
+   * be buffered to completion before the first byte reached the client.
+   *
    * @param baseHeaders - Headers from `buildHeaders()` to merge in.
    * @returns A native `Response` with the stream as its body.
    */
@@ -78,10 +85,12 @@ export class StreamingResponse {
     const mergedHeaders = { ...baseHeaders, ...this.headers };
     mergedHeaders["Content-Type"] = this.contentType;
 
-    return new Response(this.stream, {
-      status: 200,
-      headers: mergedHeaders,
-    });
+    return markStreamingResponse(
+      new Response(this.stream, {
+        status: 200,
+        headers: mergedHeaders,
+      }),
+    );
   }
 }
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.41.2",
+  "version": "0.41.3",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/servers/web.ts
+++ b/packages/keryx/servers/web.ts
@@ -30,6 +30,10 @@ import {
 } from "../util/webSocket";
 import { shouldWarnStackLeak } from "../util/webStackLeakWarning";
 import { handleStaticFile } from "../util/webStaticFiles";
+import {
+  isStreamingResponse,
+  markStreamingResponse,
+} from "../util/webStreaming";
 
 /**
  * Per-request context passed to {@link BeforeRequestHook} and {@link AfterRequestHook}.
@@ -285,8 +289,10 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
       await hook(req, response, ctx, outcome);
     }
 
-    // SSE and other streaming responses: disable idle timeout and skip compression
-    if (response.headers.get("Content-Type")?.includes("text/event-stream")) {
+    // Streaming responses (SSE, chunked downloads, proxied bodies): disable the idle
+    // timeout so a stream that goes quiet between chunks is not cut, and skip compression
+    // so the body is passed through byte-for-byte as it is produced.
+    if (isStreamingResponse(response)) {
       server.timeout(req, 0);
       return response;
     }
@@ -606,10 +612,21 @@ export class WebServer extends Server<ReturnType<typeof Bun.serve>> {
       errorStatusCode = ErrorStatusCodes[error.type];
     }
 
+    const builtResponse = error
+      ? buildError(connection, error, errorStatusCode, requestOrigin)
+      : buildResponse(connection, response, 200, requestOrigin);
+
+    // An action that declares `web.streaming` can also hand back a raw `Response` wrapping a
+    // stream (a proxied upstream, `Bun.file()`, an LLM relay). Treat the declaration as a
+    // transport hint so those bodies get the same pass-through treatment as a
+    // `StreamingResponse`. Errors are ordinary JSON, so they stay compressible.
+    if (!error && actionName) {
+      const action = api.actions.actions.find((a) => a.name === actionName);
+      if (action?.web?.streaming) markStreamingResponse(builtResponse);
+    }
+
     return {
-      response: error
-        ? buildError(connection, error, errorStatusCode, requestOrigin)
-        : buildResponse(connection, response, 200, requestOrigin),
+      response: builtResponse,
       actionName: actionName ?? undefined,
     };
   }

--- a/packages/keryx/util/webCompression.ts
+++ b/packages/keryx/util/webCompression.ts
@@ -1,4 +1,5 @@
 import { config } from "../config";
+import { isStreamingResponse } from "./webStreaming";
 
 const INCOMPRESSIBLE_TYPES = new Set([
   "image/png",
@@ -72,12 +73,102 @@ function compressBody(body: ReadableStream, response: Response): Response {
 }
 
 /**
+ * Reader/stream shapes described structurally, because Bun's and Node's `ReadableStream`
+ * typings disagree over members like `readMany` — a `Response.body` satisfies either.
+ */
+type BodyReader = {
+  read(): Promise<{ done: boolean; value?: Uint8Array }>;
+  cancel(reason?: unknown): Promise<void>;
+};
+type BodyStream = { getReader(): BodyReader };
+
+/**
+ * Read from a body stream until at least `limit` bytes are buffered or the stream ends.
+ *
+ * Used to answer "does this response clear the compression threshold?" for bodies with no
+ * `Content-Length`, without draining the whole body. The reader is returned still locked to
+ * the stream so the caller can resume from where this stopped.
+ *
+ * @param body The response body to read from.
+ * @param limit Stop reading once this many bytes have been buffered.
+ * @returns The buffered chunks, their total size, whether the stream ended, and the reader.
+ */
+async function readUpTo(
+  body: BodyStream,
+  limit: number,
+): Promise<{
+  chunks: Uint8Array[];
+  size: number;
+  ended: boolean;
+  reader: BodyReader;
+}> {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+
+  while (size < limit) {
+    const { done, value } = await reader.read();
+    if (done) return { chunks, size, ended: true, reader };
+    if (value?.byteLength) {
+      chunks.push(value);
+      size += value.byteLength;
+    }
+  }
+
+  return { chunks, size, ended: false, reader };
+}
+
+/**
+ * Flatten buffered chunks into a single view over a fresh `ArrayBuffer` of exactly `size`
+ * bytes — a concrete `ArrayBuffer` rather than `ArrayBufferLike`, so the result is a valid
+ * `BodyInit` under both the Bun and DOM lib typings.
+ */
+function concatChunks(
+  chunks: Uint8Array[],
+  size: number,
+): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(new ArrayBuffer(size));
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+/**
+ * Rebuild a body stream from the chunks already read plus the rest of the reader, so a
+ * partially-consumed body can be piped onward without buffering what remains.
+ */
+function restoreStream(
+  chunks: Uint8Array[],
+  reader: BodyReader,
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+    },
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) return controller.close();
+      if (value) controller.enqueue(value);
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
+/**
  * Conditionally compress an HTTP response based on the client's `Accept-Encoding` header,
  * the response content type, and the configured compression threshold.
  *
  * Uses the Web Streams `CompressionStream` API for async, non-blocking compression.
- * Skips compression for empty bodies, already-encoded responses, incompressible content
- * types, and responses below the size threshold.
+ * Skips compression for empty bodies, streaming responses, already-encoded responses,
+ * incompressible content types, and responses below the size threshold.
+ *
+ * Bodies with no `Content-Length` are measured by reading at most `threshold` bytes, never
+ * the whole body — memory stays bounded and a large or slow response keeps flowing.
  *
  * @param response The original Response to potentially compress
  * @param req The incoming Request (used to read Accept-Encoding)
@@ -92,9 +183,10 @@ export async function compressResponse(
   // No body to compress
   if (!response.body) return response;
 
-  // Never compress SSE streams
-  if (response.headers.get("Content-Type")?.includes("text/event-stream"))
-    return response;
+  // Never touch a streaming body — SSE, chunked downloads, proxied responses. Compressing
+  // one would mean handing it to a CompressionStream that is free to withhold output until
+  // it has enough bytes to be worth a gzip block, which defeats incremental delivery.
+  if (isStreamingResponse(response)) return response;
 
   // Already compressed
   if (response.headers.get("Content-Encoding")) return response;
@@ -118,18 +210,28 @@ export async function compressResponse(
     return response;
   }
 
-  // For responses without Content-Length, we need to read the body to check size
-  // This covers most of our responses (JSON action responses, error responses)
+  // Without a Content-Length the size is unknown until the body is read — which covers most
+  // of our responses (JSON action responses, error responses). Read only as far as the
+  // threshold, which is all it takes to answer "is this worth compressing?", then either
+  // return the buffered bytes as-is or stream-compress the buffered prefix plus the rest.
+  // Draining the whole body here would hold an arbitrarily large response in memory and
+  // stall delivery until the body closed.
   if (!contentLength) {
-    const body = await response.arrayBuffer();
-    if (body.byteLength < config.server.web.compression.threshold) {
-      return new Response(body, {
+    const threshold = config.server.web.compression.threshold;
+    const { chunks, size, ended, reader } = await readUpTo(
+      response.body,
+      threshold,
+    );
+
+    if (ended) {
+      // The whole body fit under the threshold, so send exactly those bytes back.
+      return new Response(size > 0 ? concatChunks(chunks, size) : null, {
         status: response.status,
         headers: response.headers,
       });
     }
 
-    return compressBody(new Blob([body]).stream(), response);
+    return compressBody(restoreStream(chunks, reader), response);
   }
 
   // Content-Length is present and above threshold — stream-compress

--- a/packages/keryx/util/webStreaming.ts
+++ b/packages/keryx/util/webStreaming.ts
@@ -1,0 +1,47 @@
+/**
+ * Transport-level bookkeeping for streaming HTTP responses.
+ *
+ * A `Response` whose body is produced incrementally must not be buffered, compressed,
+ * or cut short by an idle timeout. There is no way to detect that from the `Response`
+ * itself — every `Response` body is a `ReadableStream`, and a streaming body has no
+ * `Content-Length` to distinguish it from a small JSON payload. So the code that
+ * *creates* the response marks it here, and the web server reads the mark back when
+ * deciding whether to compress and whether to disarm Bun's idle timeout.
+ */
+
+/**
+ * Responses known to be streams. A `WeakSet` keeps this out of the response's own
+ * headers (nothing leaks to the client) and lets the entries be collected with the
+ * responses themselves.
+ */
+const streamingResponses = new WeakSet<Response>();
+
+/**
+ * Mark a response as a stream so the web server skips compression and disables the
+ * idle timeout for it.
+ *
+ * @param response - The response to mark. Returned as-is for call-site chaining.
+ * @returns The same response instance that was passed in.
+ */
+export function markStreamingResponse<T extends Response>(response: T): T {
+  streamingResponses.add(response);
+  return response;
+}
+
+/**
+ * Check whether a response should be treated as a stream.
+ *
+ * True for responses explicitly marked by {@link markStreamingResponse} (anything from
+ * `StreamingResponse.toResponse()`, plus raw `Response` passthrough from actions that
+ * declare `web.streaming`), and for any `text/event-stream` response regardless of
+ * origin — SSE is always incremental.
+ *
+ * @param response - The response to inspect.
+ * @returns True when the body must be passed through untouched.
+ */
+export function isStreamingResponse(response: Response): boolean {
+  if (streamingResponses.has(response)) return true;
+  return (
+    response.headers.get("Content-Type")?.includes("text/event-stream") ?? false
+  );
+}


### PR DESCRIPTION
`compressResponse` treated only `text/event-stream` as a stream. Any other streaming response with no `Content-Length` — `StreamingResponse.stream()`, a proxied upstream, a file download — fell into the buffering branch and was drained by `arrayBuffer()` before a single byte reached the client. So the one property `StreamingResponse.stream()` exists to provide didn't hold: no incremental delivery, unbounded response memory, and a long-lived non-SSE stream that never responded at all. `server.timeout(req, 0)` was gated the same way, so a non-SSE stream that went quiet could be cut by Bun's idle timeout.

## What changed

- **`util/webStreaming.ts` (new)** — tracks streaming responses out-of-band in a `WeakSet` rather than inferring them from a media type. Nothing leaks into response headers. `StreamingResponse.toResponse()` marks its output, and `handleIncomingConnection` skips both compression and the idle timeout for anything marked (plus any `text/event-stream` response, whatever its origin).
- **`Action.web.streaming` is now transport-level**, not just a Swagger hint. An action that returns a raw `Response` wrapping a stream can declare itself streaming and get the same pass-through.
- **Bounded measurement in `compressResponse`** — a body with no `Content-Length` still has to be measured, but now only up to `threshold` bytes. Under the threshold, those bytes are returned as-is (unchanged behavior for JSON and error responses). Over it, the buffered prefix plus the remaining reader are stream-compressed, so memory is bounded by the threshold and delivery keeps flowing.

Streaming bodies are skipped rather than stream-compressed on purpose: `CompressionStream` may withhold output until it has enough bytes for a worthwhile gzip block, which would reintroduce the stall this fixes.

## Tests

- `__tests__/util/webStreaming.test.ts` — marker semantics, no header leakage, `StreamingResponse` marks its own output.
- `__tests__/util/webCompression.test.ts` — marked/`StreamingResponse` bodies pass through untouched; an unclosed body no longer blocks a response; at most ~2 chunks of a 40-chunk body are read to clear the threshold; chunked bodies round-trip byte-exact on both sides of the threshold boundary; empty chunked bodies don't throw.
- `__tests__/servers/streaming.test.ts` — end-to-end, `Accept-Encoding: gzip`: a slow `text/plain` stream arrives one chunk at a time (fails without the fix), non-SSE streams are not compressed, and `web.streaming` extends this to raw `Response` passthrough.

Full `bun run ci` is green (1298 tests, 0 failures).

closes #525