### PR TITLE
fix(swagger): warn before ts-morph generation, document `keryx build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,16 @@ If you're coming from ActionHero, the biggest changes are: unified controllers (
 
 Each application has its own `Dockerfile`, and a `docker-compose.yml` runs them together. You probably won't use this exact setup in production, but it shows how the pieces fit together.
 
+**Run `keryx build` at image build time.** It pre-generates the OpenAPI response schemas into `.cache/swagger-schemas.json` so the server doesn't have to derive them from your action return types on every boot:
+
+```dockerfile
+COPY . .
+RUN cd backend && bun keryx.ts build
+CMD ["bun", "keryx.ts", "start"]
+```
+
+See the [deployment guide](https://keryxjs.com/guide/deployment#build-step) for details.
+
 ## Documentation
 
 Full docs at [keryxjs.com](https://keryxjs.com), including:

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -137,7 +137,9 @@ RUN bun keryx.ts build
 CMD ["bun", "keryx.ts", "start"]
 ```
 
-If you skip this step, the server will attempt to generate schemas on the fly at startup. On machines with limited memory this may cause an out-of-memory crash. If ts-morph fails without crashing the process, the server will start with empty swagger response schemas.
+If you skip this step, the server generates the schemas on the fly at startup instead. That analysis can peak over 1 GB of RSS on a large app, which is enough to get the process OOM-killed on a small container before it finishes booting. The server logs a warning naming this remedy *before* it starts generating, so the message survives a kill. If ts-morph fails without crashing the process, the server starts with empty swagger response schemas.
+
+See [Deployment](/guide/deployment#build-step) for the full picture.
 
 ### `keryx start`
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -6,6 +6,39 @@ description: Deploying Keryx — Docker, production builds, reverse proxies, and
 
 Keryx is a backend API server. The included Vite + React frontend is a demo app — in production you'll bring your own client. This guide focuses on deploying the backend.
 
+## Build Step
+
+Run `keryx build` at image build time. It is the one deploy step Keryx really wants you to have:
+
+```bash
+cd backend && bun keryx.ts build
+```
+
+The command analyzes every action's return type with [ts-morph](https://ts-morph.com) and writes the result to `.cache/swagger-schemas.json`. At startup the server looks for that file, and — if its hash still matches your action sources — loads the schemas and moves on.
+
+**Without it, the server does the same analysis on every boot.** ts-morph loads the whole TypeScript program into memory, so peak RSS during that window scales with your action count: an app with ~100 actions peaks near 1.5 GB, roughly 18× its ~80 MB steady state, for about three seconds. On a 512 MB container the kernel kills the process before it finishes, and because the kill lands mid-analysis you get no application log at all — just the host's OOM notice. Container filesystems don't survive a restart, so a fresh container never has the cache and every deploy pays it.
+
+Keryx now warns before it starts generating, so if you do hit this the log names the cause:
+
+```
+warning: no swagger schema cache found at .cache/swagger-schemas.json;
+generating response schemas via ts-morph. This takes seconds and can peak
+over 1 GB of RSS, which will OOM a memory-capped host. Run `keryx build`
+at build time to pre-generate them and skip this step.
+```
+
+`keryx build` needs no database and no Redis, which is what makes it safe to run inside an image build:
+
+```dockerfile
+COPY . .
+RUN cd backend && bun keryx.ts build
+CMD ["bun", "keryx.ts", "start"]
+```
+
+If you can't add a build step, the fallbacks are to give the runtime host enough headroom to absorb the spike (~1.5 GB for a large app), or to bake the cache in some other way — a persistent volume mounted at `.cache/` also works, since the server rewrites the file whenever it does regenerate.
+
+See [`keryx build`](/guide/cli#keryx-build) for the full command reference.
+
 ## Production Start
 
 ```bash
@@ -23,7 +56,7 @@ There's a `docker-compose.yaml` to run the backend with PostgreSQL and Redis:
 docker compose up
 ```
 
-You probably won't use this exact setup in production, but it shows how the pieces fit together and gives you a working reference for your own deployment config.
+You probably won't use this exact setup in production, but it shows how the pieces fit together and gives you a working reference for your own deployment config. The backend `Dockerfile` runs `bun keryx.ts build` before its `CMD` — keep that line in whatever image you build.
 
 ## Environment Variables
 

--- a/packages/keryx/__tests__/initializers/swagger.test.ts
+++ b/packages/keryx/__tests__/initializers/swagger.test.ts
@@ -1,15 +1,49 @@
 import { describe, expect, test } from "bun:test";
 import { rm } from "fs/promises";
 import path from "path";
-import { api } from "../../api";
+import { api, logger } from "../../api";
+import { LogLevel } from "../../classes/Logger";
+import { SwaggerInitializer } from "../../initializers/swagger";
 import {
   computeActionsHash,
   loadCachedSchemas,
+  SCHEMA_CACHE_DIR,
+  SCHEMA_CACHE_RELATIVE_PATH,
   writeSchemasCache,
 } from "../../util/swaggerSchemaGenerator";
-import { useTestServer } from "./../setup";
+import { HOOK_TIMEOUT, useTestServer } from "./../setup";
 
 useTestServer();
+
+/**
+ * Run the swagger initializer with the cache in a given state, capturing every
+ * log line it emits so we can assert on both content and ordering. Restores the
+ * logger and the original cache file afterwards.
+ */
+async function initializeCapturingLogs(
+  prepareCache: () => Promise<void>,
+): Promise<string[]> {
+  const originalCache = await loadCachedSchemas(api.rootDir);
+  const originalStream = logger.outputStream;
+  const originalLevel = logger.level;
+  const lines: string[] = [];
+
+  logger.outputStream = (...args: unknown[]) => {
+    lines.push(args.join(" "));
+  };
+  logger.level = LogLevel.info;
+
+  try {
+    await prepareCache();
+    await new SwaggerInitializer().initialize();
+  } finally {
+    logger.outputStream = originalStream;
+    logger.level = originalLevel;
+    if (originalCache) await writeSchemasCache(api.rootDir, originalCache);
+  }
+
+  return lines;
+}
 
 describe("swagger initializer", () => {
   test("swagger namespace is initialized", () => {
@@ -84,5 +118,68 @@ describe("swagger cache behavior", () => {
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+// Generating schemas via ts-morph can peak over 1 GB of RSS, which is enough to
+// get a container OOM-killed mid-boot. The warning has to be emitted *before*
+// the work starts, or the process that most needs it never lives to log it.
+describe("swagger cache-miss warning", () => {
+  test(
+    "warns and names `keryx build` before running ts-morph",
+    async () => {
+      const lines = await initializeCapturingLogs(() =>
+        rm(path.join(api.rootDir, SCHEMA_CACHE_DIR), {
+          recursive: true,
+          force: true,
+        }),
+      );
+
+      const warnIndex = lines.findIndex((line) =>
+        line.includes("no swagger schema cache found"),
+      );
+      const generatedIndex = lines.findIndex((line) =>
+        line.includes("response schemas for swagger"),
+      );
+
+      expect(warnIndex).toBeGreaterThanOrEqual(0);
+      expect(lines[warnIndex]).toContain(`[${LogLevel.warn}]`);
+      expect(lines[warnIndex]).toContain(SCHEMA_CACHE_RELATIVE_PATH);
+      expect(lines[warnIndex]).toContain("keryx build");
+      expect(lines[warnIndex]).toContain("OOM");
+
+      // The warning must precede the generation it is warning about.
+      expect(generatedIndex).toBeGreaterThan(warnIndex);
+    },
+    HOOK_TIMEOUT,
+  );
+
+  test(
+    "distinguishes a stale cache from a missing one",
+    async () => {
+      const lines = await initializeCapturingLogs(async () => {
+        await writeSchemasCache(api.rootDir, {
+          hash: "stale-hash",
+          responseSchemas: {},
+        });
+      });
+
+      const warning = lines.find((line) => line.includes("keryx build"));
+      expect(warning).toBeDefined();
+      expect(warning).toContain("is stale");
+    },
+    HOOK_TIMEOUT,
+  );
+
+  test("says nothing when the cache is valid", async () => {
+    const lines = await initializeCapturingLogs(async () => {
+      const hash = await computeActionsHash(api.rootDir);
+      await writeSchemasCache(api.rootDir, {
+        hash,
+        responseSchemas: api.swagger.responseSchemas,
+      });
+    });
+
+    expect(lines.find((line) => line.includes("keryx build"))).toBeUndefined();
   });
 });

--- a/packages/keryx/initializers/swagger.ts
+++ b/packages/keryx/initializers/swagger.ts
@@ -5,6 +5,7 @@ import {
   computeActionsHash,
   generateSwaggerSchemas,
   loadCachedSchemas,
+  SCHEMA_CACHE_RELATIVE_PATH,
   writeSchemasCache,
 } from "../util/swaggerSchemaGenerator";
 
@@ -33,6 +34,18 @@ export class SwaggerInitializer extends Initializer {
       );
       return { responseSchemas: cached.responseSchemas };
     }
+
+    // No usable cache, so we fall through to ts-morph. This is by far the most
+    // expensive thing that happens at boot (it can peak over 1 GB of RSS on a
+    // large app) and it is the usual cause of an unexplained OOM kill during
+    // startup on a memory-capped host. Warn *before* doing the work — a process
+    // that cannot afford the allocation never reaches a message logged after it.
+    const cacheState = cached
+      ? `swagger schema cache at ${SCHEMA_CACHE_RELATIVE_PATH} is stale`
+      : `no swagger schema cache found at ${SCHEMA_CACHE_RELATIVE_PATH}`;
+    logger.warn(
+      `${cacheState}; generating response schemas via ts-morph. This takes seconds and can peak over 1 GB of RSS, which will OOM a memory-capped host. Run \`keryx build\` at build time to pre-generate them and skip this step — see \`keryx build --help\`.`,
+    );
 
     // Generate schemas via ts-morph
     let responseSchemas: Record<string, JSONSchema> = {};

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.42.2",
+  "version": "0.42.3",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/cli.ts
+++ b/packages/keryx/util/cli.ts
@@ -107,7 +107,9 @@ export async function buildProgram(opts: {
     .description(
       "Run build-time code generation. Analyzes Action return types via ts-morph\n" +
         "and writes .cache/swagger-schemas.json so the server can skip this step at\n" +
-        "startup. Recommended for memory-constrained environments (e.g., Docker).\n\n" +
+        "startup. Strongly recommended for memory-constrained environments (e.g.,\n" +
+        "Docker): the analysis can peak over 1 GB of RSS and will OOM a small\n" +
+        "container if it runs at boot instead. Needs no database and no Redis.\n\n" +
         "Example Dockerfile usage:\n" +
         "  COPY . .\n" +
         "  RUN bun keryx.ts build\n" +

--- a/packages/keryx/util/swaggerSchemaGenerator.ts
+++ b/packages/keryx/util/swaggerSchemaGenerator.ts
@@ -2,6 +2,13 @@ import { mkdir } from "fs/promises";
 import path from "path";
 import type { Type } from "ts-morph";
 
+/** Directory (relative to the app root) holding build-time generated artifacts. */
+export const SCHEMA_CACHE_DIR = ".cache";
+/** File name of the pre-generated swagger response schema cache. */
+export const SCHEMA_CACHE_FILE = "swagger-schemas.json";
+/** Human-readable path to the schema cache, for log and doc messages. */
+export const SCHEMA_CACHE_RELATIVE_PATH = `${SCHEMA_CACHE_DIR}/${SCHEMA_CACHE_FILE}`;
+
 export type JSONSchema = {
   type?: string;
   properties?: Record<string, JSONSchema>;
@@ -202,7 +209,7 @@ export async function loadCachedSchemas(rootDir: string): Promise<{
   hash: string;
   responseSchemas: Record<string, JSONSchema>;
 } | null> {
-  const cacheFile = path.join(rootDir, ".cache", "swagger-schemas.json");
+  const cacheFile = path.join(rootDir, SCHEMA_CACHE_DIR, SCHEMA_CACHE_FILE);
   const cacheFileHandle = Bun.file(cacheFile);
   if (await cacheFileHandle.exists()) {
     try {
@@ -325,10 +332,10 @@ export async function writeSchemasCache(
   rootDir: string,
   data: { hash: string; responseSchemas: Record<string, JSONSchema> },
 ): Promise<void> {
-  const cacheDir = path.join(rootDir, ".cache");
+  const cacheDir = path.join(rootDir, SCHEMA_CACHE_DIR);
   await mkdir(cacheDir, { recursive: true });
   await Bun.write(
-    path.join(cacheDir, "swagger-schemas.json"),
+    path.join(cacheDir, SCHEMA_CACHE_FILE),
     JSON.stringify(data, null, 2),
   );
 }


### PR DESCRIPTION
closes #531

## The problem

A container filesystem never carries `.cache/swagger-schemas.json` across a restart, so `SwaggerInitializer` finds no cache and falls through to ts-morph on **every** boot. That analysis peaks over 1 GB of RSS (measured: 1464 MB vs. an 80 MB steady state, ~18×, for about three seconds) and gets the process OOM-killed on a memory-capped host.

The failure is nearly undiagnosable, because the initializer takes the generation branch silently. `Generated N response schemas for swagger` is logged *after* the allocation that kills the process, so the one line that would point at the cause is the line it never reaches. All you get is the host's OOM notice.

`keryx build` already fixes this. Nothing told you it existed.

## Changes

**Warn before doing the work.** `initializers/swagger.ts` now logs at `warn` *before* calling ts-morph — ordering is the whole point, since a message logged afterwards is never logged at all on the host that needs it. It distinguishes a missing cache from a stale one:

```
[warn] no swagger schema cache found at .cache/swagger-schemas.json; generating
response schemas via ts-morph. This takes seconds and can peak over 1 GB of RSS,
which will OOM a memory-capped host. Run `keryx build` at build time to
pre-generate them and skip this step — see `keryx build --help`.
```

**Put the remedy where people will find it.** Previously `keryx build` lived only in its own `--help` text and the initializer's source:

- `docs/guide/deployment.md` — a new **Build Step** section leading the guide: what the command does, the measured cost of skipping it, the Dockerfile pattern, and the fallbacks if you can't add a build step
- `README.md` — the Production Deployment section now names it with the Dockerfile snippet
- `docs/guide/cli.md` — spells out the OOM consequence and links to the deployment guide
- `keryx build --help` — names the ~1 GB peak and that it needs no database or Redis

**Small cleanup.** The `.cache/swagger-schemas.json` path was a repeated string literal in `loadCachedSchemas` and `writeSchemasCache`; it's now `SCHEMA_CACHE_DIR` / `SCHEMA_CACHE_FILE` / `SCHEMA_CACHE_RELATIVE_PATH`, which is also what the log message interpolates.

## Tests

Three new tests in `packages/keryx/__tests__/initializers/swagger.test.ts` drive the initializer with a captured log stream:

- cache missing → warns, names `keryx build` and the cache path, **and the warn line's index precedes the generation line's** (the actual regression guard)
- cache present but hash stale → says `is stale`, not `not found`
- cache valid → no warning at all

Verified end-to-end by booting the example backend with `.cache/` removed.

## Not included

The issue also flags `api/status` reporting `consumedMemoryMB` from `heapUsed` (627 MB reported against 100 MB actual RSS under Bun/JSC). The author explicitly deferred that as possibly its own issue, and the field is consumed by the frontend, the MCP app, and the OpenAPI snapshot tests — worth doing, but separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)