### PR TITLE
feat(sentry): give background tasks a root queue.process transaction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
     },
     "packages/keryx": {
       "name": "keryx",
-      "version": "0.42.5",
+      "version": "0.42.6",
       "bin": {
         "keryx": "keryx.ts",
       },
@@ -146,7 +146,7 @@
     },
     "packages/plugins/sentry": {
       "name": "@keryxjs/sentry",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@sentry/bun": "^10.32.1",
       },

--- a/docs/plugins/sentry.md
+++ b/docs/plugins/sentry.md
@@ -74,7 +74,7 @@ The plugin adds its own `config.sentry.*` namespace. All keys except the `before
 | `redis.<command>`            | `db`          | `db.system="redis"`, `db.operation.name`, `db.query.text`                  | `db.query.text` is `<command> <key1> <key2>…` — keys only, values are never captured           |
 | `pg.<OP>`                    | `db`          | `db.system="postgresql"`, `db.operation.name`, `db.query.text`             | Wraps the node-postgres `Pool` Drizzle uses. SQL text up to 1000 chars; bind values are not    |
 
-Spans nest naturally: the transport span (HTTP request, WebSocket message, MCP message, or background task) is the parent of the action span, which is the parent of any Redis / Postgres spans emitted during the action.
+Spans nest naturally: the transport span (HTTP request, WebSocket message, MCP message, or background task) is the parent of the action span, which is the parent of any Redis / Postgres spans emitted during the action. Nested `connection.act()` calls stay in that same trace — the inner action is a child span, not a new transaction.
 
 ## Error Capture
 
@@ -88,7 +88,7 @@ The plugin uses Sentry's native trace headers:
 
 - **Incoming HTTP**: reads `sentry-trace` / `baggage` and links the request span to the caller's trace.
 - **Outgoing tasks**: injects `_sentryTrace` / `_sentryBaggage` into background task params, so a worker picking up a job continues the originating trace.
-- **Task execution**: extracts those fields, starts a root `queue.process` transaction (`task:<name>`), and strips the headers so they never reach the action's validated params. Scheduled jobs with no incoming headers still get their own root transaction.
+- **Task execution**: extracts those fields, starts a root `queue.process` transaction (`task:<name>`), and strips the headers so they never reach the action's validated params. Scheduled jobs with no incoming headers still get their own root transaction. If that action then calls another action via `connection.act()`, the inner span stays on the same task trace — it does not open a second `task:` transaction.
 
 ## Programmatic Access
 

--- a/docs/plugins/sentry.md
+++ b/docs/plugins/sentry.md
@@ -69,11 +69,12 @@ The plugin adds its own `config.sentry.*` namespace. All keys except the `before
 | `ws.message <type>`          | `ws.server`   | `keryx.ws.message_type`                                                    | Child of the connection span. Action messages stay open until `afterAct`                       |
 | `mcp.connect`                | `mcp.server`  | `keryx.mcp.session_id`                                                     | Opened when the MCP session is initialized, ended on teardown                                  |
 | `mcp.message`                | `mcp.server`  | `keryx.mcp.session_id`                                                     | Child of the session span. Ended when the action finishes or the session closes                |
-| `action:<name>`              | `keryx.action` / `queue.process` | `keryx.action`, `keryx.connection.type`, `keryx.action.duration_ms` | Fires for every action across HTTP, WebSocket, CLI, background tasks, and MCP                  |
+| `task:<name>`                | `queue.process` | `keryx.action`, `keryx.connection.type`, `messaging.destination.name`     | Root transaction for a Resque job. Continues the enqueuer's trace when headers are present; otherwise starts a new trace |
+| `action:<name>`              | `keryx.action` | `keryx.action`, `keryx.connection.type`, `keryx.action.duration_ms`        | Fires for every action across HTTP, WebSocket, CLI, background tasks, and MCP                  |
 | `redis.<command>`            | `db`          | `db.system="redis"`, `db.operation.name`, `db.query.text`                  | `db.query.text` is `<command> <key1> <key2>…` — keys only, values are never captured           |
 | `pg.<OP>`                    | `db`          | `db.system="postgresql"`, `db.operation.name`, `db.query.text`             | Wraps the node-postgres `Pool` Drizzle uses. SQL text up to 1000 chars; bind values are not    |
 
