### PR TITLE
refactor(docs): regroup navigation by task, generate llms.txt from sidebar

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -15,6 +15,120 @@ const pkg = JSON.parse(
 );
 const version: string = pkg.version;
 
+type SidebarItem = { text: string; link: string };
+type SidebarGroup = { text: string; items: SidebarItem[] };
+
+/**
+ * The guide is grouped by what the reader is trying to do, not by how the
+ * framework is built. Order within each group is the order you'd meet the
+ * ideas building a real app.
+ */
+export const GUIDE_SIDEBAR: SidebarGroup[] = [
+  {
+    // Orientation: what this is, whether it's for you, how it compares.
+    text: "Introduction",
+    items: [
+      { text: "Getting Started", link: "/guide/" },
+      { text: "About Keryx", link: "/guide/about" },
+      { text: "Coming from ActionHero", link: "/guide/from-actionhero" },
+      { text: "Framework Comparisons", link: "/guide/comparisons" },
+    ],
+  },
+  {
+    // The primitives. Everything else composes these.
+    text: "Core Concepts",
+    items: [
+      { text: "Actions", link: "/guide/actions" },
+      { text: "Initializers", link: "/guide/initializers" },
+      { text: "Middleware", link: "/guide/middleware" },
+      { text: "Channels", link: "/guide/channels" },
+      { text: "Background Tasks", link: "/guide/tasks" },
+      { text: "Configuration", link: "/guide/config" },
+    ],
+  },
+  {
+    // How an action reaches the outside world.
+    text: "Transports & Clients",
+    items: [
+      { text: "Streaming", link: "/guide/streaming" },
+      { text: "CLI", link: "/guide/cli" },
+      { text: "MCP Server", link: "/guide/mcp" },
+      { text: "MCP Apps", link: "/guide/mcp-apps" },
+      { text: "Building for AI Agents", link: "/guide/agents" },
+      { text: "Typed Clients", link: "/guide/typed-clients" },
+    ],
+  },
+  {
+    // Things you reach for once the shape of the app exists.
+    text: "Building Your App",
+    items: [
+      { text: "Authentication", link: "/guide/authentication" },
+      { text: "Caching", link: "/guide/caching" },
+      { text: "Advanced Patterns", link: "/guide/advanced-patterns" },
+      { text: "Plugins", link: "/guide/plugins" },
+    ],
+  },
+  {
+    // Everything between "it works locally" and "it's serving traffic".
+    text: "Going to Production",
+    items: [
+      { text: "Testing", link: "/guide/testing" },
+      { text: "Security", link: "/guide/security" },
+      { text: "Observability", link: "/guide/observability" },
+      { text: "Deployment", link: "/guide/deployment" },
+    ],
+  },
+  {
+    // Different audience: people editing these docs, not people using Keryx.
+    text: "Contributing",
+    items: [{ text: "Docs Style Guide", link: "/guide/style-guide" }],
+  },
+];
+
+/** Six pages don't need four headings. Flat, alphabetical by concept. */
+export const REFERENCE_SIDEBAR: SidebarGroup[] = [
+  {
+    text: "Reference",
+    items: [
+      { text: "Action", link: "/reference/actions" },
+      { text: "Initializer", link: "/reference/initializers" },
+      { text: "Core Classes", link: "/reference/classes" },
+      { text: "Servers", link: "/reference/servers" },
+      { text: "Utilities", link: "/reference/utilities" },
+      { text: "Configuration", link: "/reference/config" },
+    ],
+  },
+];
+
+export const PLUGINS_SIDEBAR: SidebarGroup[] = [
+  {
+    text: "First-Party Plugins",
+    items: [
+      { text: "Overview", link: "/plugins/" },
+      { text: "Tracing", link: "/plugins/tracing" },
+      { text: "Resque Admin", link: "/plugins/resque-admin" },
+      { text: "CSRF", link: "/plugins/csrf" },
+    ],
+  },
+];
+
+/** Render a sidebar group as markdown links for the LLM landing page. */
+function renderLlmSection(heading: string, groups: SidebarGroup[]): string {
+  const lines = [`## ${heading}`, ""];
+  for (const group of groups) {
+    for (const item of group.items) {
+      const path = item.link.endsWith("/")
+        ? `${item.link}index.md`
+        : `${item.link}.md`;
+      lines.push(`- ${item.text}: ${path}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+// Derived from the sidebars above rather than hand-maintained — the previous
+// hand-written list had silently drifted, omitting the changelog and the style
+// guide. Adding a page to a sidebar now adds it here too.
 export const LLM_LANDING_PAGE = `# Keryx
 
 > The fullstack TypeScript framework for MCP and APIs, built on Bun.
@@ -29,48 +143,15 @@ This is the Keryx documentation site. Two LLM-friendly documentation formats are
 Each documentation page is available in Markdown format by appending \`.md\` to the URL.
 For example: \`/guide/actions.md\`, \`/reference/config.md\`
 
-## Guide
+${renderLlmSection("Guide", GUIDE_SIDEBAR)}
 
-- Getting Started: /guide/index.md
-- About Keryx: /guide/about.md
-- Actions: /guide/actions.md
-- Streaming: /guide/streaming.md
-- Initializers: /guide/initializers.md
-- Channels: /guide/channels.md
-- Tasks: /guide/tasks.md
-- Middleware: /guide/middleware.md
-- MCP Server: /guide/mcp.md
-- MCP Apps (Dynamic UIs): /guide/mcp-apps.md
-- Configuration: /guide/config.md
-- Plugins: /guide/plugins.md
-- CLI: /guide/cli.md
-- Authentication: /guide/authentication.md
-- Typed Clients: /guide/typed-clients.md
-- Building for AI Agents: /guide/agents.md
-- Caching: /guide/caching.md
-- Security: /guide/security.md
-- Advanced Patterns: /guide/advanced-patterns.md
-- Observability: /guide/observability.md
-- Testing: /guide/testing.md
-- Deployment: /guide/deployment.md
-- Coming from ActionHero: /guide/from-actionhero.md
-- Framework Comparisons: /guide/comparisons.md
+${renderLlmSection("Reference", REFERENCE_SIDEBAR)}
 
-## Reference
+${renderLlmSection("Plugins", PLUGINS_SIDEBAR)}
 
-- Action class: /reference/actions.md
-- Initializer class: /reference/initializers.md
-- API, Connection, Channel, Server, TypedError, Logger: /reference/classes.md
-- Servers (HTTP, WebSocket, CLI, MCP): /reference/servers.md
-- Zod Helpers & Utilities: /reference/utilities.md
-- Configuration Reference: /reference/config.md
+## Project
 
-## Plugins
-
-- Plugins Overview: /plugins/index.md
-- Tracing: /plugins/tracing.md
-- Resque Admin: /plugins/resque-admin.md
-- CSRF: /plugins/csrf.md
+- Changelog: /changelog.md
 `;
 
 export function toMarkdownUrl(url: string): string {
@@ -107,6 +188,8 @@ function addLlmMiddleware(server: {
 
 export default defineConfig({
   appearance: "dark",
+  // Reads each page's last git commit date; themeConfig.lastUpdated formats it.
+  lastUpdated: true,
   title: "Keryx",
   description:
     "The fullstack TypeScript framework for MCP and APIs — transport-agnostic actions for HTTP, WebSocket, CLI, background tasks, and MCP, built on Bun.",
@@ -175,116 +258,9 @@ export default defineConfig({
       },
     ],
     sidebar: {
-      "/guide/": [
-        {
-          text: "Introduction",
-          items: [
-            { text: "Getting Started", link: "/guide/" },
-            { text: "About Keryx", link: "/guide/about" },
-          ],
-        },
-        {
-          text: "Core Concepts",
-          items: [
-            { text: "Actions", link: "/guide/actions" },
-            { text: "Streaming", link: "/guide/streaming" },
-            { text: "Initializers", link: "/guide/initializers" },
-            { text: "Channels", link: "/guide/channels" },
-            { text: "Tasks", link: "/guide/tasks" },
-            { text: "Middleware", link: "/guide/middleware" },
-            { text: "MCP", link: "/guide/mcp" },
-            { text: "MCP Apps", link: "/guide/mcp-apps" },
-            { text: "Configuration", link: "/guide/config" },
-            { text: "Plugins", link: "/guide/plugins" },
-          ],
-        },
-        {
-          text: "Usage",
-          items: [
-            { text: "CLI", link: "/guide/cli" },
-            { text: "Authentication", link: "/guide/authentication" },
-            { text: "Typed Clients", link: "/guide/typed-clients" },
-            {
-              text: "Building for AI Agents",
-              link: "/guide/agents",
-            },
-            { text: "Caching", link: "/guide/caching" },
-            { text: "Security", link: "/guide/security" },
-            { text: "Advanced Patterns", link: "/guide/advanced-patterns" },
-            { text: "Observability", link: "/guide/observability" },
-            { text: "Testing", link: "/guide/testing" },
-            { text: "Deployment", link: "/guide/deployment" },
-          ],
-        },
-        {
-          text: "Migration",
-          items: [
-            {
-              text: "Coming from ActionHero",
-              link: "/guide/from-actionhero",
-            },
-          ],
-        },
-        {
-          text: "Comparisons",
-          items: [
-            {
-              text: "Framework Comparisons",
-              link: "/guide/comparisons",
-            },
-          ],
-        },
-        {
-          text: "Contributing",
-          items: [{ text: "Style Guide", link: "/guide/style-guide" }],
-        },
-      ],
-      "/plugins/": [
-        {
-          text: "First-Party Plugins",
-          items: [
-            { text: "Overview", link: "/plugins/" },
-            { text: "Tracing", link: "/plugins/tracing" },
-            { text: "Resque Admin", link: "/plugins/resque-admin" },
-            { text: "CSRF", link: "/plugins/csrf" },
-          ],
-        },
-      ],
-      "/reference/": [
-        {
-          text: "Classes",
-          items: [
-            { text: "Action", link: "/reference/actions" },
-            { text: "Initializer", link: "/reference/initializers" },
-            {
-              text: "API, Connection, Channel & more",
-              link: "/reference/classes",
-            },
-          ],
-        },
-        {
-          text: "Transports",
-          items: [
-            {
-              text: "Servers (HTTP, WebSocket, CLI, MCP)",
-              link: "/reference/servers",
-            },
-          ],
-        },
-        {
-          text: "Utilities",
-          items: [
-            {
-              text: "Zod Helpers & Mixins",
-              link: "/reference/utilities",
-            },
-          ],
-        },
-        {
-          text: "Configuration",
-          items: [{ text: "Config Reference", link: "/reference/config" }],
-        },
-      ],
+      "/guide/": GUIDE_SIDEBAR,
+      "/plugins/": PLUGINS_SIDEBAR,
+      "/reference/": REFERENCE_SIDEBAR,
     },
     socialLinks: [
       {
@@ -293,6 +269,14 @@ export default defineConfig({
       },
     ],
     search: { provider: "local" },
+    editLink: {
+      pattern: "https://github.com/actionhero/keryx/edit/main/docs/:path",
+      text: "Edit this page on GitHub",
+    },
+    lastUpdated: {
+      text: "Last updated",
+      formatOptions: { dateStyle: "medium" },
+    },
     footer: {
       message: "Released under the MIT License.",
       copyright: "Copyright © 2024-present Evan Tahler",

--- a/docs/__tests__/docs.test.ts
+++ b/docs/__tests__/docs.test.ts
@@ -98,6 +98,16 @@ describe("sidebar", () => {
     expect(missing).toEqual([]);
   });
 
+  // The LLM landing page is derived from the sidebars, so this holds by
+  // construction — but it's the assertion that would have caught the old
+  // hand-maintained list silently dropping pages.
+  test("the LLM landing page lists every guide and reference page", () => {
+    const missing = contentFiles
+      .map((f) => relative(docsDir, f))
+      .filter((rel) => !LLM_LANDING_PAGE.includes(rel));
+    expect(missing).toEqual([]);
+  });
+
   test("every guide/reference page is in the sidebar", () => {
     const orphans: string[] = [];
     for (const file of contentFiles) {

--- a/docs/guide/mcp-apps.md
+++ b/docs/guide/mcp-apps.md
@@ -2,7 +2,7 @@
 description: MCP Apps — render an action's MCP tool result as an interactive HTML UI in the host. Point mcp.ui.client at a browser entrypoint; Keryx bundles it and delivers structured data via UIResponse.
 ---
 
-# MCP Apps (Dynamic UIs)
+# MCP Apps
 
 [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview) is an extension to the Model Context Protocol that lets a tool return an **interactive HTML UI** instead of just text. The host (Claude, Claude Desktop, VS Code Copilot, and others) renders that UI inline in the conversation, inside a sandboxed iframe. The UI can call back into your server's tools and receive fresh data — a dashboard, form, chart, or viewer that lives right next to the chat.
 

--- a/docs/reference/classes.md
+++ b/docs/reference/classes.md
@@ -2,7 +2,7 @@
 description: API singleton, Connection, Channel, Server, TypedError, and Logger class definitions.
 ---
 
-# Other Classes
+# Core Classes
 
 The remaining framework classes — the API singleton, connections, channels, servers, errors, and logging.
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -6,7 +6,7 @@ description: Auto-generated configuration reference — every config key, its en
 import configData from '../.vitepress/data/config.json'
 </script>
 
-# Configuration Reference
+# Configuration
 
 Every config key in the backend, auto-generated from source. Each key can be overridden via environment variable — the system checks for `ENV_VAR_NODEENV` first (e.g., `DATABASE_URL_TEST` when `NODE_ENV=test`), then `ENV_VAR`, then falls back to the default.
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.42.1",
+  "version": "0.42.2",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
A deep look at the docs taxonomy. This PR implements the navigation changes; the content-level restructuring it surfaced is proposed at the bottom for a separate pass, since moving prose is a bigger call than moving links.

## What's wrong today

The guide sidebar grew by accretion rather than design:

```
Introduction     2 pages
Core Concepts   10 pages   ← primitives + features + config, no through-line
Usage           10 pages   ← junk drawer
Migration        1 page    ┐
Comparisons      1 page    ├ three groups holding one page each
Contributing     1 page    ┘
```

"Core Concepts" mixes genuine primitives (Actions, Initializers, Middleware) with a transport feature (Streaming), a spec extension (MCP Apps), an operational concern (Configuration), and an extension mechanism (Plugins). "Usage" has no organizing principle at all — CLI sits next to Security sits next to Deployment. A reader can't tell where they are in a journey, because there isn't one.

Two more problems the data turned up:

**Nine pages had a sidebar label that disagreed with their own H1.** Worst offenders: `reference/utilities` was labelled "Zod Helpers & Mixins" while the page (after #529) covers loaders, CLI helpers, the swagger cache, constants, and test helpers — the label actively misdescribes it. `reference/classes` was "API, Connection, Channel & more" in the sidebar and "Other Classes" on the page. This hurts search and SEO, where the label and title are what people match against.

**`LLM_LANDING_PAGE` was a hand-maintained list of every page, and it had drifted** — silently omitting `changelog.md` and `guide/style-guide.md`. Exactly the failure mode of any list that has to be updated by hand.

## What this PR changes

Regrouped by what the reader is doing, sized 4 / 6 / 6 / 4 / 4 / 1:

| Group | Pages | Rationale |
| --- | --- | --- |
| **Introduction** | Getting Started, About, Coming from ActionHero, Framework Comparisons | Orientation. Absorbs the two former single-item groups — "is this for me, how does it compare, what changed from ActionHero" is one question, not three sections |
| **Core Concepts** | Actions, Initializers, Middleware, Channels, Background Tasks, Configuration | Only the primitives. Streaming, MCP, MCP Apps, and Plugins move out — they're things you do *with* the primitives |
| **Transports & Clients** | Streaming, CLI, MCP Server, MCP Apps, Building for AI Agents, Typed Clients | How an action reaches the outside world. Gives the MCP trio a home together instead of splitting them across two groups |
| **Building Your App** | Authentication, Caching, Advanced Patterns, Plugins | What you reach for once the shape of the app exists |
| **Going to Production** | Testing, Security, Observability, Deployment | Everything between "works locally" and "serving traffic". Security moves here — it's hardening for deploy, not a usage topic |
| **Contributing** | Docs Style Guide | Genuinely a different audience. The one remaining single-item group, and defensible for that reason |

Reference was four headings over six pages — now flat under one.

Labels and H1s now agree everywhere. Renames: "Other Classes" → **Core Classes**, "Zod Helpers & Mixins" → **Utilities**, "Config Reference" → **Configuration**, "MCP" → **MCP Server**, "Tasks" → **Background Tasks**, "MCP Apps (Dynamic UIs)" → **MCP Apps** (the parenthetical moves to the frontmatter description, where it still feeds search).

`LLM_LANDING_PAGE` is now derived from the sidebar definitions rather than hand-written, so adding a page to a sidebar adds it to the LLM index automatically. A new test asserts the coverage regardless of how it's produced.

Also turns on `editLink` — nothing previously invited readers to fix a doc they'd just found wrong — and `lastUpdated`, so pages carry their git commit date.

**No page content moved.** This is navigation only, so it's easy to review and easy to revert.

## Proposed next: content restructuring

Three findings need content moves rather than link moves. Flagging rather than doing, since they change what pages exist:

**1. `advanced-patterns.md` (429 lines) is four unrelated topics.** Middleware Factories, RBAC, Database Transactions, Audit Logging. Nobody navigates to "advanced patterns" — they navigate to the thing they need. Suggest dissolving it: factories → `middleware.md`, RBAC → `authentication.md` or its own page, transactions → a new database guide, audit logging → its own short page.

**2. There is no database guide, and that's the largest coverage gap on the site.** Drizzle and Postgres are core dependencies. `drizzle` appears across nine pages; transactions are documented only inside `advanced-patterns.md` and `middleware.md`. There's no page a reader can go to for schema, migrations, queries, and transactions. I'd add `guide/database.md` and move the transaction material into it.

**3. `mcp.md` is 510 lines and is really two documents** — the MCP server, and OAuth 2.1. OAuth spans ~150 lines and is the part most likely to be searched on its own. Suggest splitting `guide/mcp-oauth.md` out, which would also resolve the overlap with `authentication.md`.

Happy to take any of these in a follow-up; wanted the navigation change reviewable on its own first.

## Testing

`docs`: 27/27 pass (1 new), build succeeds, `bun lint` clean across all workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)