### PR TITLE
docs: make keryxjs.com agent-ready (OpenAPI, OAuth/MCP discovery, metadata, 404)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { defineConfig } from "vitepress";
@@ -130,6 +130,34 @@ function renderLlmSection(heading: string, groups: SidebarGroup[]): string {
 // Derived from the sidebars above rather than hand-maintained — the previous
 // hand-written list had silently drifted, omitting the changelog and the style
 // guide. Adding a page to a sidebar now adds it here too.
+/** Shared "when to use" + resources block, used in both the landing page and
+ * the generated llms.txt so agents get consistent guidance either way. */
+export const LLM_WHEN_TO_USE = `## When to use Keryx
+
+Reach for Keryx when you are building a TypeScript/Bun backend that must be
+callable by both people and AI agents from one code base. It is the right fit
+when you want to:
+
+- Expose your API to AI agents as MCP tools **without** writing a separate MCP
+  server — add \`mcp = { tool: true }\` to an action and it becomes a tool.
+- Serve the same logic over HTTP, WebSocket, a CLI, and background jobs at once,
+  with one set of Zod-validated inputs, middleware, and typed errors.
+- Give agents OAuth 2.1 + PKCE auth that works exactly like your browser clients'.
+- Ship an auto-generated OpenAPI spec and real-time PubSub channels.
+
+Keryx is **not** a good fit for tiny static sites, serverless-only edge
+functions with no long-lived process, or projects that cannot run Bun,
+PostgreSQL, and Redis.
+
+### How an agent should call Keryx
+
+1. Read the OpenAPI spec at [/openapi.json](/openapi.json) to discover endpoints.
+2. Discover auth via [/.well-known/oauth-protected-resource](/.well-known/oauth-protected-resource)
+   and [/.well-known/oauth-authorization-server](/.well-known/oauth-authorization-server).
+3. Connect over MCP (Streamable HTTP) using [/.well-known/mcp](/.well-known/mcp);
+   the demo server is at \`https://api.demo.keryxjs.com/mcp\`.
+4. See the [Developer Portal](/developers) for a runnable sandbox and quickstart.`;
+
 export const LLM_LANDING_PAGE = `# Keryx
 
 > The fullstack TypeScript framework for MCP and APIs, built on Bun.
@@ -138,6 +166,14 @@ This is the Keryx documentation site. Two LLM-friendly documentation formats are
 
 - [llms.txt](/llms.txt) — Table of contents with links to all documentation pages
 - [llms-full.txt](/llms-full.txt) — Complete documentation bundle (all pages in one file)
+
+${LLM_WHEN_TO_USE}
+
+## Developer Resources
+
+- [Developer Portal](/developers) — API reference, sandbox, auth, MCP, CLI
+- [OpenAPI spec](/openapi.json) — full API surface for the live demo
+- [About](/about) · [Contact](/contact) · [Privacy](/privacy)
 
 ## Per-Page Markdown
 
@@ -154,6 +190,127 @@ ${renderLlmSection("Plugins", PLUGINS_SIDEBAR)}
 
 - Changelog: /changelog.md
 `;
+
+const SITE_HOSTNAME = "https://keryxjs.com";
+
+/**
+ * JSON-LD identity graph for the homepage (and every page). Lets AI agents and
+ * search engines resolve "Keryx" to this domain, its author, and its source.
+ * Includes a `SoftwareApplication` (the product) and an `Organization` with a
+ * `contactPoint` and `address` so business-legitimacy checks have something to
+ * read.
+ */
+export const STRUCTURED_DATA = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      "@id": `${SITE_HOSTNAME}/#software`,
+      name: "Keryx",
+      alternateName: "KeryxJS",
+      description:
+        "The fullstack TypeScript framework for MCP and APIs — write one action and serve HTTP, WebSocket, CLI, background tasks, and MCP tools, built on Bun.",
+      url: SITE_HOSTNAME,
+      applicationCategory: "DeveloperApplication",
+      operatingSystem: "Cross-platform (Bun)",
+      softwareVersion: version,
+      license: "https://opensource.org/licenses/MIT",
+      downloadUrl: "https://www.npmjs.com/package/keryx",
+      softwareHelp: `${SITE_HOSTNAME}/guide/`,
+      offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+      author: {
+        "@type": "Person",
+        name: "Evan Tahler",
+        url: "https://evantahler.com",
+      },
+      sameAs: [
+        "https://github.com/actionhero/keryx",
+        "https://www.npmjs.com/package/keryx",
+      ],
+    },
+    {
+      "@type": "Organization",
+      "@id": `${SITE_HOSTNAME}/#organization`,
+      name: "Keryx",
+      alternateName: "KeryxJS",
+      url: SITE_HOSTNAME,
+      logo: `${SITE_HOSTNAME}/images/hearald.svg`,
+      description:
+        "Open-source fullstack TypeScript framework for MCP servers and APIs, built on Bun.",
+      founder: { "@type": "Person", name: "Evan Tahler" },
+      contactPoint: {
+        "@type": "ContactPoint",
+        contactType: "technical support",
+        email: "evan@evantahler.com",
+        url: `${SITE_HOSTNAME}/contact`,
+        availableLanguage: ["English"],
+      },
+      address: {
+        "@type": "PostalAddress",
+        addressCountry: "US",
+      },
+      sameAs: [
+        "https://github.com/actionhero/keryx",
+        "https://www.npmjs.com/package/keryx",
+        "https://slack.actionherojs.com",
+      ],
+    },
+  ],
+};
+
+/** Absolute canonical URL for a page, matching VitePress's default output. */
+export function canonicalUrl(relativePath: string): string {
+  const path = relativePath
+    .replace(/\.md$/, ".html")
+    .replace(/(^|\/)index\.html$/, "$1");
+  return `${SITE_HOSTNAME}/${path}`;
+}
+
+/**
+ * Recovery links shown on the 404 page. Kept in one place so the client
+ * `NotFound.vue` component and the statically-injected 404 body stay in sync.
+ */
+export const NOT_FOUND_LINKS: { text: string; href: string; note: string }[] = [
+  { text: "Home", href: "/", note: "Keryx overview and quick start" },
+  { text: "Guide", href: "/guide/", note: "Concepts, transports, and how-tos" },
+  {
+    text: "API Reference",
+    href: "/reference/actions",
+    note: "Actions, initializers, servers, config",
+  },
+  {
+    text: "Developer Portal",
+    href: "/developers",
+    note: "OpenAPI spec, auth, sandbox, MCP, CLI",
+  },
+  {
+    text: "llms.txt",
+    href: "/llms.txt",
+    note: "Machine-readable index of every page",
+  },
+  {
+    text: "OpenAPI spec",
+    href: "/openapi.json",
+    note: "Full API surface for the live demo",
+  },
+  { text: "Sitemap", href: "/sitemap.xml", note: "Every URL on this site" },
+];
+
+/**
+ * Static HTML injected into the built `404.html` so agents and crawlers that
+ * don't execute JavaScript still get a helpful, recoverable body (VitePress
+ * otherwise renders the not-found page only client-side). Written as a small
+ * Markdown-style document with links to the sitemap, llms.txt, and docs index.
+ */
+export const NOT_FOUND_STATIC_BODY = `<div class="vp-doc" style="max-width:640px;margin:0 auto;padding:64px 24px">
+<h1>404 — Page not found</h1>
+<p>That page doesn't exist. This site is the documentation for <strong>Keryx</strong>, the fullstack TypeScript framework for MCP and APIs. Here's where to look next — this index is also available as machine-readable Markdown at <a href="/llms.txt">/llms.txt</a>.</p>
+<ul>
+${NOT_FOUND_LINKS.map(
+  (l) => `<li><a href="${l.href}">${l.text}</a> — ${l.note}</li>`,
+).join("\n")}
+</ul>
+</div>`;
 
 export function toMarkdownUrl(url: string): string {
   const cleanUrl = url.split("?")[0].split("#")[0];
@@ -189,18 +346,42 @@ function addLlmMiddleware(server: {
 
 export default defineConfig({
   appearance: "dark",
+  lang: "en-US",
   // Reads each page's last git commit date; themeConfig.lastUpdated formats it.
   lastUpdated: true,
   title: "Keryx",
   description:
     "The fullstack TypeScript framework for MCP and APIs — transport-agnostic actions for HTTP, WebSocket, CLI, background tasks, and MCP, built on Bun.",
+  // Per-page <head> additions: the Markdown alternate link, a canonical URL,
+  // and og:url. Agents use these for entity resolution and attribution.
   transformHead({ pageData }) {
     const mdUrl = "/" + pageData.relativePath;
-    return [["link", { rel: "alternate", type: "text/markdown", href: mdUrl }]];
+    const canonical = canonicalUrl(pageData.relativePath);
+    return [
+      ["link", { rel: "alternate", type: "text/markdown", href: mdUrl }],
+      ["link", { rel: "canonical", href: canonical }],
+      ["meta", { property: "og:url", content: canonical }],
+    ];
   },
 
   head: [
     ["link", { rel: "icon", href: "/images/horn.svg" }],
+    ["meta", { property: "og:type", content: "website" }],
+    ["meta", { property: "og:site_name", content: "Keryx" }],
+    [
+      "meta",
+      { property: "og:image", content: `${SITE_HOSTNAME}/images/hearald.svg` },
+    ],
+    ["meta", { name: "twitter:card", content: "summary_large_image" }],
+    [
+      "meta",
+      { name: "twitter:image", content: `${SITE_HOSTNAME}/images/hearald.svg` },
+    ],
+    [
+      "script",
+      { type: "application/ld+json" },
+      JSON.stringify(STRUCTURED_DATA),
+    ],
     [
       "link",
       {
@@ -245,6 +426,7 @@ export default defineConfig({
       { text: "Guide", link: "/guide/" },
       { text: "Plugins", link: "/plugins/" },
       { text: "Reference", link: "/reference/actions" },
+      { text: "Developers", link: "/developers" },
       { text: "Changelog", link: "/changelog" },
       {
         text: `v${version}`,
@@ -286,6 +468,29 @@ export default defineConfig({
 
   sitemap: { hostname: "https://keryxjs.com" },
 
+  // The `.well-known` discovery documents are static files in `public/`, not
+  // VitePress pages, so the dead-link checker can't resolve them. They are
+  // verified by the docs test suite instead.
+  ignoreDeadLinks: [/^\/\.well-known\//],
+
+  // VitePress renders the not-found page only on the client, leaving a bare
+  // shell in the static 404.html. Inject a helpful, link-rich body so agents
+  // and crawlers that don't run JavaScript can still recover. The client-side
+  // NotFound.vue component replaces this once hydrated.
+  buildEnd(siteConfig) {
+    const notFoundPath = resolve(siteConfig.outDir, "404.html");
+    try {
+      const html = readFileSync(notFoundPath, "utf-8");
+      const injected = html.replace(
+        '<div id="app"></div>',
+        `<div id="app">${NOT_FOUND_STATIC_BODY}</div>`,
+      );
+      if (injected !== html) writeFileSync(notFoundPath, injected);
+    } catch {
+      // If the 404.html shape changes upstream, don't fail the build.
+    }
+  },
+
   vite: {
     plugins: [
       llmstxt({
@@ -298,6 +503,14 @@ export default defineConfig({
 {details}
 
 For the complete documentation in a single file, see [llms-full.txt](/llms-full.txt).
+
+${LLM_WHEN_TO_USE}
+
+## Developer Resources
+
+- [Developer Portal](/developers) — API reference, sandbox, auth, MCP, CLI
+- [OpenAPI spec](/openapi.json) — full API surface for the live demo
+- [About](/about) · [Contact](/contact) · [Privacy](/privacy)
 
 ## Table of Contents
 

--- a/docs/.vitepress/theme/NotFound.vue
+++ b/docs/.vitepress/theme/NotFound.vue
@@ -1,0 +1,144 @@
+<script setup>
+import { withBase } from "vitepress";
+
+const links = [
+  { text: "Home", href: "/", note: "Keryx overview and quick start" },
+  { text: "Guide", href: "/guide/", note: "Concepts, transports, and how-tos" },
+  {
+    text: "API Reference",
+    href: "/reference/actions",
+    note: "Actions, initializers, servers, config",
+  },
+  {
+    text: "Developer Portal",
+    href: "/developers",
+    note: "OpenAPI spec, auth, sandbox, MCP, CLI",
+  },
+  {
+    text: "llms.txt",
+    href: "/llms.txt",
+    note: "Machine-readable index of every page",
+  },
+  {
+    text: "OpenAPI spec",
+    href: "/openapi.json",
+    note: "Full API surface for the live demo",
+  },
+  {
+    text: "Sitemap",
+    href: "/sitemap.xml",
+    note: "Every URL on this site",
+  },
+];
+</script>
+
+<template>
+  <div class="NotFound">
+    <p class="code">404</p>
+    <h1 class="title">Page not found</h1>
+    <div class="divider" />
+    <blockquote class="quote">
+      That page doesn't exist. Here's where to look next — this list is also
+      available as machine-readable Markdown at
+      <a :href="withBase('/llms.txt')">/llms.txt</a>.
+    </blockquote>
+
+    <ul class="link-list">
+      <li v-for="link in links" :key="link.href">
+        <a :href="withBase(link.href)" class="link">{{ link.text }}</a>
+        <span class="note">— {{ link.note }}</span>
+      </li>
+    </ul>
+
+    <div class="action">
+      <a class="link home-link" :href="withBase('/')" aria-label="go to home"
+        >Take me home →</a
+      >
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.NotFound {
+  padding: 64px 24px 96px;
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.code {
+  line-height: 64px;
+  font-size: 64px;
+  font-weight: 600;
+  color: var(--vp-c-brand-1);
+}
+
+.title {
+  padding-top: 12px;
+  letter-spacing: 2px;
+  line-height: 20px;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.divider {
+  margin: 24px auto 18px;
+  width: 64px;
+  height: 1px;
+  background-color: var(--vp-c-divider);
+}
+
+.quote {
+  margin: 0 auto;
+  max-width: 512px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+}
+
+.quote a {
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+}
+
+.link-list {
+  list-style: none;
+  padding: 0;
+  margin: 28px auto 0;
+  max-width: 512px;
+  text-align: left;
+}
+
+.link-list li {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--vp-c-divider);
+  font-size: 14px;
+}
+
+.link {
+  font-weight: 600;
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+  transition: color 0.25s;
+}
+
+.link:hover {
+  color: var(--vp-c-brand-2);
+}
+
+.note {
+  color: var(--vp-c-text-3);
+}
+
+.action {
+  padding-top: 32px;
+}
+
+.home-link {
+  display: inline-block;
+  border: 1px solid var(--vp-c-brand-1);
+  border-radius: 16px;
+  padding: 6px 16px;
+  font-size: 14px;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,11 +3,13 @@ import DefaultTheme from "vitepress/theme";
 import CopyOrDownloadAsMarkdownButtons from "vitepress-plugin-llms/vitepress-components/CopyOrDownloadAsMarkdownButtons.vue";
 import Changelog from "./Changelog.vue";
 import Layout from "./Layout.vue";
+import NotFound from "./NotFound.vue";
 import "./custom.css";
 
 export default {
   extends: DefaultTheme,
   Layout,
+  NotFound,
   enhanceApp({ app }) {
     app.component("Changelog", Changelog);
     app.component(

--- a/docs/__tests__/docs.test.ts
+++ b/docs/__tests__/docs.test.ts
@@ -1,7 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, readdirSync, readFileSync } from "fs";
 import { dirname, relative, resolve } from "path";
-import { LLM_LANDING_PAGE, toMarkdownUrl } from "../.vitepress/config.mts";
+import {
+  LLM_LANDING_PAGE,
+  NOT_FOUND_LINKS,
+  toMarkdownUrl,
+} from "../.vitepress/config.mts";
 
 const docsDir = resolve(import.meta.dir, "..");
 const publicDir = resolve(docsDir, "public");
@@ -528,5 +532,206 @@ describe("generated reference data", () => {
       }
     }
     expect(missing).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agent-readiness: machine-readable files, metadata, and trust pages
+// ---------------------------------------------------------------------------
+
+const distDir = resolve(docsDir, ".vitepress", "dist");
+
+describe("openapi.json", () => {
+  const sourcePath = resolve(publicDir, "openapi.json");
+  // biome-ignore lint/suspicious/noExplicitAny: parsed OpenAPI document
+  let spec: any;
+
+  beforeAll(() => {
+    spec = JSON.parse(readFileSync(sourcePath, "utf-8"));
+  });
+
+  test("is published to public/ and copied into the build", () => {
+    expect(existsSync(sourcePath)).toBe(true);
+    expect(existsSync(resolve(distDir, "openapi.json"))).toBe(true);
+  });
+
+  test("is a valid OpenAPI 3.x document with servers", () => {
+    expect(String(spec.openapi)).toMatch(/^3\./);
+    expect(spec.info?.title).toBeTruthy();
+    expect(Array.isArray(spec.servers)).toBe(true);
+    expect(spec.servers.length).toBeGreaterThan(0);
+    expect(Object.keys(spec.paths ?? {}).length).toBeGreaterThan(0);
+  });
+
+  test("declares scoped OAuth permissions in security schemes", () => {
+    const schemes = spec.components?.securitySchemes ?? {};
+    const oauth = schemes.oauth2;
+    expect(oauth?.type).toBe("oauth2");
+    const scopes = oauth?.flows?.authorizationCode?.scopes ?? {};
+    expect(Object.keys(scopes)).toContain("mcp");
+  });
+
+  test("every operation has a unique operationId and a description", () => {
+    const seen = new Set<string>();
+    const dupes: string[] = [];
+    const missing: string[] = [];
+    for (const [path, methods] of Object.entries(spec.paths)) {
+      for (const [method, op] of Object.entries(
+        methods as Record<
+          string,
+          { operationId?: string; description?: string }
+        >,
+      )) {
+        const where = `${method.toUpperCase()} ${path}`;
+        if (!op.operationId) missing.push(`${where}: no operationId`);
+        else if (seen.has(op.operationId)) dupes.push(op.operationId);
+        else seen.add(op.operationId);
+        if (!op.description) missing.push(`${where}: no description`);
+      }
+    }
+    expect(missing).toEqual([]);
+    expect(dupes).toEqual([]);
+  });
+
+  test("defines a structured JSON error schema", () => {
+    const err = spec.components?.schemas?.Error;
+    expect(err).toBeTruthy();
+    const errorProps = err.properties?.error?.properties ?? {};
+    expect(Object.keys(errorProps)).toEqual(
+      expect.arrayContaining(["message", "type", "timestamp"]),
+    );
+  });
+
+  test("error responses are referenced by write operations", () => {
+    const userCreate = spec.paths["/user"]?.put;
+    expect(userCreate?.responses?.["422"]).toBeTruthy();
+    expect(userCreate?.responses?.["500"]).toBeTruthy();
+  });
+});
+
+describe(".well-known discovery documents", () => {
+  const files = [
+    "oauth-authorization-server",
+    "oauth-protected-resource",
+    "mcp",
+  ];
+
+  test("are published and copied into the build", () => {
+    for (const f of files) {
+      expect(existsSync(resolve(publicDir, ".well-known", f))).toBe(true);
+      expect(existsSync(resolve(distDir, ".well-known", f))).toBe(true);
+    }
+  });
+
+  test("a .nojekyll file ships so GitHub Pages serves dotfiles", () => {
+    expect(existsSync(resolve(publicDir, ".nojekyll"))).toBe(true);
+    expect(existsSync(resolve(distDir, ".nojekyll"))).toBe(true);
+  });
+
+  test("oauth-authorization-server has an issuer and endpoints", () => {
+    const meta = JSON.parse(
+      readFileSync(
+        resolve(publicDir, ".well-known", "oauth-authorization-server"),
+        "utf-8",
+      ),
+    );
+    expect(meta.issuer).toBeTruthy();
+    expect(meta.authorization_endpoint).toContain(meta.issuer);
+    expect(meta.token_endpoint).toContain(meta.issuer);
+    expect(meta.scopes_supported).toContain("mcp");
+    expect(meta.code_challenge_methods_supported).toContain("S256");
+  });
+
+  test("oauth-protected-resource advertises scopes_supported (RFC 9728)", () => {
+    const meta = JSON.parse(
+      readFileSync(
+        resolve(publicDir, ".well-known", "oauth-protected-resource"),
+        "utf-8",
+      ),
+    );
+    expect(Array.isArray(meta.authorization_servers)).toBe(true);
+    expect(meta.authorization_servers.length).toBeGreaterThan(0);
+    expect(meta.scopes_supported).toContain("mcp");
+  });
+
+  test("mcp manifest points at a Streamable HTTP server", () => {
+    const meta = JSON.parse(
+      readFileSync(resolve(publicDir, ".well-known", "mcp"), "utf-8"),
+    );
+    expect(meta.server?.url).toMatch(/^https?:\/\//);
+    expect(meta.server?.transport).toBe("streamable-http");
+    expect(meta.server?.authentication?.type).toBe("oauth2");
+  });
+});
+
+describe("homepage metadata & structured data", () => {
+  let html: string;
+
+  beforeAll(() => {
+    html = readFileSync(resolve(distDir, "index.html"), "utf-8");
+  });
+
+  test("declares html lang, canonical, and Open Graph tags", () => {
+    expect(html).toContain('lang="en-US"');
+    expect(html).toMatch(/rel="canonical" href="https:\/\/keryxjs\.com\/"/);
+    expect(html).toContain('property="og:type" content="website"');
+    expect(html).toMatch(/property="og:image" content="https:\/\/keryxjs\.com/);
+  });
+
+  test("embeds JSON-LD with SoftwareApplication and a complete Organization", () => {
+    const match = html.match(
+      /<script type="application\/ld\+json">([\s\S]*?)<\/script>/,
+    );
+    expect(match).not.toBeNull();
+    const data = JSON.parse(match![1]);
+    const graph = data["@graph"] ?? [data];
+    const types = graph.map((n: { "@type": string }) => n["@type"]);
+    expect(types).toContain("SoftwareApplication");
+    expect(types).toContain("Organization");
+    const org = graph.find(
+      (n: { "@type": string }) => n["@type"] === "Organization",
+    );
+    expect(org.contactPoint?.email).toBeTruthy();
+    expect(org.contactPoint?.contactType).toBeTruthy();
+    expect(org.address?.["@type"]).toBe("PostalAddress");
+  });
+
+  test("links developer/API resources from the homepage", () => {
+    expect(html).toContain("/developers");
+    expect(html).toContain("/openapi.json");
+  });
+});
+
+describe("agent-friendly 404", () => {
+  test("static 404.html carries a recovery body for non-JS agents", () => {
+    const html = readFileSync(resolve(distDir, "404.html"), "utf-8");
+    expect(html).toContain("Page not found");
+    for (const link of NOT_FOUND_LINKS) {
+      expect(html).toContain(`href="${link.href}"`);
+    }
+  });
+});
+
+describe("llms.txt agent guidance", () => {
+  test("includes when-to-use guidance and developer resources", () => {
+    const content = readFileSync(resolve(distDir, "llms.txt"), "utf-8");
+    expect(content).toContain("When to use Keryx");
+    expect(content).toContain("/openapi.json");
+    expect(content).toContain("/developers");
+  });
+});
+
+describe("trust anchor pages", () => {
+  const pages = ["about.md", "contact.md", "privacy.md", "developers.md"];
+
+  test("exist with a description and at least 500 characters of prose", () => {
+    for (const page of pages) {
+      const file = resolve(docsDir, page);
+      expect(existsSync(file)).toBe(true);
+      const raw = readFileSync(file, "utf-8");
+      expect(raw).toMatch(/^---\n[\s\S]*?description:/);
+      const body = raw.replace(/^---\n[\s\S]*?\n---\n/, "");
+      expect(body.length).toBeGreaterThanOrEqual(500);
+    }
   });
 });

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,33 @@
+---
+title: About Keryx
+description: What Keryx is, who makes it, and why it exists — the fullstack TypeScript framework for MCP and APIs, built on Bun.
+---
+
+# About Keryx
+
+**Keryx** is an open-source, MIT-licensed fullstack TypeScript framework for building MCP servers and APIs, built on [Bun](https://bun.sh) and powered by [Zod](https://zod.dev). Its core idea is that an **action** is the universal controller: you write your business logic once as an action class, and Keryx serves it across five transports simultaneously — HTTP endpoints, WebSocket handlers, CLI commands, background tasks, and [Model Context Protocol](https://modelcontextprotocol.io) (MCP) tools for AI agents. The same validation, middleware, authentication, and response shape apply everywhere, so you never maintain five implementations of the same logic.
+
+Keryx is the spiritual successor to [ActionHero](https://www.actionherojs.com), carrying forward the same "actions everywhere" philosophy with a modern, type-safe, Bun-native foundation. It is designed for teams that need their backend to be reachable by both humans and machines: a browser, a terminal, a background worker, and an AI agent can all call the same endpoint, authenticate the same way, and receive the same typed, structured responses and errors.
+
+The name comes from the ancient Greek κῆρυξ ("KEH-rüks"), meaning "herald" or "messenger" — the person who carried proclamations between gods and mortals. It fits: your actions are the message, and Keryx heralds them to every client. Read the [full etymology and brand assets](/guide/about) for more.
+
+## Why it exists
+
+Most backends start as an HTTP framework and then bolt on a WebSocket server, a CLI, a job queue, and — increasingly — an MCP layer. Each addition brings its own handler, validation, and auth. Keryx flips that model: write the controller once and let the framework deliver it everywhere. It is the only TypeScript framework where your API is automatically an MCP server, with built-in OAuth 2.1 + PKCE so AI agents authenticate exactly like browser clients do.
+
+## Who makes Keryx
+
+Keryx is created and maintained by **Evan Tahler** and a community of open-source contributors. It is developed in the open on GitHub and shares its community with ActionHero.
+
+- **Source** — [github.com/actionhero/keryx](https://github.com/actionhero/keryx)
+- **Discussions** — [github.com/actionhero/keryx/discussions](https://github.com/actionhero/keryx/discussions)
+- **Community Slack** — [actionherojs.slack.com](https://slack.actionherojs.com)
+- **npm** — [keryx](https://www.npmjs.com/package/keryx)
+
+## Learn more
+
+- [Getting Started](/guide/) — install Keryx and build your first action
+- [About Keryx (name, philosophy, brand assets)](/guide/about)
+- [Building for AI Agents](/guide/agents) — the MCP-native workflow
+- [Developer Portal](/developers) — API reference, sandbox, and auth
+- [Contact](/contact) · [Privacy](/privacy)

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,0 +1,37 @@
+---
+title: Contact
+description: How to reach the Keryx team and community — GitHub, Slack, npm, and email — for support, questions, security reports, and contributions.
+---
+
+# Contact
+
+Keryx is an open-source project developed in the open. The fastest way to get help depends on what you need — here is where to go.
+
+## Support & questions
+
+- **GitHub Discussions** — the best place for usage questions, ideas, and show-and-tell: [github.com/actionhero/keryx/discussions](https://github.com/actionhero/keryx/discussions)
+- **Community Slack** — chat with maintainers and other users in real time: [actionherojs.slack.com](https://slack.actionherojs.com). Keryx shares the ActionHero community Slack.
+- **Documentation** — most answers already live in the [guide](/guide/) and [reference](/reference/actions); AI agents can start from [`/llms.txt`](/llms.txt).
+
+## Bug reports & feature requests
+
+Open an issue on GitHub with reproduction steps and your environment details: [github.com/actionhero/keryx/issues](https://github.com/actionhero/keryx/issues). Pull requests are welcome — see the [contributing notes](/guide/style-guide) and the repository's `CONTRIBUTING` guidance.
+
+## Security
+
+Please do **not** file public issues for security vulnerabilities. Report them privately via GitHub Security Advisories at [github.com/actionhero/keryx/security](https://github.com/actionhero/keryx/security/advisories) or by email to the maintainer (below). We will acknowledge your report and work with you on a coordinated disclosure.
+
+## Maintainer
+
+Keryx is maintained by **Evan Tahler**.
+
+- **Email** — [evan@evantahler.com](mailto:evan@evantahler.com)
+- **GitHub** — [@evantahler](https://github.com/evantahler)
+- **Web** — [evantahler.com](https://evantahler.com)
+
+## Project links
+
+- **Source** — [github.com/actionhero/keryx](https://github.com/actionhero/keryx)
+- **npm** — [keryx](https://www.npmjs.com/package/keryx)
+- **Developer Portal** — [/developers](/developers)
+- **About** — [/about](/about) · **Privacy** — [/privacy](/privacy)

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,0 +1,102 @@
+---
+title: Developer Portal
+description: The Keryx developer portal — API reference, OpenAPI spec, authentication, a live sandbox API, the CLI, and the MCP server. Everything an agent or developer needs to integrate with Keryx.
+---
+
+# Developer Portal
+
+Everything you need to build with Keryx — as a developer or as an AI agent. Keryx is an open-source, MIT-licensed TypeScript framework: you install it, define [actions](/guide/actions), and every action is automatically an HTTP endpoint, a WebSocket handler, a CLI command, a background task, and an [MCP](/guide/mcp) tool. There's nothing to sign up for and no API keys to request — the framework and the live demo below are free and self-serve.
+
+## Quickstart
+
+```bash
+bunx keryx new my-app
+cd my-app
+cp .env.example .env
+bun install
+bun dev
+```
+
+Your server boots with a machine-readable OpenAPI document at `/api/swagger`, an MCP endpoint at `/mcp`, and OAuth 2.1 discovery at `/.well-known/oauth-authorization-server`. See the [Getting Started guide](/guide/) for the full walkthrough.
+
+## API Reference
+
+- **OpenAPI specification** — [`/openapi.json`](/openapi.json). A complete OpenAPI 3.1 document for the live demo API, with a unique `operationId`, a description, typed parameters, and typed request/response schemas on every operation. Use it to generate typed clients or drive LLM function-calling.
+- **Live spec from the running server** — every Keryx server serves its own OpenAPI document at `GET /api/swagger`. On the demo that is <https://api.demo.keryxjs.com/api/swagger>.
+- **Reference docs** — the [Action](/reference/actions), [Initializer](/reference/initializers), [Servers](/reference/servers), and [Configuration](/reference/config) references.
+
+## Live Sandbox API
+
+A public demo server runs the [example chat app](https://github.com/actionhero/keryx/tree/main/example) so you can try the API without deploying anything:
+
+| Resource | URL |
+| --- | --- |
+| API base | `https://api.demo.keryxjs.com/api` |
+| Health check | [`/api/status`](https://api.demo.keryxjs.com/api/status) |
+| OpenAPI spec | [`/api/swagger`](https://api.demo.keryxjs.com/api/swagger) |
+| MCP endpoint | `https://api.demo.keryxjs.com/mcp` |
+| Web UI | <https://www.demo.keryxjs.com> |
+
+Try it:
+
+```bash
+# Health check — no auth required
+curl -s https://api.demo.keryxjs.com/api/status | jq
+
+# Register a user (self-serve, no API key)
+curl -s -X PUT https://api.demo.keryxjs.com/api/user \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Ada","email":"ada@example.com","password":"lovelace123"}' | jq
+```
+
+The sandbox database is periodically reset. It is for evaluation only — do not store real data.
+
+## Authentication
+
+Keryx ships two auth paths from one code base:
+
+- **Session cookies** for browser and HTTP clients — call `PUT /api/session` (`session:create`) with an email and password to receive a session cookie.
+- **OAuth 2.1 + PKCE** for AI agents connecting over MCP. The authorization server metadata is published at [`/.well-known/oauth-authorization-server`](/.well-known/oauth-authorization-server) and the protected-resource metadata (with `scopes_supported`) at [`/.well-known/oauth-protected-resource`](/.well-known/oauth-protected-resource). Clients register dynamically at `POST /oauth/register` — no manual key issuance. The only scope is `mcp`, which grants least-privilege access to the actions you have opted in as tools.
+
+See the [Authentication guide](/guide/authentication) and the [MCP OAuth reference](/guide/mcp#oauth-21-authentication) for the full flow.
+
+## MCP Server
+
+Keryx is MCP-native: any action becomes a tool with one line (`mcp = { tool: true }`). The demo's MCP manifest is published at [`/.well-known/mcp`](/.well-known/mcp).
+
+```json
+{
+  "mcpServers": {
+    "keryx-demo": {
+      "url": "https://api.demo.keryxjs.com/mcp"
+    }
+  }
+}
+```
+
+Claude Desktop, Cursor, VS Code Copilot, Windsurf, and any other MCP client can discover and call the exposed actions. The browser client library is published on npm as [`@keryxjs/mcp-app`](https://www.npmjs.com/package/@keryxjs/mcp-app). See [Building for AI Agents](/guide/agents) and the [MCP guide](/guide/mcp).
+
+## CLI
+
+The framework ships an official CLI, published on npm as [`keryx`](https://www.npmjs.com/package/keryx):
+
+```bash
+bunx keryx new my-app        # scaffold a project
+bunx keryx generate action   # generate an action, initializer, plugin, ...
+bunx keryx start             # start the server
+```
+
+Every action is also runnable directly from the command line, with flags generated from its Zod schema. See the [CLI guide](/guide/cli).
+
+## Documentation for LLMs
+
+- [`/llms.txt`](/llms.txt) — a table of contents of every page, optimized for LLMs.
+- [`/llms-full.txt`](/llms-full.txt) — the complete documentation bundle in one file.
+- Append `.md` to any documentation URL for the raw Markdown version (e.g. `/guide/actions.md` or `/reference/config.md`).
+
+## Links
+
+- **Source** — [github.com/actionhero/keryx](https://github.com/actionhero/keryx)
+- **npm** — [keryx](https://www.npmjs.com/package/keryx)
+- **Issues & support** — [github.com/actionhero/keryx/issues](https://github.com/actionhero/keryx/issues)
+- **Contact** — [/contact](/contact)

--- a/docs/index.md
+++ b/docs/index.md
@@ -180,6 +180,16 @@ bun dev
 
 Requires Bun, PostgreSQL, and Redis. See the [Getting Started guide](/guide/) for full setup instructions.
 
+## API & Developer Resources
+
+Keryx is open source, and there's a live demo API you can call right now — no signup, no API keys.
+
+- **[Developer Portal](/developers)** — API reference, authentication, a live sandbox, the CLI, and the MCP server in one place.
+- **[OpenAPI specification](/openapi.json)** — the full, machine-readable API surface (OpenAPI 3.1) for the live demo.
+- **[Live demo API](https://api.demo.keryxjs.com/api/status)** — a running Keryx server: try `GET /api/status`, or the spec at `/api/swagger`.
+- **[MCP server](/guide/mcp)** — connect Claude, Cursor, or any MCP client to `https://api.demo.keryxjs.com/mcp`.
+- **[llms.txt](/llms.txt)** — machine-readable documentation index for LLMs.
+
 ## Built With
 
 [Bun](https://bun.sh) · [Zod](https://zod.dev) · [Drizzle](https://orm.drizzle.team) · [Redis](https://redis.io) · [PostgreSQL](https://www.postgresql.org) · [OpenTelemetry](https://opentelemetry.io)

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,43 @@
+---
+title: Privacy Policy
+description: How the Keryx documentation site and the public demo API handle data — analytics, the sandbox environment, and what we do and do not collect.
+---
+
+# Privacy Policy
+
+_Last updated: 2026._
+
+Keryx is an open-source software framework. This policy explains how the **Keryx documentation website** (`keryxjs.com`) and the **public demo API** (`api.demo.keryxjs.com` / `www.demo.keryxjs.com`) handle data. The Keryx framework itself, when you install and run it on your own infrastructure, does not send any data to us — you control your own deployment, database, and logs.
+
+## The documentation website
+
+`keryxjs.com` is a static site. It uses **Google Analytics** to understand aggregate traffic (pages viewed, approximate location, device and browser type). This data is processed by Google under its own privacy terms and is used only in aggregate to improve the documentation. We do not sell it or use it to identify individuals. You can block analytics with any standard content blocker or by enabling "Do Not Track" in your browser.
+
+The site sets no advertising cookies and requires no account to read any page.
+
+## The demo API and sandbox
+
+The public demo server exists so you can evaluate the framework without deploying it. If you register a user or post a message there:
+
+- The data you submit (name, email, messages) is stored in the demo database purely to make the demo work.
+- **The demo database is periodically reset**, deleting all accounts and messages. Do not store real, sensitive, or personal data in the sandbox.
+- Passwords are stored only as salted hashes, never in plaintext.
+- Standard server logs (IP address, request metadata) may be retained transiently for abuse prevention and operations.
+
+Because the sandbox is wiped regularly, the simplest way to remove your demo data is to wait for the next reset. For anything urgent, contact us (below).
+
+## Data we do not collect
+
+- We do not sell personal data.
+- We do not run third-party advertising networks.
+- The framework you download and self-host does not phone home.
+
+## Your choices
+
+- Use a disposable email and a throwaway password in the sandbox.
+- Block analytics via your browser or an extension.
+- Self-host Keryx to keep all data entirely under your control.
+
+## Contact
+
+Questions about privacy or a data request? Reach the maintainer at [evan@evantahler.com](mailto:evan@evantahler.com), or see the [Contact page](/contact) for more options. Changes to this policy will be published on this page.

--- a/docs/public/.well-known/mcp
+++ b/docs/public/.well-known/mcp
@@ -1,0 +1,22 @@
+{
+  "name": "keryx-demo",
+  "title": "Keryx Demo",
+  "description": "The live Keryx demo application, exposed as an MCP server. Actions such as status, user:view, message:create, messages:list, message:view, user:edit, and channel:members are available as MCP tools over Streamable HTTP.",
+  "version": "0.42.9",
+  "documentation": "https://keryxjs.com/guide/mcp",
+  "server": {
+    "url": "https://api.demo.keryxjs.com/mcp",
+    "transport": "streamable-http",
+    "authentication": {
+      "type": "oauth2",
+      "authorization_server": "https://api.demo.keryxjs.com/.well-known/oauth-authorization-server",
+      "protected_resource": "https://api.demo.keryxjs.com/.well-known/oauth-protected-resource",
+      "scopes": ["mcp"]
+    }
+  },
+  "mcpServers": {
+    "keryx-demo": {
+      "url": "https://api.demo.keryxjs.com/mcp"
+    }
+  }
+}

--- a/docs/public/.well-known/oauth-authorization-server
+++ b/docs/public/.well-known/oauth-authorization-server
@@ -1,0 +1,17 @@
+{
+  "issuer": "https://api.demo.keryxjs.com",
+  "authorization_endpoint": "https://api.demo.keryxjs.com/oauth/authorize",
+  "token_endpoint": "https://api.demo.keryxjs.com/oauth/token",
+  "registration_endpoint": "https://api.demo.keryxjs.com/oauth/register",
+  "introspection_endpoint": "https://api.demo.keryxjs.com/oauth/introspect",
+  "revocation_endpoint": "https://api.demo.keryxjs.com/oauth/revoke",
+  "scopes_supported": ["mcp"],
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "code_challenge_methods_supported": ["S256"],
+  "authorization_response_iss_parameter_supported": true,
+  "token_endpoint_auth_methods_supported": ["none"],
+  "introspection_endpoint_auth_methods_supported": ["none"],
+  "revocation_endpoint_auth_methods_supported": ["none"],
+  "service_documentation": "https://keryxjs.com/guide/mcp"
+}

--- a/docs/public/.well-known/oauth-protected-resource
+++ b/docs/public/.well-known/oauth-protected-resource
@@ -1,0 +1,7 @@
+{
+  "resource": "https://api.demo.keryxjs.com",
+  "authorization_servers": ["https://api.demo.keryxjs.com"],
+  "scopes_supported": ["mcp"],
+  "bearer_methods_supported": ["header"],
+  "resource_documentation": "https://keryxjs.com/developers"
+}

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,0 +1,22 @@
+# HTTP headers for CDN-backed static hosts (Netlify, Cloudflare Pages, etc.).
+# GitHub Pages ignores this file, but it documents the intended headers and is
+# honored automatically if the site is ever fronted by a supporting CDN.
+
+# Cache correctness for Accept-based content negotiation (acceptmarkdown.com):
+# an intermediary must not serve a cached HTML variant to a client that asked
+# for Markdown, or vice-versa.
+/*
+  Vary: Accept, Accept-Encoding
+
+# Serve machine-readable discovery documents as JSON.
+/openapi.json
+  Content-Type: application/json; charset=utf-8
+
+/.well-known/oauth-authorization-server
+  Content-Type: application/json; charset=utf-8
+
+/.well-known/oauth-protected-resource
+  Content-Type: application/json; charset=utf-8
+
+/.well-known/mcp
+  Content-Type: application/json; charset=utf-8

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1,0 +1,754 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Keryx Demo API",
+    "version": "0.42.9",
+    "summary": "A live Keryx API — HTTP, WebSocket, CLI, background tasks, and MCP from one set of actions.",
+    "description": "This is the public OpenAPI specification for the live Keryx demo application served at https://api.demo.keryxjs.com. It is generated from the same Keryx `Action` classes that back the demo's HTTP endpoints, WebSocket handlers, CLI commands, and MCP tools, so every operation here maps 1:1 to a real, callable endpoint.\n\nUse it to discover the API surface programmatically, generate typed clients, or drive LLM function-calling. Every operation has a unique `operationId`, a description, typed parameters, and typed request/response schemas. Errors are returned as structured JSON (see the `Error` schema).\n\nAuthentication is available two ways: a session cookie (`session:create`) for browser/HTTP clients, and OAuth 2.1 with PKCE (the `oauth2` scheme) for AI agents connecting over MCP. See https://keryxjs.com/developers for a quickstart, and https://api.demo.keryxjs.com/.well-known/oauth-authorization-server for the authorization server metadata.",
+    "termsOfService": "https://keryxjs.com/privacy",
+    "contact": {
+      "name": "Keryx",
+      "url": "https://keryxjs.com/contact",
+      "email": "evan@evantahler.com"
+    },
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    }
+  },
+  "externalDocs": {
+    "description": "Keryx documentation",
+    "url": "https://keryxjs.com"
+  },
+  "servers": [
+    {
+      "url": "https://api.demo.keryxjs.com/api",
+      "description": "Live Keryx demo API"
+    }
+  ],
+  "tags": [
+    { "name": "status", "description": "Server health and metadata." },
+    { "name": "user", "description": "User accounts and profiles." },
+    { "name": "session", "description": "Authentication and sign-in." },
+    {
+      "name": "message",
+      "description": "Chat messages, persisted and broadcast over PubSub."
+    },
+    { "name": "channel", "description": "Real-time PubSub channels." },
+    { "name": "file", "description": "File uploads." },
+    { "name": "swagger", "description": "Machine-readable API specification." }
+  ],
+  "security": [{ "sessionCookie": [] }, { "oauth2": ["mcp"] }],
+  "paths": {
+    "/status": {
+      "get": {
+        "operationId": "status",
+        "summary": "Server status",
+        "description": "Returns server health and runtime information including the server name, process ID, package version, uptime in milliseconds, memory consumption in MB, and dependency health checks for the database and Redis. Does not require authentication.",
+        "tags": ["status"],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Server status",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Status" }
+              }
+            }
+          },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/swagger": {
+      "get": {
+        "operationId": "swagger",
+        "summary": "OpenAPI specification",
+        "description": "Returns the full API documentation as an OpenAPI 3.x JSON document, generated from the live server's registered actions. Does not require authentication.",
+        "tags": ["swagger"],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "OpenAPI document",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object", "additionalProperties": true }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user": {
+      "put": {
+        "operationId": "user:create",
+        "summary": "Register a new user",
+        "description": "Register a new user account with a name, email, and password. The email must be unique across all users (case-insensitive). Password must be at least 8 characters and is stored securely as a hash. Returns the created user's profile. Does not require an existing session.",
+        "tags": ["user"],
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UserCreateRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The created user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": { "$ref": "#/components/schemas/User" }
+                  },
+                  "required": ["user"]
+                }
+              }
+            }
+          },
+          "422": { "$ref": "#/components/responses/ValidationError" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      },
+      "post": {
+        "operationId": "user:edit",
+        "summary": "Edit the current user",
+        "description": "Update the currently authenticated user's profile. All fields are optional — only provided fields will be updated. Requires an active session. Returns the updated user profile.",
+        "tags": ["user"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UserEditRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": { "$ref": "#/components/schemas/User" }
+                  },
+                  "required": ["user"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "422": { "$ref": "#/components/responses/ValidationError" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/user/{user}": {
+      "get": {
+        "operationId": "user:view",
+        "summary": "View a user's public profile",
+        "description": "Retrieve another user's public profile by their user ID. Returns public information only (ID, name, timestamps) — does not expose email or other private fields. Requires an active session.",
+        "tags": ["user"],
+        "parameters": [
+          {
+            "name": "user",
+            "in": "path",
+            "required": true,
+            "description": "The numeric ID of the user to view.",
+            "schema": { "type": "integer", "minimum": 1 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested public user profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": { "$ref": "#/components/schemas/PublicUser" }
+                  },
+                  "required": ["user"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/session": {
+      "put": {
+        "operationId": "session:create",
+        "summary": "Sign in",
+        "description": "Sign in by providing an email and password. If credentials are valid, creates an authenticated session and returns the user's profile along with session details. Call this before using any endpoints that require authentication.",
+        "tags": ["session"],
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SessionCreateRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The authenticated user and session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": { "$ref": "#/components/schemas/User" },
+                    "session": { "$ref": "#/components/schemas/Session" }
+                  },
+                  "required": ["user", "session"]
+                }
+              }
+            }
+          },
+          "422": { "$ref": "#/components/responses/ValidationError" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      },
+      "delete": {
+        "operationId": "session:destroy",
+        "summary": "Sign out",
+        "description": "Sign out by destroying the current authenticated session. After calling this, the session token is invalidated and subsequent requests will be unauthenticated. Requires an active session.",
+        "tags": ["session"],
+        "responses": {
+          "200": {
+            "description": "Sign-out result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "success": { "type": "boolean" } },
+                  "required": ["success"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/message": {
+      "put": {
+        "operationId": "message:create",
+        "summary": "Post a chat message",
+        "description": "Create a new chat message as the currently authenticated user. The message is persisted and broadcast in real-time to all connected users via the 'messages' PubSub channel. Requires an active session.",
+        "tags": ["message"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MessageCreateRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The created message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": { "$ref": "#/components/schemas/Message" }
+                  },
+                  "required": ["message"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "422": { "$ref": "#/components/responses/ValidationError" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/messages/list": {
+      "get": {
+        "operationId": "messages:list",
+        "summary": "List chat messages",
+        "description": "List chat messages in reverse chronological order (newest first) with pagination. Each message includes the author's name, body, and timestamps. Requires an active session.",
+        "tags": ["message"],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of messages to return (1-100).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "1-indexed page number.",
+            "schema": { "type": "integer", "minimum": 1, "default": 1 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of messages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "messages": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Message" }
+                    },
+                    "pagination": { "$ref": "#/components/schemas/Pagination" }
+                  },
+                  "required": ["messages", "pagination"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "422": { "$ref": "#/components/responses/ValidationError" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/message/{message}": {
+      "get": {
+        "operationId": "message:view",
+        "summary": "View a message",
+        "description": "Retrieve a single message by its numeric ID. Returns the message body, author name, and timestamps. Requires an active session.",
+        "tags": ["message"],
+        "parameters": [
+          {
+            "name": "message",
+            "in": "path",
+            "required": true,
+            "description": "The numeric ID of the message to view.",
+            "schema": { "type": "integer", "minimum": 1 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": { "$ref": "#/components/schemas/Message" }
+                  },
+                  "required": ["message"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/channel/{channel}/members": {
+      "get": {
+        "operationId": "channel:members",
+        "summary": "List channel members",
+        "description": "Get the list of presence keys for members currently subscribed to a PubSub channel. Requires an active session.",
+        "tags": ["channel"],
+        "parameters": [
+          {
+            "name": "channel",
+            "in": "path",
+            "required": true,
+            "description": "The channel name to query.",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Channel members",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "members": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  },
+                  "required": ["members"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "422": { "$ref": "#/components/responses/ValidationError" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/file": {
+      "post": {
+        "operationId": "fileUpload",
+        "summary": "Upload a file",
+        "description": "Upload a file along with a string parameter. Returns metadata about the uploaded file (name, MIME type, size in bytes) and the string parameter. Does not require authentication.",
+        "tags": ["file"],
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": { "type": "string", "format": "binary" },
+                  "stringParam": { "type": "string", "minLength": 1 }
+                },
+                "required": ["file", "stringParam"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Uploaded file metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "params": {
+                      "type": "object",
+                      "properties": {
+                        "stringParam": { "type": "string" },
+                        "file": {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": "string" },
+                            "type": { "type": "string" },
+                            "size": { "type": "integer" }
+                          },
+                          "required": ["name", "type", "size"]
+                        }
+                      },
+                      "required": ["stringParam", "file"]
+                    }
+                  },
+                  "required": ["params"]
+                }
+              }
+            }
+          },
+          "422": { "$ref": "#/components/responses/ValidationError" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "sessionCookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "__session",
+        "description": "Session cookie set by the session:create action after a successful sign-in."
+      },
+      "oauth2": {
+        "type": "oauth2",
+        "description": "OAuth 2.1 authorization code flow with PKCE. Used by AI agents connecting over MCP. Dynamic client registration and authorization server metadata are published at https://api.demo.keryxjs.com/.well-known/oauth-authorization-server.",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://api.demo.keryxjs.com/oauth/authorize",
+            "tokenUrl": "https://api.demo.keryxjs.com/oauth/token",
+            "refreshUrl": "https://api.demo.keryxjs.com/oauth/token",
+            "scopes": {
+              "mcp": "Call actions exposed as MCP tools on behalf of the authenticated user."
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Authentication is required or the session is invalid.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "The requested resource does not exist.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "ValidationError": {
+        "description": "One or more parameters failed validation.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Too many requests. Retry after the interval in the Retry-After header.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "ServerError": {
+        "description": "An unexpected server error occurred.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "description": "Structured error envelope returned by every Keryx endpoint. Agents should read `error.type` to distinguish validation failures, authentication failures, and server errors, and surface `error.message` to the user.",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string",
+                "description": "Human-readable description of what went wrong."
+              },
+              "type": {
+                "type": "string",
+                "description": "Machine-readable error code.",
+                "examples": [
+                  "CONNECTION_ACTION_PARAM_VALIDATION",
+                  "CONNECTION_ACTION_RUN",
+                  "ACTION_VALIDATION",
+                  "CONNECTION_SESSION_NOT_FOUND"
+                ]
+              },
+              "timestamp": {
+                "type": "integer",
+                "description": "Unix epoch time (ms) when the error was generated."
+              },
+              "key": {
+                "type": "string",
+                "description": "The input field that caused a validation error, when applicable."
+              },
+              "value": {
+                "description": "The offending value, when applicable."
+              }
+            },
+            "required": ["message", "type", "timestamp"]
+          }
+        },
+        "required": ["error"]
+      },
+      "User": {
+        "type": "object",
+        "description": "A user account, including private fields visible only to the account owner.",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "email": { "type": "string", "format": "email" },
+          "createdAt": {
+            "type": "integer",
+            "description": "Unix epoch time (ms)."
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "Unix epoch time (ms)."
+          }
+        },
+        "required": ["id", "name", "email", "createdAt", "updatedAt"]
+      },
+      "PublicUser": {
+        "type": "object",
+        "description": "The publicly visible subset of a user profile.",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "createdAt": {
+            "type": "integer",
+            "description": "Unix epoch time (ms)."
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "Unix epoch time (ms)."
+          }
+        },
+        "required": ["id", "name", "createdAt", "updatedAt"]
+      },
+      "Message": {
+        "type": "object",
+        "description": "A chat message.",
+        "properties": {
+          "id": { "type": "integer" },
+          "body": { "type": "string" },
+          "user_id": { "type": "integer" },
+          "user_name": { "type": "string" },
+          "createdAt": {
+            "type": "integer",
+            "description": "Unix epoch time (ms)."
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "Unix epoch time (ms)."
+          }
+        },
+        "required": ["id", "body", "user_id", "createdAt", "updatedAt"]
+      },
+      "Session": {
+        "type": "object",
+        "description": "An authenticated session envelope.",
+        "properties": {
+          "id": { "type": "string" },
+          "data": { "type": "object", "additionalProperties": true },
+          "createdAt": {
+            "type": "integer",
+            "description": "Unix epoch time (ms)."
+          }
+        }
+      },
+      "Pagination": {
+        "type": "object",
+        "description": "Standardized pagination metadata.",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "1-indexed page number."
+          },
+          "limit": { "type": "integer", "description": "Items per page." },
+          "total": {
+            "type": "integer",
+            "description": "Total items across all pages."
+          },
+          "pages": {
+            "type": "integer",
+            "description": "Total number of pages."
+          }
+        },
+        "required": ["page", "limit", "total", "pages"]
+      },
+      "Status": {
+        "type": "object",
+        "description": "Server health and runtime information.",
+        "properties": {
+          "name": { "type": "string" },
+          "pid": { "type": "integer" },
+          "version": { "type": "string" },
+          "uptime": {
+            "type": "integer",
+            "description": "Milliseconds since boot."
+          },
+          "consumedMemoryMB": { "type": "number" },
+          "healthy": { "type": "boolean" },
+          "checks": {
+            "type": "object",
+            "properties": {
+              "database": { "type": "boolean" },
+              "redis": { "type": "boolean" }
+            }
+          }
+        },
+        "required": ["name", "version", "uptime", "healthy"]
+      },
+      "UserCreateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 256,
+            "description": "The user's name."
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "The user's email. Must be unique (case-insensitive)."
+          },
+          "password": {
+            "type": "string",
+            "minLength": 8,
+            "maxLength": 256,
+            "format": "password",
+            "description": "The user's password. Stored as a hash."
+          }
+        },
+        "required": ["name", "email", "password"]
+      },
+      "UserEditRequest": {
+        "type": "object",
+        "description": "All fields optional; only provided fields are updated.",
+        "properties": {
+          "name": { "type": "string", "minLength": 1, "maxLength": 256 },
+          "email": { "type": "string", "format": "email" },
+          "password": {
+            "type": "string",
+            "minLength": 8,
+            "maxLength": 256,
+            "format": "password"
+          }
+        }
+      },
+      "SessionCreateRequest": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "The user's email."
+          },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "description": "The user's password."
+          }
+        },
+        "required": ["email", "password"]
+      },
+      "MessageCreateRequest": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1000,
+            "description": "The message body."
+          },
+          "csrfToken": {
+            "type": "string",
+            "description": "CSRF token from GET /api/csrf-token."
+          }
+        },
+        "required": ["body"]
+      }
+    }
+  }
+}

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.42.8",
+  "version": "0.42.9",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves how ready `keryxjs.com` is for AI agents. `keryxjs.com` is a static VitePress site deployed to GitHub Pages, with the live API / OAuth / MCP server running at `api.demo.keryxjs.com`. This PR publishes the machine-readable discovery documents, metadata, and recovery affordances that an agent audit expects, all as static files and build-time metadata — no runtime behavior or visual design changes.

## What changed

**Machine-readable discovery (served at the site root)**
- `/openapi.json` — OpenAPI 3.1 spec for the live demo API. Every operation has a unique `operationId`, a description, typed parameters, and typed request/response schemas. Declares an `oauth2` security scheme with a named `mcp` scope (scoped permissions) and a structured JSON `Error` schema (`{ error: { message, type, timestamp, ... } }`) referenced by write operations.
- `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` — RFC 8414 / RFC 9728 metadata (with `scopes_supported`) pointing at the live OAuth server on `api.demo.keryxjs.com`.
- `/.well-known/mcp` — MCP manifest advertising the Streamable HTTP endpoint and its OAuth auth.
- `_headers` (`Vary: Accept, Accept-Encoding`) for CDN-backed hosts, and `.nojekyll` so GitHub Pages serves the dotfiles.

**Pages**
- `/developers` — developer portal: API reference, OpenAPI, a runnable sandbox (the live demo), authentication, MCP, CLI, and LLM docs.
- `/about`, `/contact`, `/privacy` — trust-anchor pages (each 500+ chars).
- Homepage now links the developer/API resources; nav gains a **Developers** entry.

**Metadata & recovery**
- `html lang`, per-page `canonical` + `og:url`, global `og:type` / `og:image`, and JSON-LD (`SoftwareApplication` + `Organization` with `contactPoint` and a `PostalAddress`).
- Agent-friendly 404: a build-time step injects a static, link-rich recovery body into `404.html` so non-JS agents get a helpful list (home, guide, developer portal, `llms.txt`, `openapi.json`, sitemap). GitHub Pages already returns a real `404` status.
- `llms.txt` now includes a **When to use Keryx** section plus developer-resource links.

## Verification

- `docs` build passes; `bun run test` (docs) is green — **44 pass / 0 fail**, including new tests for the OpenAPI structure & OAuth scopes, the `.well-known` documents, homepage JSON-LD/canonical/OG tags, the static 404 body, `llms.txt` guidance, and the trust pages.
- `bun run lint` (docs) clean.
- Verified against a local `vitepress preview`:
  - `GET /openapi.json` → `200`, `application/json`
  - `GET /.well-known/oauth-protected-resource` / `/.well-known/mcp` → `200`, valid JSON
  - `GET /this-path-does-not-exist` → **`404`** with a `Page not found` body containing `/developers`, `/openapi.json`, etc.

## Audit items addressed

Failures/partials fixed: agent-friendly 404s, scoped permissions (OAuth scopes), OpenAPI spec published, JSON error responses (documented in the spec), OAuth 2.0 discovery, developer resource + brand discoverability (titles, JSON-LD, sitemap), developer portal, JSON-LD structured data, API/docs linked from homepage, agent when-to-use guidance, API schema/function-calling compatibility, organization schema completeness, trust anchor pages, public API discoverability, agent onboarding (self-serve sandbox), metadata completeness, CLI discoverability, and MCP manifest.

## Remaining recommendations (need infra/product decisions)

- **Markdown content negotiation (`Vary: Accept`)** cannot be satisfied on GitHub Pages, which serves static files with no server-side negotiation and no custom headers. The Markdown variants are still reachable by appending `.md`, and `_headers` is included so the correct `Vary` is applied automatically if the site is ever fronted by a CDN (Cloudflare Pages, Netlify, etc.). Fully fixing this requires moving `keryxjs.com` behind such a host.
- The `.well-known` OAuth/MCP endpoints on `keryxjs.com` are static copies that point at the live server on `api.demo.keryxjs.com` (which serves the working, RFC-correct endpoints). A strict issuer-match client following the discovery chain will fetch from the demo origin.
- `og:image` currently reuses the SVG herald logo; adding a raster (PNG) social image would improve link-preview coverage.
- Brand-name search ranking is largely off-page SEO (backlinks, consistent listings) beyond what a code change can guarantee.

Bumps `keryx` to `0.42.9` per repo convention; the static spec/manifest versions are kept in sync with the framework version the live `/api/swagger` reports.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02bac-3f57-755f-93c2-4c8735e9ee52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02bac-3f57-755f-93c2-4c8735e9ee52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