-Spans nest naturally: the transport span (HTTP request, WebSocket message, or MCP message) is the parent of the action span, which is the parent of any Redis / Postgres spans emitted during the action.
+Spans nest naturally: the transport span (HTTP request, WebSocket message, MCP message, or background task) is the parent of the action span, which is the parent of any Redis / Postgres spans emitted during the action.
 
 ## Error Capture
 
@@ -87,7 +88,7 @@ The plugin uses Sentry's native trace headers:
 
 - **Incoming HTTP**: reads `sentry-trace` / `baggage` and links the request span to the caller's trace.
 - **Outgoing tasks**: injects `_sentryTrace` / `_sentryBaggage` into background task params, so a worker picking up a job continues the originating trace.
-- **Task execution**: extracts those fields before running the action and strips them so they never reach the action's validated params.
+- **Task execution**: extracts those fields, starts a root `queue.process` transaction (`task:<name>`), and strips the headers so they never reach the action's validated params. Scheduled jobs with no incoming headers still get their own root transaction.
 
 ## Programmatic Access
 
@@ -130,7 +131,7 @@ The plugin is fully hook-based — it does **not** modify core Keryx code. It re
 - `api.hooks.mcp.onConnect` / `onMessage` / `onDisconnect` — MCP session and message spans
 - `api.hooks.actions.beforeAct` / `afterAct` — create and finalize the action span; capture 5xx exceptions
 - `api.hooks.actions.onEnqueue` — inject Sentry trace headers into task params
