### PR TITLE
feat(db): expose the project's Drizzle tables as api.db.schema

### DIFF
--- a/docs/guide/advanced-patterns.md
+++ b/docs/guide/advanced-patterns.md
@@ -1,5 +1,5 @@
 ---
-description: Production patterns for database transactions, RBAC, audit logging, and middleware composition in Keryx apps.
+description: Production patterns for database transactions, schema introspection, RBAC, audit logging, and middleware composition in Keryx apps.
 ---
 
 # Advanced Patterns
@@ -305,6 +305,58 @@ export class CreateUserWithWelcome extends Action {
 ```
 
 `connection.metadata` is preserved across nested `act()` calls (it resets only on the outermost call), so the child action sees the parent's `transaction`, `_txClient`, and any other metadata set by earlier middleware.
+
+## Schema Introspection
+
+Most of the time you import the table you need and get on with it:
+
+```ts
+import { users } from "../schema/users";
+
+const rows = await api.db.db.select().from(users);
+```
+
+That breaks down the moment you write code that doesn't know its tables ahead of time — an admin dashboard, a CSV exporter, a data-retention sweeper. For those, Keryx loads every Drizzle table exported from your `schema/` directory into `api.db.schema`, keyed by export name:
+
+```ts
+Object.keys(api.db.schema); // ["messages", "users"]
+
+api.db.schema.users === users; // the very same table object
+```
+
+Entries are ordinary Drizzle tables, so they go straight into the query builder:
+
+```ts
+const rows = await api.db.db.select().from(api.db.schema.users).limit(10);
+```
+
+Pair the registry with Drizzle's `getTableConfig()` to read a table's real shape — column types, nullability, defaults, unique indexes, and foreign keys:
+
+```ts
+import { getTableName } from "drizzle-orm";
+import { getTableConfig } from "drizzle-orm/pg-core";
+
+for (const [exportName, table] of Object.entries(api.db.schema)) {
+  const { columns, indexes, foreignKeys } = getTableConfig(table);
+
+  console.log(`${exportName} -> ${getTableName(table)}`);
+  for (const column of columns) {
+    console.log(`  ${column.name}: ${column.getSQLType()}`, {
+      nullable: !column.notNull,
+      primaryKey: column.primary,
+      hasDefault: column.hasDefault,
+    });
+  }
+  console.log(`  ${indexes.length} indexes, ${foreignKeys.length} foreign keys`);
+}
+```
+
+Two things worth knowing:
+
+- **Keys are export names, not SQL names.** `export const gadgets = pgTable("gadgets_table", ...)` registers under `gadgets`. Reach for `getTableName(table)` when you need the name PostgreSQL knows.
+- **Non-table exports are ignored.** Schema files can export types, constants, and helpers freely; only Drizzle tables land in the registry.
+
+Projects without a `schema/` directory get an empty registry rather than an error, so this stays out of your way until you need it.
 
 ## Audit Logging with Base Action Classes
 

--- a/example/backend/__tests__/initializers/db.test.ts
+++ b/example/backend/__tests__/initializers/db.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { sql } from "drizzle-orm";
+import { getTableName, sql } from "drizzle-orm";
+import { getTableConfig } from "drizzle-orm/pg-core";
 import { api } from "keryx";
 import { users } from "../../schema/users";
 import { HOOK_TIMEOUT } from "./../setup";
@@ -35,6 +36,30 @@ describe("db initializer", () => {
   test("can query tables", async () => {
     const result = await api.db.db.select().from(users);
     expect(Array.isArray(result)).toBe(true);
+  });
+
+  describe("schema registry", () => {
+    test("discovers every table in schema/", () => {
+      expect(Object.keys(api.db.schema).sort()).toEqual(["messages", "users"]);
+    });
+
+    test("registers the same table objects the app imports directly", () => {
+      expect(api.db.schema.users).toBe(users);
+    });
+
+    test("registered tables carry introspectable column metadata", () => {
+      const { columns } = getTableConfig(api.db.schema.users);
+      const email = columns.find((c) => c.name === "email");
+
+      expect(getTableName(api.db.schema.users)).toBe("users");
+      expect(email?.getSQLType()).toBe("text");
+      expect(email?.notNull).toBe(true);
+    });
+
+    test("registered tables are queryable without importing the schema file", async () => {
+      const result = await api.db.db.select().from(api.db.schema.messages);
+      expect(Array.isArray(result)).toBe(true);
+    });
   });
 
   test("clearDatabase truncates all tables", async () => {

--- a/packages/keryx/__tests__/fixtures/schema/gadgets.ts
+++ b/packages/keryx/__tests__/fixtures/schema/gadgets.ts
@@ -1,0 +1,8 @@
+import { integer, pgTable, serial } from "drizzle-orm/pg-core";
+
+// The export name (`gadgets`) intentionally differs from the SQL name (`gadgets_table`)
+// so tests can prove the registry keys off the export, not the table name.
+export const gadgets = pgTable("gadgets_table", {
+  id: serial("id").primaryKey(),
+  widgetId: integer("widget_id").notNull(),
+});

--- a/packages/keryx/__tests__/fixtures/schema/widgets.ts
+++ b/packages/keryx/__tests__/fixtures/schema/widgets.ts
@@ -1,0 +1,13 @@
+import { pgTable, serial, text } from "drizzle-orm/pg-core";
+
+export const widgets = pgTable("widgets", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+});
+
+// Non-table exports live alongside tables in real schema files; the loader must skip them.
+export const WIDGET_KINDS = ["round", "square"] as const;
+
+export function widgetLabel(name: string) {
+  return `widget:${name}`;
+}

--- a/packages/keryx/__tests__/initializers/db.test.ts
+++ b/packages/keryx/__tests__/initializers/db.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { sql } from "drizzle-orm";
+import { getTableName, is, sql } from "drizzle-orm";
+import { PgTable } from "drizzle-orm/pg-core";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -7,7 +8,7 @@ import { Pool } from "pg";
 import { api } from "../../api";
 import { ErrorType, TypedError } from "../../classes/TypedError";
 import { config } from "../../config";
-import { DB } from "../../initializers/db";
+import { DB, loadSchema } from "../../initializers/db";
 import { HOOK_TIMEOUT } from "../setup";
 
 beforeAll(async () => {
@@ -33,6 +34,52 @@ describe("DB initializer", () => {
   test("exposes clearDatabase and generateMigrations methods", () => {
     expect(typeof api.db.clearDatabase).toBe("function");
     expect(typeof api.db.generateMigrations).toBe("function");
+  });
+
+  test("exposes a schema registry on api.db", () => {
+    // api.rootDir is the framework package itself, which has no schema/ directory,
+    // so the registry is empty rather than absent.
+    expect(api.db.schema).toEqual({});
+  });
+
+  describe("loadSchema", () => {
+    const fixtureSchemaDir = path.join(
+      import.meta.dir,
+      "..",
+      "fixtures",
+      "schema",
+    );
+
+    test("registers every Drizzle table it finds, keyed by export name", async () => {
+      const schema = await loadSchema(fixtureSchemaDir);
+
+      expect(Object.keys(schema).sort()).toEqual(["gadgets", "widgets"]);
+      expect(is(schema.widgets, PgTable)).toBe(true);
+      expect(getTableName(schema.widgets)).toBe("widgets");
+      expect(getTableName(schema.gadgets)).toBe("gadgets_table");
+    });
+
+    test("ignores schema exports that are not tables", async () => {
+      const schema = await loadSchema(fixtureSchemaDir);
+
+      expect(schema.WIDGET_KINDS).toBeUndefined();
+      expect(schema.widgetLabel).toBeUndefined();
+    });
+
+    test("returns an empty registry when schema/ does not exist", async () => {
+      const schema = await loadSchema(
+        path.join(api.rootDir, "no-such-schema-dir"),
+      );
+
+      expect(schema).toEqual({});
+    });
+
+    test("registered tables can be handed straight to the query builder", async () => {
+      const schema = await loadSchema(fixtureSchemaDir);
+      const { sql: query } = api.db.db.select().from(schema.widgets).toSQL();
+
+      expect(query).toContain('"widgets"');
+    });
   });
 
   test("round-trips SELECT NOW() through the raw pool", async () => {

--- a/packages/keryx/__tests__/util/glob.test.ts
+++ b/packages/keryx/__tests__/util/glob.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import { getTableName, is } from "drizzle-orm";
+import { PgTable } from "drizzle-orm/pg-core";
+import path from "path";
+import { TypedError } from "../../classes/TypedError";
+import { globModuleExports } from "../../util/glob";
+
+const isTable = (value: unknown): value is PgTable => is(value, PgTable);
+const fixtureSchemaDir = path.join(import.meta.dir, "..", "fixtures", "schema");
+
+describe("globModuleExports", () => {
+  test("collects matching exports from every file in the directory", async () => {
+    const registry = await globModuleExports(fixtureSchemaDir, isTable);
+
+    expect(Object.keys(registry).sort()).toEqual(["gadgets", "widgets"]);
+    expect(isTable(registry.widgets)).toBe(true);
+    expect(isTable(registry.gadgets)).toBe(true);
+  });
+
+  test("keys off the export name, not the SQL table name", async () => {
+    const registry = await globModuleExports(fixtureSchemaDir, isTable);
+
+    expect(getTableName(registry.gadgets)).toBe("gadgets_table");
+    expect(registry.gadgets_table).toBeUndefined();
+  });
+
+  test("skips exports the predicate rejects", async () => {
+    const registry = await globModuleExports(fixtureSchemaDir, isTable);
+
+    // widgets.ts also exports a const array and a function.
+    expect(registry.WIDGET_KINDS).toBeUndefined();
+    expect(registry.widgetLabel).toBeUndefined();
+  });
+
+  test("returns an empty registry for a directory that does not exist", async () => {
+    const missing = path.join(import.meta.dir, "no-such-directory");
+
+    expect(await globModuleExports(missing, isTable)).toEqual({});
+  });
+
+  test("honors a predicate that selects non-class values", async () => {
+    const isStringArray = (value: unknown): value is readonly string[] =>
+      Array.isArray(value) && value.every((v) => typeof v === "string");
+
+    const registry = await globModuleExports(fixtureSchemaDir, isStringArray);
+
+    expect(registry.WIDGET_KINDS).toEqual(["round", "square"]);
+    expect(registry.widgets).toBeUndefined();
+  });
+
+  test("wraps import failures in a TypedError naming the offending file", async () => {
+    const brokenDir = fs.mkdtempSync(path.join(os.tmpdir(), "keryx-glob-"));
+    fs.writeFileSync(
+      path.join(brokenDir, "syntaxError.ts"),
+      "export const broken = (",
+    );
+
+    try {
+      await expect(globModuleExports(brokenDir, isTable)).rejects.toThrow(
+        TypedError,
+      );
+      await expect(globModuleExports(brokenDir, isTable)).rejects.toThrow(
+        /syntaxError\.ts/,
+      );
+    } finally {
+      fs.rmSync(brokenDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/keryx/index.ts
+++ b/packages/keryx/index.ts
@@ -68,7 +68,7 @@ export type {
 export { buildProgram } from "./util/cli";
 export { deepMerge, deepMergeDefaults, loadFromEnvIfSet } from "./util/config";
 export { getValidTypes } from "./util/generate";
-export { globLoader } from "./util/glob";
+export { globLoader, globModuleExports } from "./util/glob";
 export { type PaginatedResult, paginate } from "./util/pagination";
 export { safeCompare } from "./util/safeCompare";
 export type { JSONSchema } from "./util/swaggerSchemaGenerator";

--- a/packages/keryx/initializers/db.ts
+++ b/packages/keryx/initializers/db.ts
@@ -2,9 +2,10 @@ import fs from "node:fs";
 import { unlink } from "node:fs/promises";
 import { $, Glob } from "bun";
 import { type Config as DrizzleMigrateConfig } from "drizzle-kit";
-import { DefaultLogger, type LogWriter, sql } from "drizzle-orm";
+import { DefaultLogger, is, type LogWriter, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { PgTable } from "drizzle-orm/pg-core";
 import path from "path";
 import { Pool } from "pg";
 import { api, logger } from "../api";
@@ -15,6 +16,7 @@ import {
   formatConnectionStringForLogging,
   throwConnectionError,
 } from "../util/connectionString";
+import { globModuleExports } from "../util/glob";
 
 const namespace = "db";
 
@@ -41,6 +43,29 @@ async function hasSchemaFiles(schemaDir: string) {
   return false;
 }
 
+/**
+ * Build a registry of the project's Drizzle tables so the framework and plugins can
+ * enumerate the database at runtime. Drizzle itself only ever sees the tables an action
+ * imports directly, which leaves generic tooling — an admin dashboard, a schema
+ * explorer — with nothing to introspect.
+ *
+ * Every `.ts` file under the directory is imported and its exports filtered down to
+ * Drizzle tables. Keys are the *export* names (`users`), which may differ from the SQL
+ * table names (`"users"`); use `getTableName()` when the SQL name is what you need.
+ *
+ * @param schemaDir - Absolute path to the project's `schema/` directory. A missing
+ * directory yields an empty registry, so `schema/` remains an optional convention and
+ * schema-less projects are unaffected.
+ * @returns Map of export name to Drizzle table, ready to hand to `db.select().from()`
+ * or `getTableConfig()`.
+ * @throws {TypedError} With `ErrorType.SERVER_INITIALIZATION` if a schema file fails to import.
+ */
+export async function loadSchema(schemaDir: string) {
+  return globModuleExports<PgTable>(schemaDir, (value): value is PgTable =>
+    is(value, PgTable),
+  );
+}
+
 declare module "keryx" {
   export interface API {
     [namespace]: Awaited<ReturnType<DB["initialize"]>>;
@@ -53,6 +78,10 @@ export class DB extends Initializer {
   }
 
   async initialize() {
+    const schema = await loadSchema(path.join(api.rootDir, SCHEMA_DIR));
+    const tableCount = Object.keys(schema).length;
+    logger.debug(`loaded ${tableCount} table(s) from ${SCHEMA_DIR}/`);
+
     const dbContainer = {} as {
       db: ReturnType<typeof drizzle>;
       pool: InstanceType<typeof Pool>;
@@ -61,6 +90,7 @@ export class DB extends Initializer {
       {
         generateMigrations: this.generateMigrations,
         clearDatabase: this.clearDatabase,
+        schema,
       },
       dbContainer,
     );
@@ -79,6 +109,7 @@ export class DB extends Initializer {
     }
 
     api.db.db = drizzle(api.db.pool, {
+      schema: api.db.schema,
       logger: new DefaultLogger({ writer: new DrizzleLogger() }),
     });
 

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.42.8",
+  "version": "0.43.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/keryx/util/glob.ts
+++ b/packages/keryx/util/glob.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { Glob } from "bun";
 import path from "path";
 import { api } from "../api";
@@ -40,6 +41,59 @@ export async function globLoader<T>(searchDir: string) {
           cause: error,
         });
       }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Auto-discover exported *values* from `.ts`/`.tsx` files in a directory, keyed by export name.
+ *
+ * Where {@link globLoader} instantiates every exported class, this returns the exports
+ * themselves. Use it for modules that export plain objects rather than classes — Drizzle
+ * table definitions, for example, which cannot be constructed with `new`.
+ *
+ * @param searchDir - Absolute path, or a path resolved from `api.rootDir`, to scan. A missing
+ * directory yields an empty registry instead of throwing, so optional project conventions
+ * (like `schema/`) stay optional.
+ * @param predicate - Type guard selecting which exports to keep; rejected exports are skipped,
+ * which lets schema files freely export helpers, types, and constants alongside tables.
+ * @returns Object mapping export name to value. When two files export the same name, whichever
+ * the glob visits last wins.
+ * @throws {TypedError} With `ErrorType.SERVER_INITIALIZATION` if a file fails to import.
+ */
+export async function globModuleExports<T>(
+  searchDir: string,
+  predicate: (value: unknown) => value is T,
+) {
+  const results: Record<string, T> = {};
+  const dir = path.isAbsolute(searchDir)
+    ? searchDir
+    : path.join(api.rootDir, searchDir);
+
+  if (!fs.existsSync(dir)) return results;
+
+  const glob = new Glob("**/*.{ts,tsx}");
+
+  for await (const file of glob.scan(dir)) {
+    if (file.startsWith(".")) continue;
+
+    const fullPath = path.join(dir, file);
+    let modules: Record<string, unknown>;
+
+    try {
+      modules = (await import(fullPath)) as Record<string, unknown>;
+    } catch (error) {
+      throw new TypedError({
+        message: `Error loading from ${dir} -  ${file} - ${error}`,
+        type: ErrorType.SERVER_INITIALIZATION,
+        cause: error,
+      });
+    }
+
+    for (const [name, value] of Object.entries(modules)) {
+      if (predicate(value)) results[name] = value;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`api.db.db` is created with `drizzle(api.db.pool, { logger })` — no schema object. Drizzle only ever sees the tables an action imports directly, so nothing can enumerate an app's tables at runtime. The only place the framework does it today is `clearDatabase()`, via a raw `SELECT tablename FROM pg_tables`.

That's a dead end for any generic tooling: an admin dashboard, a schema explorer, a CSV exporter, a retention sweeper. This is the prerequisite for an upcoming RailsAdmin/DjangoAdmin-style admin plugin, but it stands on its own.

## What

Every Drizzle table exported from `{api.rootDir}/schema` — the same directory `generateMigrations()` already scans — is loaded into a registry on `api.db.schema`, keyed by export name:

```ts
Object.keys(api.db.schema); // ["messages", "users"]
api.db.schema.users === users; // the same table object the app imports

const rows = await api.db.db.select().from(api.db.schema.users).limit(10);
```

Entries are `PgTable` instances, so they go straight into the query builder and into Drizzle's `getTableConfig()` for column types, nullability, defaults, unique indexes, and foreign keys.

Supporting change: `globModuleExports(dir, predicate)` in `util/glob.ts`, a sibling to the existing `globLoader`. `globLoader` instantiates every exported class, which is wrong for table definitions — they can't be constructed with `new`. The new helper returns the exports themselves, filtered by a type guard, and treats a missing directory as empty rather than throwing.

## Notes

- **Additive.** Projects with no `schema/` directory get `{}` and behave exactly as before. The registry keys off export names, so `export const gadgets = pgTable("gadgets_table", ...)` registers under `gadgets` — use `getTableName()` for the SQL name.
- **Non-table exports are skipped**, so schema files stay free to export types, constants, and helpers.
- The schema is also passed to `drizzle()`, which additionally enables the runtime relational query API.

## Testing

- New `packages/keryx/__tests__/util/glob.test.ts` covering `globModuleExports`: multi-file collection, export-name keying, predicate filtering, missing directories, non-class predicates, and import failures surfacing as a `TypedError` naming the offending file.
- New cases in `packages/keryx/__tests__/initializers/db.test.ts` for `loadSchema` and for `api.db.schema` being present-but-empty when the root has no `schema/`.
- New cases in `example/backend/__tests__/initializers/db.test.ts` proving the real app discovers both of its tables, that registry entries are identity-equal to the directly imported ones, and that they are introspectable and queryable without importing the schema file.
- Fixture schema files under `packages/keryx/__tests__/fixtures/schema/`.

`bun run ci` passes end to end: lint across all workspaces plus 1387 tests, 0 failures.

## Docs

New "Schema Introspection" section in [docs/guide/advanced-patterns.md](docs/guide/advanced-patterns.md).

Version bumped to `0.43.0` (minor — new feature).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8a370e7-3919-41f6-b687-6aaa1a8bf0a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8a370e7-3919-41f6-b687-6aaa1a8bf0a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