-- `api.hooks.resque.beforeJob` — continue the enqueuer's trace when a worker picks up a task
+- `api.hooks.resque.beforeJob` / `afterJob` — create and finalize the root `queue.process` transaction (continuing the enqueuer's trace when headers are present)
 
 The plugin also wraps `api.redis.redis.sendCommand` and the node-postgres `Pool` on `api.db.pool` after those initializers run. Drizzle goes through that pool, so `api.db.db.execute(...)` and query builders show up as `pg.*` spans.
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.42.5",
+  "version": "0.42.6",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/plugins/sentry/__tests__/sentry.test.ts
+++ b/packages/plugins/sentry/__tests__/sentry.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   type Action,
   api,
+  type Connection,
   config,
   ErrorType,
   HTTP_METHOD,
@@ -63,6 +64,19 @@ class SentryEnqueue implements Action {
   async run() {
     await api.actions.enqueue("status");
     return { enqueued: true };
+  }
+}
+
+class SentryNest implements Action {
+  name = "sentry:nest";
+  description = "Calls status via connection.act()";
+  inputs = z.object({});
+  web = { route: "/sentry-nest", method: HTTP_METHOD.GET };
+  mcp = { tool: false };
+  async run(_params: Record<string, unknown>, connection?: Connection) {
+    const { error } = await connection!.act("status", {});
+    if (error) throw error;
+    return { nested: true };
   }
 }
 
@@ -135,13 +149,20 @@ describe("sentry plugin (enabled)", () => {
     api.actions.actions.push(boom);
     api.resque.jobs[boom.name] = api.resque.wrapActionAsJob(boom);
     api.actions.actions.push(new SentryEnqueue());
+    const nest = new SentryNest();
+    api.actions.actions.push(nest);
+    api.resque.jobs[nest.name] = api.resque.wrapActionAsJob(nest);
   }, HOOK_TIMEOUT);
 
   afterAll(async () => {
     api.actions.actions = api.actions.actions.filter(
-      (a: Action) => a.name !== "sentry:boom" && a.name !== "sentry:enqueue",
+      (a: Action) =>
+        a.name !== "sentry:boom" &&
+        a.name !== "sentry:enqueue" &&
+        a.name !== "sentry:nest",
     );
     delete api.resque.jobs["sentry:boom"];
+    delete api.resque.jobs["sentry:nest"];
     await api.stop();
     config.plugins = [];
   }, HOOK_TIMEOUT);
@@ -325,6 +346,7 @@ describe("sentry plugin (enabled)", () => {
 
   test("enqueued tasks continue the originating HTTP trace", async () => {
     spans.length = 0;
+    await api.actions.delQueue("default");
     const res = await fetch(`${serverUrl()}/api/sentry-enqueue`);
     expect(res.status).toBe(200);
 
@@ -339,12 +361,58 @@ describe("sentry plugin (enabled)", () => {
     await Bun.sleep(50);
 
     const httpSpan = spans.find(
-      (s) => s.op === "http.server" || s.name.includes("sentry:enqueue"),
+      (s) => s.op === "http.server" && s.name.includes("sentry:enqueue"),
     );
     const taskSpan = spans.find((s) => s.name === "task:status");
     expect(httpSpan).toBeDefined();
     expect(taskSpan).toBeDefined();
     expect(taskSpan!.traceId).toBe(httpSpan!.traceId);
+  });
+
+  test("nested connection.act() from HTTP stays on the same parent trace", async () => {
+    spans.length = 0;
+    const res = await fetch(`${serverUrl()}/api/sentry-nest`);
+    expect(res.status).toBe(200);
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    const httpSpan = spans.find(
+      (s) => s.op === "http.server" || s.name.includes("sentry:nest"),
+    );
+    const outer = spans.find((s) => s.name === "action:sentry:nest");
+    const inner = spans.find(
+      (s) =>
+        s.name === "action:status" && s.data["keryx.connection.type"] === "web",
+    );
+    expect(httpSpan).toBeDefined();
+    expect(outer).toBeDefined();
+    expect(inner).toBeDefined();
+    expect(outer!.traceId).toBe(httpSpan!.traceId);
+    expect(inner!.traceId).toBe(httpSpan!.traceId);
+    expect(spans.filter((s) => s.op === "queue.process")).toEqual([]);
+  });
+
+  test("nested connection.act() from a task stays on the task root trace", async () => {
+    spans.length = 0;
+    await performJob("sentry:nest");
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    const taskRoots = spans.filter((s) => s.op === "queue.process");
+    expect(taskRoots).toHaveLength(1);
+    expect(taskRoots[0]!.name).toBe("task:sentry:nest");
+    expect(spans.some((s) => s.name === "task:status")).toBe(false);
+
+    const outer = spans.find((s) => s.name === "action:sentry:nest");
+    const inner = spans.find(
+      (s) =>
+        s.name === "action:status" &&
+        s.data["keryx.connection.type"] === "task",
+    );
+    expect(outer).toBeDefined();
+    expect(inner).toBeDefined();
+    expect(outer!.traceId).toBe(taskRoots[0]!.traceId);
+    expect(inner!.traceId).toBe(taskRoots[0]!.traceId);
   });
 
   test("failed background tasks mark the root span as error and capture the exception", async () => {

--- a/packages/plugins/sentry/__tests__/sentry.test.ts
+++ b/packages/plugins/sentry/__tests__/sentry.test.ts
@@ -80,6 +80,18 @@ class SentryNest implements Action {
   }
 }
 
+class SentryRecurring implements Action {
+  name = "sentry:recurring";
+  description =
+    "Recurring task used to assert cron re-enqueue starts a new trace";
+  inputs = z.object({});
+  mcp = { tool: false };
+  task = { frequency: 60_000, queue: "default" };
+  async run() {
+    return { ok: true };
+  }
+}
+
 async function performJob(
   actionName: string,
   params: Record<string, unknown> = {},
@@ -152,6 +164,9 @@ describe("sentry plugin (enabled)", () => {
     const nest = new SentryNest();
     api.actions.actions.push(nest);
     api.resque.jobs[nest.name] = api.resque.wrapActionAsJob(nest);
+    const recurring = new SentryRecurring();
+    api.actions.actions.push(recurring);
+    api.resque.jobs[recurring.name] = api.resque.wrapActionAsJob(recurring);
   }, HOOK_TIMEOUT);
 
   afterAll(async () => {
@@ -159,10 +174,12 @@ describe("sentry plugin (enabled)", () => {
       (a: Action) =>
         a.name !== "sentry:boom" &&
         a.name !== "sentry:enqueue" &&
-        a.name !== "sentry:nest",
+        a.name !== "sentry:nest" &&
+        a.name !== "sentry:recurring",
     );
     delete api.resque.jobs["sentry:boom"];
     delete api.resque.jobs["sentry:nest"];
+    delete api.resque.jobs["sentry:recurring"];
     await api.stop();
     config.plugins = [];
   }, HOOK_TIMEOUT);
@@ -428,5 +445,17 @@ describe("sentry plugin (enabled)", () => {
     expect(taskSpan).toBeDefined();
     expect(taskSpan!.op).toBe("queue.process");
     expect(events.length).toBeGreaterThan(0);
+  });
+
+  test("recurring re-enqueue does not continue the finished job's trace", async () => {
+    await performJob("sentry:recurring");
+    const delayed = await api.actions.allDelayed();
+    const jobs = Object.values(delayed).flat();
+    const recurring = jobs.filter((j) => j.class === "sentry:recurring");
+    expect(recurring.length).toBeGreaterThan(0);
+    for (const job of recurring) {
+      const payload = (job.args?.[0] ?? {}) as Record<string, unknown>;
+      expect(payload._sentryTrace).toBeUndefined();
+    }
   });
 });

--- a/packages/plugins/sentry/__tests__/sentry.test.ts
+++ b/packages/plugins/sentry/__tests__/sentry.test.ts
@@ -54,6 +54,27 @@ class SentryBoom implements Action {
   }
 }
 
+class SentryEnqueue implements Action {
+  name = "sentry:enqueue";
+  description = "Enqueues status as a background task";
+  inputs = z.object({});
+  web = { route: "/sentry-enqueue", method: HTTP_METHOD.GET };
+  mcp = { tool: false };
+  async run() {
+    await api.actions.enqueue("status");
+    return { enqueued: true };
+  }
+}
+
+async function performJob(
+  actionName: string,
+  params: Record<string, unknown> = {},
+) {
+  const job = api.resque.jobs[actionName];
+  if (!job) throw new Error(`No resque job registered for ${actionName}`);
+  return job.perform.call({ queue: "default" }, params);
+}
+
 describe("sentry plugin (disabled)", () => {
   beforeAll(async () => {
     config.plugins = [sentryPlugin];
@@ -110,13 +131,17 @@ describe("sentry plugin (enabled)", () => {
       return span;
     };
     await api.start();
-    api.actions.actions.push(new SentryBoom());
+    const boom = new SentryBoom();
+    api.actions.actions.push(boom);
+    api.resque.jobs[boom.name] = api.resque.wrapActionAsJob(boom);
+    api.actions.actions.push(new SentryEnqueue());
   }, HOOK_TIMEOUT);
 
   afterAll(async () => {
     api.actions.actions = api.actions.actions.filter(
-      (a: Action) => a.name !== "sentry:boom",
+      (a: Action) => a.name !== "sentry:boom" && a.name !== "sentry:enqueue",
     );
+    delete api.resque.jobs["sentry:boom"];
     await api.stop();
     config.plugins = [];
   }, HOOK_TIMEOUT);
@@ -272,6 +297,68 @@ describe("sentry plugin (enabled)", () => {
     api.sentry.captureMessage("sentry plugin smoke");
     await api.sentry.flush(2000);
     await Bun.sleep(50);
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  test("background tasks create a root queue.process span and a child action span", async () => {
+    spans.length = 0;
+    await performJob("status");
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    const taskSpan = spans.find((s) => s.name === "task:status");
+    const actionSpan = spans.find(
+      (s) =>
+        s.name === "action:status" &&
+        s.data["keryx.connection.type"] === "task",
+    );
+    expect(taskSpan).toBeDefined();
+    expect(taskSpan!.op).toBe("queue.process");
+    expect(taskSpan!.data["keryx.action"]).toBe("status");
+    expect(taskSpan!.data["keryx.connection.type"]).toBe("task");
+    expect(taskSpan!.data["messaging.destination.name"]).toBe("default");
+    expect(actionSpan).toBeDefined();
+    expect(actionSpan!.op).toBe("keryx.action");
+    expect(actionSpan!.parentSpanId).toBeDefined();
+    expect(actionSpan!.traceId).toBe(taskSpan!.traceId);
+  });
+
+  test("enqueued tasks continue the originating HTTP trace", async () => {
+    spans.length = 0;
+    const res = await fetch(`${serverUrl()}/api/sentry-enqueue`);
+    expect(res.status).toBe(200);
+
+    const queued = await api.actions.queued();
+    const statusJob = queued.find((j) => j.class === "status");
+    expect(statusJob).toBeDefined();
+    const payload = statusJob!.args[0] as Record<string, unknown>;
+    expect(typeof payload._sentryTrace).toBe("string");
+
+    await performJob("status", payload);
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    const httpSpan = spans.find(
+      (s) => s.op === "http.server" || s.name.includes("sentry:enqueue"),
+    );
+    const taskSpan = spans.find((s) => s.name === "task:status");
+    expect(httpSpan).toBeDefined();
+    expect(taskSpan).toBeDefined();
+    expect(taskSpan!.traceId).toBe(httpSpan!.traceId);
+  });
+
+  test("failed background tasks mark the root span as error and capture the exception", async () => {
+    spans.length = 0;
+    events.length = 0;
+    await expect(performJob("sentry:boom")).rejects.toThrow(
+      "intentional sentry test failure",
+    );
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    const taskSpan = spans.find((s) => s.name === "task:sentry:boom");
+    expect(taskSpan).toBeDefined();
+    expect(taskSpan!.op).toBe("queue.process");
     expect(events.length).toBeGreaterThan(0);
   });
 });

--- a/packages/plugins/sentry/initializer.ts
+++ b/packages/plugins/sentry/initializer.ts
@@ -458,9 +458,6 @@ export class SentryPlugin extends Initializer {
       if (!api.sentry.enabled) return;
       const parent = this.spanALS.getStore();
       if (!parent) return;
-      if (typeof parent.isRecording === "function" && !parent.isRecording()) {
-        return;
-      }
       const ctx = parent.spanContext();
       if (!ctx.traceId || !ctx.spanId) return;
       const sampled = ctx.traceFlags & 1 ? 1 : 0;

--- a/packages/plugins/sentry/initializer.ts
+++ b/packages/plugins/sentry/initializer.ts
@@ -236,7 +236,7 @@ export class SentryPlugin extends Initializer {
    *  - `mcp.onConnect` / `onMessage` / `onDisconnect`: MCP transport
    *  - `actions.beforeAct` / `actions.afterAct`: action span + errors
    *  - `actions.onEnqueue`: inject Sentry trace headers into task params
-   *  - `resque.beforeJob`: continue the enqueuer's trace
+   *  - `resque.beforeJob` / `afterJob`: root `queue.process` transaction
    */
   private registerTracingHooks() {
     api.hooks.web.beforeRequest((req, ctx) => {
@@ -380,10 +380,7 @@ export class SentryPlugin extends Initializer {
       const parent = this.spanALS.getStore();
       const actionSpan = Sentry.startInactiveSpan({
         name: `action:${actionName ?? "unknown"}`,
-        op:
-          connection.type === CONNECTION_TYPE.TASK
-            ? "queue.process"
-            : "keryx.action",
+        op: "keryx.action",
         parentSpan: parent,
         attributes: {
           "keryx.action": actionName ?? "unknown",
@@ -463,18 +460,47 @@ export class SentryPlugin extends Initializer {
       return next;
     });
 
-    api.hooks.resque.beforeJob((_actionName, params) => {
+    api.hooks.resque.beforeJob((actionName, params, jobCtx) => {
       const p = params as Record<string, unknown>;
       const sentryTrace = p._sentryTrace as string | undefined;
-      if (!sentryTrace) return;
       const baggage = p._sentryBaggage as string | undefined;
       delete p._sentryTrace;
       delete p._sentryBaggage;
-      Sentry.continueTrace({ sentryTrace, baggage }, () => {
-        // continueTrace applies the incoming propagation context to the
-        // current scope so the action span started in beforeAct joins the
-        // enqueuer's trace.
-      });
+
+      const start = () =>
+        Sentry.startInactiveSpan({
+          name: `task:${actionName}`,
+          op: "queue.process",
+          forceTransaction: true,
+          attributes: {
+            "keryx.action": actionName,
+            "keryx.connection.type": CONNECTION_TYPE.TASK,
+            "messaging.destination.name": jobCtx.queue || "default",
+          },
+        });
+      const jobSpan =
+        sentryTrace || baggage
+          ? Sentry.continueTrace({ sentryTrace, baggage }, start)
+          : start();
+      jobCtx.metadata.sentrySpan = jobSpan;
+      this.spanALS.enterWith(jobSpan);
+    });
+
+    api.hooks.resque.afterJob((_actionName, _params, jobCtx, outcome) => {
+      const jobSpan = jobCtx.metadata.sentrySpan as SentrySpan | undefined;
+      if (!jobSpan) return;
+      if (outcome.success) {
+        jobSpan.setStatus({ code: 1 });
+      } else {
+        jobSpan.setStatus({
+          code: 2,
+          message:
+            outcome.error instanceof Error
+              ? outcome.error.message
+              : String(outcome.error),
+        });
+      }
+      jobSpan.end();
     });
   }
 

--- a/packages/plugins/sentry/initializer.ts
+++ b/packages/plugins/sentry/initializer.ts
@@ -150,7 +150,7 @@ export class SentryPlugin extends Initializer {
    * inherit the right parent without wrapping the rest of the request in
    * `Sentry.startSpan(...)`.
    */
-  private spanALS = new AsyncLocalStorage<SentrySpan>();
+  private spanALS = new AsyncLocalStorage<SentrySpan | undefined>();
   private wsConnections = new WeakMap<object, SentrySpan>();
   private wsMessageSpans = new WeakMap<object, SentrySpan>();
   private mcpSessions = new Map<string, SentrySpan>();
@@ -458,6 +458,9 @@ export class SentryPlugin extends Initializer {
       if (!api.sentry.enabled) return;
       const parent = this.spanALS.getStore();
       if (!parent) return;
+      if (typeof parent.isRecording === "function" && !parent.isRecording()) {
+        return;
+      }
       const ctx = parent.spanContext();
       if (!ctx.traceId || !ctx.spanId) return;
       const sampled = ctx.traceFlags & 1 ? 1 : 0;
@@ -511,6 +514,9 @@ export class SentryPlugin extends Initializer {
         });
       }
       jobSpan.end();
+      // enqueueRecurrent runs after afterJob in the same async context.
+      // Drop the ended span so the next occurrence starts a fresh trace.
+      this.spanALS.enterWith(undefined);
     });
   }
 

--- a/packages/plugins/sentry/initializer.ts
+++ b/packages/plugins/sentry/initializer.ts
@@ -458,6 +458,10 @@ export class SentryPlugin extends Initializer {
       if (!api.sentry.enabled) return;
       const parent = this.spanALS.getStore();
       if (!parent) return;
+      // Ended spans (afterJob has already closed the job root) must not
+      // propagate into enqueueRecurrent — that would chain cron runs.
+      // Unsampled *live* spans still propagate so workers honor head sampling.
+      if (typeof Sentry.spanToJSON(parent).timestamp === "number") return;
       const ctx = parent.spanContext();
       if (!ctx.traceId || !ctx.spanId) return;
       const sampled = ctx.traceFlags & 1 ? 1 : 0;
@@ -511,9 +515,6 @@ export class SentryPlugin extends Initializer {
         });
       }
       jobSpan.end();
-      // enqueueRecurrent runs after afterJob in the same async context.
-      // Drop the ended span so the next occurrence starts a fresh trace.
-      this.spanALS.enterWith(undefined);
     });
   }
 

--- a/packages/plugins/sentry/initializer.ts
+++ b/packages/plugins/sentry/initializer.ts
@@ -395,6 +395,9 @@ export class SentryPlugin extends Initializer {
     api.hooks.actions.afterAct(
       (actionName, _params, connection, actCtx, outcome) => {
         const span = actCtx.metadata.sentrySpan as SentrySpan | undefined;
+        const parent = actCtx.metadata.sentryParentSpan as
+          | SentrySpan
+          | undefined;
         if (span) {
           span.setAttribute("keryx.action.duration_ms", outcome.duration);
           if (!outcome.success) {
@@ -420,43 +423,50 @@ export class SentryPlugin extends Initializer {
           span.end();
         }
 
+        // Nested connection.act() must not close the transport span — only the
+        // outermost action (whose parent is the message/session span) does.
         if (connection.type === CONNECTION_TYPE.WEBSOCKET) {
           const messageSpan = this.wsMessageSpans.get(connection);
-          if (messageSpan) {
+          if (messageSpan && messageSpan === parent) {
             messageSpan.setStatus({ code: outcome.success ? 1 : 2 });
             messageSpan.end();
             this.wsMessageSpans.delete(connection);
           }
         }
         if (connection.type === CONNECTION_TYPE.MCP) {
-          const parent = actCtx.metadata.sentryParentSpan as
-            | SentrySpan
-            | undefined;
-          if (parent && parent !== span) {
-            parent.setStatus({ code: outcome.success ? 1 : 2 });
-            parent.end();
+          let mcpSessionId: string | undefined;
+          if (parent) {
             for (const [sid, s] of this.mcpMessageSpans) {
               if (s === parent) {
-                this.mcpMessageSpans.delete(sid);
+                mcpSessionId = sid;
                 break;
               }
             }
           }
+          if (parent && mcpSessionId !== undefined) {
+            parent.setStatus({ code: outcome.success ? 1 : 2 });
+            parent.end();
+            this.mcpMessageSpans.delete(mcpSessionId);
+          }
         }
+
+        if (parent) this.spanALS.enterWith(parent);
       },
     );
 
     api.hooks.actions.onEnqueue((_actionName, inputs) => {
       if (!api.sentry.enabled) return;
       const parent = this.spanALS.getStore();
-      const traceData = parent
-        ? Sentry.withActiveSpan(parent, () => Sentry.getTraceData())
-        : Sentry.getTraceData();
-      const sentryTrace = traceData["sentry-trace"];
-      if (!sentryTrace) return;
+      if (!parent) return;
+      const ctx = parent.spanContext();
+      if (!ctx.traceId || !ctx.spanId) return;
+      const sampled = ctx.traceFlags & 1 ? 1 : 0;
       const next: Record<string, unknown> = { ...inputs };
-      next._sentryTrace = sentryTrace;
-      if (traceData.baggage) next._sentryBaggage = traceData.baggage;
+      next._sentryTrace = `${ctx.traceId}-${ctx.spanId}-${sampled}`;
+      const baggage = Sentry.withActiveSpan(parent, () =>
+        Sentry.getTraceData(),
+      ).baggage;
+      if (baggage) next._sentryBaggage = baggage;
       return next;
     });
 

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keryxjs/sentry",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Background tasks were labeled (`queue.process` on the action span, `keryx.connection.type=task`) but never got a root Sentry transaction. HTTP, WebSocket, and MCP all start one with `forceTransaction: true`; Resque jobs only called `continueTrace` with an empty callback, and skipped span creation entirely when no incoming headers were present (scheduled / cron jobs).

This gives every job a root `task:<name>` / `queue.process` transaction in `resque.beforeJob`, continued from the enqueuer when `_sentryTrace` is present, and finalized in `afterJob`. The action span stays `keryx.action` as a child of that root.

Nested `connection.act()` calls stay on that same trace: the inner action is a child span, not a second `task:` / HTTP transaction. Enqueued child jobs inject headers from the active span so they continue the parent too. Recurring re-enqueues (`enqueueRecurrent`) do **not** continue the finished job — each occurrence gets its own root.

## Tests
- Root `queue.process` span + child `action:*` span for a direct job run
- Enqueued jobs continue the originating HTTP trace
- Nested `connection.act()` from HTTP and from a task share the parent trace (one root, no extra `task:` transaction)
- Recurring re-enqueue does not inject the finished job's `_sentryTrace`
- Failed jobs mark the root span as error and still capture the exception

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88326edd-f797-465f-bd8e-f1232964af5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88326edd-f797-465f-bd8e-f1232964af5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

