### PR TITLE
feat(actions): opt out of distributed tracing with tracing = false

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
     },
     "packages/keryx": {
       "name": "keryx",
-      "version": "0.43.0",
+      "version": "0.45.0",
       "bin": {
         "keryx": "keryx.ts",
       },
@@ -121,7 +121,7 @@
     },
     "packages/plugins/admin": {
       "name": "@keryxjs/admin",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/bun": "^1.3.12",
         "drizzle-orm": "^0.45.2",
@@ -149,7 +149,7 @@
     },
     "packages/plugins/resque-admin": {
       "name": "@keryxjs/resque-admin",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/bun": "^1.3.12",
         "typescript": "^7.0.2",
@@ -162,7 +162,7 @@
     },
     "packages/plugins/sentry": {
       "name": "@keryxjs/sentry",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@sentry/bun": "^10.32.1",
       },
@@ -177,7 +177,7 @@
     },
     "packages/plugins/tracing": {
       "name": "@keryxjs/tracing",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "dependencies": {
         "@kubiks/otel-drizzle": "^2.1.0",
         "@opentelemetry/core": "^1.30.0",

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -1,5 +1,5 @@
 ---
-description: How to write actions — inputs, validation, web routes, task scheduling, middleware, MCP exposure, and type helpers.
+description: How to write actions — inputs, validation, web routes, task scheduling, middleware, MCP exposure, tracing opt-out, and type helpers.
 ---
 
 # Actions
@@ -31,6 +31,8 @@ export class Status implements Action {
 
 That's a fully functioning HTTP endpoint, CLI command, and WebSocket handler. Hit `GET /api/status` from a browser, run `./keryx.ts status -q | jq` from the terminal, or send `{ action: "status" }` over a WebSocket — same action, same response.
 
+The built-in `status` action also sets [`tracing = false`](#opting-out-of-tracing) so load-balancer health checks don't flood Sentry or Jaeger.
+
 ## Properties
 
 | Property      | Type                    | What it does                                                                   |
@@ -43,6 +45,7 @@ That's a fully functioning HTTP endpoint, CLI command, and WebSocket handler. Hi
 | `middleware`  | `ActionMiddleware[]`    | Runs before/after the action (auth, logging, etc.)                             |
 | `mcp`         | `McpActionConfig`       | Controls MCP exposure: tool, resource, and/or prompt (tools are opt-in)       |
 | `timeout`     | `number`                | Per-action timeout in ms (overrides `config.actions.timeout`; `0` disables)    |
+| `tracing`     | `boolean`               | Set `false` to [skip distributed tracing](#opting-out-of-tracing) for this action. Unset means traced. |
 
 ## Input Validation
 
@@ -254,6 +257,23 @@ task = { queue: "default", frequency: 1000 * 60 * 60 }; // every hour
 
 See [Tasks](/guide/tasks) for the full story on background processing and the fan-out pattern.
 
+## Opting Out of Tracing
+
+Health checks and other high-frequency endpoints will drown a trace backend if you sample them at the same rate as real work. Set `tracing = false` on the action:
+
+```ts
+export class Status implements Action {
+  name = "status";
+  tracing = false;
+  web = { route: "/status", method: HTTP_METHOD.GET };
+  // ...
+}
+```
+
+[`@keryxjs/sentry`](/plugins/sentry) and [`@keryxjs/tracing`](/plugins/tracing) both honor this: no action span, and for HTTP and background tasks the whole request or job transaction is dropped. Nested `connection.act()` into an opted-out action skips that inner span but leaves the outer trace alone. Error capture and metrics still run — you still hear about a failing health check, you just don't store a trace for every successful ping.
+
+The built-in `status` action sets `tracing = false` already.
+
 ## Timeouts
 
 Every action execution is wrapped with a timeout (default: 5 minutes). If an action exceeds its timeout, the framework aborts it and returns an HTTP `408` error with type `CONNECTION_ACTION_TIMEOUT`.
@@ -308,3 +328,5 @@ New actions need to be re-exported from `backend/actions/.index.ts`. This is how
 
 - [`Action` class reference](/reference/actions) — every property, type helper, and option in one place
 - [Servers](/reference/servers) — how an action is routed over HTTP, WebSocket, CLI, and MCP
+- [Sentry plugin](/plugins/sentry) — error monitoring and traces in Sentry, including per-action opt-out
+- [Tracing plugin](/plugins/tracing) — OTLP distributed tracing, including per-action opt-out

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -270,7 +270,7 @@ export class Status implements Action {
 }
 ```
 
-[`@keryxjs/sentry`](/plugins/sentry) and [`@keryxjs/tracing`](/plugins/tracing) both honor this: no action span, and for HTTP and background tasks the whole request or job transaction is dropped. Nested `connection.act()` into an opted-out action skips that inner span but leaves the outer trace alone. Error capture and metrics still run — you still hear about a failing health check, you just don't store a trace for every successful ping.
+[`@keryxjs/sentry`](/plugins/sentry) and [`@keryxjs/tracing`](/plugins/tracing) both honor this: no action span, and for HTTP and background tasks the whole request or job transaction is dropped. Nested `connection.act()` into an opted-out action skips that inner span but leaves the outer trace alone. Nested `connection.act()` *from* an opted-out action stays dark too — the outer request already opted out of the whole transaction. Error capture and metrics still run — you still hear about a failing health check, you just don't store a trace for every successful ping.
 
 The built-in `status` action sets `tracing = false` already.
 

--- a/docs/guide/observability.md
+++ b/docs/guide/observability.md
@@ -176,3 +176,7 @@ Your custom metrics will be exported alongside Keryx's built-in metrics on the s
 All built-in metric attributes have bounded cardinality — they use action names, HTTP methods, status codes, and queue names, all of which are known at startup. This means the number of unique time series stays proportional to your action count and memory usage remains constant regardless of traffic volume.
 
 If you record custom metrics via your own `Meter`, avoid using unbounded values (user IDs, request paths, timestamps, etc.) as attributes. Unbounded cardinality causes the OTel SDK to allocate a new time series per unique combination, which can lead to unbounded memory growth.
+
+## Distributed Tracing
+
+For traces, use [`@keryxjs/tracing`](/plugins/tracing) (OTLP) or [`@keryxjs/sentry`](/plugins/sentry). Both honor `tracing = false` on an action so health checks like `status` stay out of the trace backend — see [Opting Out of Tracing](/guide/actions#opting-out-of-tracing). Don't run both plugins at once; they fight over the process-wide tracing context.

--- a/docs/plugins/sentry.md
+++ b/docs/plugins/sentry.md
@@ -62,6 +62,23 @@ The plugin adds its own `config.sentry.*` namespace. All keys except the `before
 
 `beforeSend`, `beforeSendSpan`, `beforeSendLog`, `beforeSendMetric`, and `transport` are config-only (not env vars). Use them to filter PII, drop noisy logs/metrics, or to swap the transport in tests.
 
+## Opting Out of Tracing
+
+Set `tracing = false` on an action to keep it out of Sentry traces. See [Opting Out of Tracing](/guide/actions#opting-out-of-tracing) on the actions guide for the full behavior — no action span, no Redis / Postgres spans during that action, and for HTTP and background tasks the whole transaction is dropped. Error capture and the per-action count metric still run.
+
+```ts
+export class Status implements Action {
+  name = "status";
+  tracing = false;
+  web = { route: "/status", method: HTTP_METHOD.GET };
+  async run() {
+    return { ok: true };
+  }
+}
+```
+
+The built-in `status` action already opts out, so load-balancer health checks don't fill your Sentry project with `GET status` transactions.
+
 ## Logs and Metrics
 
 Sentry [logs](https://docs.sentry.io/product/explore/logs/) and [metrics](https://docs.sentry.io/product/explore/metrics/) are opt-in. Both are off by default so existing installs keep sending only errors and traces.
@@ -93,13 +110,13 @@ Sentry.metrics.count("orders.created", 1, { attributes: { plan: user.plan } });
 
 | Span name                    | Op            | Attributes                                                                 | Notes                                                                                          |
 | ---------------------------- | ------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `<METHOD>` / `GET status`    | `http.server` | `http.request.method`, `http.response.status_code`, `http.route`, `url.full` | Root HTTP span. Renamed to `<METHOD> <route>` once the action resolves                         |
+| `<METHOD>` / `GET user:create` | `http.server` | `http.request.method`, `http.response.status_code`, `http.route`, `url.full` | Root HTTP span. Renamed to `<METHOD> <route>` once the action resolves. Not created when the action sets `tracing = false`. |
 | `ws.connect`                 | `ws.server`   | `keryx.connection.type`, `keryx.connection.id`                             | Opened on accept, ended on disconnect                                                          |
 | `ws.message <type>`          | `ws.server`   | `keryx.ws.message_type`                                                    | Child of the connection span. Action messages stay open until `afterAct`                       |
 | `mcp.connect`                | `mcp.server`  | `keryx.mcp.session_id`                                                     | Opened when the MCP session is initialized, ended on teardown                                  |
 | `mcp.message`                | `mcp.server`  | `keryx.mcp.session_id`                                                     | Child of the session span. Ended when the action finishes or the session closes                |
 | `task:<name>`                | `queue.process` | `keryx.action`, `keryx.connection.type`, `messaging.destination.name`     | Root transaction for a Resque job. Continues the enqueuer's trace when headers are present; otherwise starts a new trace |
-| `action:<name>`              | `keryx.action` | `keryx.action`, `keryx.connection.type`, `keryx.action.duration_ms`        | Fires for every action across HTTP, WebSocket, CLI, background tasks, and MCP                  |
+| `action:<name>`              | `keryx.action` | `keryx.action`, `keryx.connection.type`, `keryx.action.duration_ms`        | Fires for every traced action across HTTP, WebSocket, CLI, background tasks, and MCP. Actions with `tracing = false` are skipped. |
 | `redis.<command>`            | `db`          | `db.system="redis"`, `db.operation.name`, `db.query.text`                  | `db.query.text` is `<command> <key1> <key2>…` — keys only, values are never captured           |
 | `pg.<OP>`                    | `db`          | `db.system="postgresql"`, `db.operation.name`, `db.query.text`             | Wraps the node-postgres `Pool` Drizzle uses. SQL text up to 1000 chars; bind values are not    |
 
@@ -160,7 +177,7 @@ The plugin is fully hook-based — it does **not** modify core Keryx code. It re
 - `api.hooks.web.beforeRequest` / `afterRequest` — create and finalize the HTTP span
 - `api.hooks.ws.onConnect` / `onMessage` / `onDisconnect` — WebSocket connection and message spans
 - `api.hooks.mcp.onConnect` / `onMessage` / `onDisconnect` — MCP session and message spans
-- `api.hooks.actions.beforeAct` / `afterAct` — create and finalize the action span; capture 5xx exceptions; emit the per-action count metric when metrics are enabled
+- `api.hooks.actions.beforeAct` / `afterAct` — create and finalize the action span (skipped when the action sets `tracing = false`); capture 5xx exceptions; emit the per-action count metric when metrics are enabled
 - `api.hooks.actions.onEnqueue` — inject Sentry trace headers into task params
 - `api.hooks.resque.beforeJob` / `afterJob` — create and finalize the root `queue.process` transaction (continuing the enqueuer's trace when headers are present)
 

--- a/docs/plugins/tracing.md
+++ b/docs/plugins/tracing.md
@@ -51,7 +51,7 @@ Run the example backend with tracing enabled:
 OTEL_TRACING_ENABLED=true bun dev
 ```
 
-Open the UI at `http://localhost:16686`, pick `keryx-example-backend` (or whatever `OTEL_SERVICE_NAME` resolves to) in the service dropdown, and click **Find Traces**. A request to `/api/status` will show an HTTP span parenting an `action:*` span; actions that touch Redis or Postgres will show `redis.*` and `drizzle.*` children.
+Open the UI at `http://localhost:16686`, pick `keryx-example-backend` (or whatever `OTEL_SERVICE_NAME` resolves to) in the service dropdown, and click **Find Traces**. A request to a traced action (not `status` — that opts out) will show an HTTP span parenting an `action:*` span; actions that touch Redis or Postgres will show `redis.*` and `drizzle.*` children.
 
 ![Jaeger trace for PUT session:create: the HTTP span parents action:session:create, which in turn parents redis.get/set/incr/expire and drizzle.select child spans. The detail pane shows redis.set with db.query.text "set session:1aa34179-…" — the key is captured, the value is not.](/images/tracing-jaeger-session-create.png)
 
@@ -78,12 +78,27 @@ The plugin adds its own `config.tracing.*` namespace. All keys can be set via en
 | `tracing.spanShutdownTimeoutMs` | `OTEL_SPAN_SHUTDOWN_TIMEOUT_MS`  | `5000`                    | Timeout for flushing pending spans on shutdown          |
 | `observability.serviceName`     | `OTEL_SERVICE_NAME`              | _(app name)_              | Service name set on all spans (shared with core metrics) |
 
+## Opting Out of Tracing
+
+Set `tracing = false` on an action to keep it out of OTLP export. See [Opting Out of Tracing](/guide/actions#opting-out-of-tracing) on the actions guide for the full behavior — no action span, no Redis spans during that action, and for HTTP the whole request transaction is dropped. The built-in `status` action already opts out so health-check pings don't flood Jaeger.
+
+```ts
+export class Status implements Action {
+  name = "status";
+  tracing = false;
+  web = { route: "/status", method: HTTP_METHOD.GET };
+  async run() {
+    return { ok: true };
+  }
+}
+```
+
 ## What Gets Instrumented
 
 | Span name                 | Kind     | Attributes                                                      | Notes                                                         |
 | ------------------------- | -------- | --------------------------------------------------------------- | ------------------------------------------------------------- |
-| `<METHOD>` / `GET status` | SERVER   | `http.request.method`, `http.response.status_code`, `http.route`, `url.full` | Renamed to `<METHOD> <route>` once the action resolves        |
-| `action:<name>`           | INTERNAL | `keryx.action`, `keryx.connection.type`, `keryx.action.duration_ms` | Fires for every action across all transports (HTTP, WS, task, CLI, MCP) |
+| `<METHOD>` / `GET user:create` | SERVER   | `http.request.method`, `http.response.status_code`, `http.route`, `url.full` | Renamed to `<METHOD> <route>` once the action resolves. Not created when the action sets `tracing = false`. |
+| `action:<name>`           | INTERNAL | `keryx.action`, `keryx.connection.type`, `keryx.action.duration_ms` | Fires for every traced action across all transports (HTTP, WS, task, CLI, MCP). Actions with `tracing = false` are skipped. |
 | `redis.<command>`         | CLIENT   | `db.system.name="redis"`, `db.operation.name`, `db.query.text`  | `db.query.text` is `<command> <key1> <key2>…` — keys only, values are never captured (so AUTH passwords, SET values, etc. stay out of traces) |
 | `drizzle.*`               | CLIENT   | `db.system="postgresql"`, `db.statement` (up to 1000 chars)     | Provided by `@kubiks/otel-drizzle`                            |
 
@@ -127,7 +142,7 @@ When tracing is disabled, `api.tracing.tracer` returns a no-op tracer — `start
 The plugin is fully hook-based — it does **not** modify core Keryx code. It registers:
 
 - `api.hooks.web.beforeRequest` / `afterRequest` — create and finalize the HTTP span
-- `api.hooks.actions.beforeAct` / `afterAct` — create and finalize the action span
+- `api.hooks.actions.beforeAct` / `afterAct` — create and finalize the action span (skipped when the action sets `tracing = false`)
 - `api.hooks.actions.onEnqueue` — inject trace context into task params
 - `api.hooks.resque.beforeJob` — extract trace context when a worker picks up a task
 

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -37,6 +37,12 @@ abstract class Action {
   /** Per-action timeout in ms (overrides config.actions.timeout; 0 disables) */
   timeout?: number;
 
+  /**
+   * When `false`, tracing plugins skip this action. Unset (the default) means traced.
+   * The built-in `status` action sets `tracing = false`.
+   */
+  tracing?: boolean;
+
   /** Background task config — queue is required, frequency makes it recurring */
   task?: {
     frequency?: number;
@@ -56,6 +62,8 @@ abstract class Action {
   ): Promise<any>;
 }
 ```
+
+Set `tracing = false` to skip distributed tracing for an action. See [Opting Out of Tracing](/guide/actions#opting-out-of-tracing).
 
 ## How Actions Work Across Transports
 

--- a/example/backend/__tests__/initializers/tracing.test.ts
+++ b/example/backend/__tests__/initializers/tracing.test.ts
@@ -7,8 +7,21 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { api, config } from "keryx";
+import { type Action, api, config, HTTP_METHOD } from "keryx";
+import { z } from "zod";
 import { HOOK_TIMEOUT, serverUrl } from "../setup";
+
+class TracingPing implements Action {
+  name = "tracing:ping";
+  description = "Traced action that pings Redis for span tests";
+  inputs = z.object({});
+  web = { route: "/tracing-ping", method: HTTP_METHOD.GET };
+  mcp = { tool: false };
+  async run() {
+    if (api.redis?.redis) await api.redis.redis.ping();
+    return { ok: true };
+  }
+}
 
 const spanExporter = new InMemorySpanExporter();
 
@@ -28,9 +41,13 @@ beforeAll(async () => {
   await api.initialize();
   config.tracing.enabled = true;
   await api.start();
+  api.actions.actions.push(new TracingPing());
 }, HOOK_TIMEOUT);
 
 afterAll(async () => {
+  api.actions.actions = api.actions.actions.filter(
+    (a: Action) => a.name !== "tracing:ping",
+  );
   await api.stop();
   config.tracing.enabled = false;
   await testProvider.shutdown();
@@ -46,15 +63,15 @@ describe("tracing", () => {
   test("action execution creates spans", async () => {
     spanExporter.reset();
     const url = serverUrl();
-    const res = await fetch(`${url}/api/status`);
+    const res = await fetch(`${url}/api/tracing-ping`);
     expect(res.status).toBe(200);
 
     await Bun.sleep(100);
 
     const spans = spanExporter.getFinishedSpans();
-    const actionSpan = spans.find((s) => s.name === "action:status");
+    const actionSpan = spans.find((s) => s.name === "action:tracing:ping");
     expect(actionSpan).toBeDefined();
-    expect(actionSpan!.attributes["keryx.action"]).toBe("status");
+    expect(actionSpan!.attributes["keryx.action"]).toBe("tracing:ping");
     expect(actionSpan!.attributes["keryx.connection.type"]).toBe("web");
     expect(actionSpan!.attributes["keryx.action.duration_ms"]).toBeDefined();
   });
@@ -62,18 +79,18 @@ describe("tracing", () => {
   test("HTTP request creates parent span with stable semconv attributes", async () => {
     spanExporter.reset();
     const url = serverUrl();
-    const res = await fetch(`${url}/api/status`);
+    const res = await fetch(`${url}/api/tracing-ping`);
     expect(res.status).toBe(200);
 
     await Bun.sleep(100);
 
     const spans = spanExporter.getFinishedSpans();
     // Span name is updated to include route after resolution
-    const httpSpan = spans.find((s) => s.name === "GET status");
+    const httpSpan = spans.find((s) => s.name === "GET tracing:ping");
     expect(httpSpan).toBeDefined();
     expect(httpSpan!.attributes["http.request.method"]).toBe("GET");
     expect(httpSpan!.attributes["http.response.status_code"]).toBe(200);
-    expect(httpSpan!.attributes["http.route"]).toBe("status");
+    expect(httpSpan!.attributes["http.route"]).toBe("tracing:ping");
   });
 
   test("W3C traceparent header is extracted from incoming requests", async () => {
@@ -83,7 +100,7 @@ describe("tracing", () => {
     const traceparent = `00-${traceId}-${spanId}-01`;
 
     const url = serverUrl();
-    const res = await fetch(`${url}/api/status`, {
+    const res = await fetch(`${url}/api/tracing-ping`, {
       headers: { traceparent },
     });
     expect(res.status).toBe(200);
@@ -100,13 +117,13 @@ describe("tracing", () => {
   test("action span is a child of HTTP span", async () => {
     spanExporter.reset();
     const url = serverUrl();
-    await fetch(`${url}/api/status`);
+    await fetch(`${url}/api/tracing-ping`);
 
     await Bun.sleep(100);
 
     const spans = spanExporter.getFinishedSpans();
-    const httpSpan = spans.find((s) => s.name === "GET status");
-    const actionSpan = spans.find((s) => s.name === "action:status");
+    const httpSpan = spans.find((s) => s.name === "GET tracing:ping");
+    const actionSpan = spans.find((s) => s.name === "action:tracing:ping");
 
     expect(httpSpan).toBeDefined();
     expect(actionSpan).toBeDefined();
@@ -132,6 +149,24 @@ describe("tracing", () => {
     const httpSpan = spans.find((s) => s.name.startsWith("GET"));
     expect(httpSpan).toBeDefined();
     expect(httpSpan!.attributes["http.response.status_code"]).toBe(404);
+  });
+
+  test("actions with tracing = false emit no HTTP or action spans", async () => {
+    spanExporter.reset();
+    const url = serverUrl();
+    const statusAction = api.actions.actions.find((a) => a.name === "status");
+    expect(statusAction?.tracing).toBe(false);
+    const res = await fetch(`${url}/api/status`);
+    expect(res.status).toBe(200);
+
+    await Bun.sleep(100);
+
+    const spans = spanExporter.getFinishedSpans();
+    expect(spans.some((s) => s.name === "GET status")).toBe(false);
+    expect(spans.some((s) => s.name === "action:status")).toBe(false);
+    // The status action pings Redis as a health check; that must not be traced.
+    // Other redis.* spans may still appear from the Resque worker polling queues.
+    expect(spans.some((s) => s.name === "redis.ping")).toBe(false);
   });
 
   test("tracing and metrics flags are independent", () => {
@@ -169,7 +204,7 @@ describe("tracing", () => {
   test("Redis command spans use stable semconv attributes", async () => {
     spanExporter.reset();
     const url = serverUrl();
-    await fetch(`${url}/api/status`);
+    await fetch(`${url}/api/tracing-ping`);
 
     await Bun.sleep(100);
 
@@ -184,7 +219,7 @@ describe("tracing", () => {
   test("Redis spans capture command + keys in db.query.text (no values)", async () => {
     spanExporter.reset();
     const url = serverUrl();
-    await fetch(`${url}/api/status`);
+    await fetch(`${url}/api/tracing-ping`);
 
     await Bun.sleep(100);
 
@@ -211,12 +246,12 @@ describe("tracing", () => {
   test("Redis spans exist alongside action spans in the same request", async () => {
     spanExporter.reset();
     const url = serverUrl();
-    await fetch(`${url}/api/status`);
+    await fetch(`${url}/api/tracing-ping`);
 
     await Bun.sleep(100);
 
     const spans = spanExporter.getFinishedSpans();
-    const actionSpan = spans.find((s) => s.name === "action:status");
+    const actionSpan = spans.find((s) => s.name === "action:tracing:ping");
     const redisSpans = spans.filter((s) => s.name.startsWith("redis."));
 
     expect(actionSpan).toBeDefined();
@@ -227,16 +262,16 @@ describe("tracing", () => {
   test("Redis spans from inside action.run are children of the action span", async () => {
     spanExporter.reset();
     const url = serverUrl();
-    // The status action explicitly calls api.redis.redis.ping() inside run(),
+    // tracing:ping explicitly calls api.redis.redis.ping() inside run(),
     // which produces a `redis.ping` span that should be parented to the
     // action span (session loads happen *before* beforeAct and are parented
     // to the HTTP span — that's correct, just not what we're testing here).
-    await fetch(`${url}/api/status`);
+    await fetch(`${url}/api/tracing-ping`);
 
     await Bun.sleep(100);
 
     const spans = spanExporter.getFinishedSpans();
-    const actionSpan = spans.find((s) => s.name === "action:status");
+    const actionSpan = spans.find((s) => s.name === "action:tracing:ping");
     expect(actionSpan).toBeDefined();
 
     const traceId = actionSpan!.spanContext().traceId;

--- a/example/backend/actions/status.ts
+++ b/example/backend/actions/status.ts
@@ -33,6 +33,7 @@ export class Status implements Action {
   inputs = z.object({});
   mcp = { tool: true };
   web = { route: "/status", method: HTTP_METHOD.GET };
+  tracing = false;
 
   async run() {
     const consumedMemoryMB =
@@ -61,6 +62,7 @@ export class StatusMarkdown implements Action {
   inputs = z.object({});
   mcp = { tool: true, responseFormat: MCP_RESPONSE_FORMAT.MARKDOWN };
   web = { route: "/status/markdown", method: HTTP_METHOD.GET };
+  tracing = false;
 
   async run() {
     const consumedMemoryMB =

--- a/packages/keryx/__tests__/classes/Action.test.ts
+++ b/packages/keryx/__tests__/classes/Action.test.ts
@@ -186,6 +186,16 @@ describe("Action constructor overrides", () => {
     expect(action.timeout).toBe(0);
   });
 
+  test("tracing defaults to unset (treated as enabled by tracing plugins)", () => {
+    const action = new MinimalAction({ name: "minimal" });
+    expect(action.tracing).toBeUndefined();
+  });
+
+  test("tracing: false is preserved", () => {
+    const action = new ConfiguredAction({ name: "status", tracing: false });
+    expect(action.tracing).toBe(false);
+  });
+
   test("input zod schema is attached", () => {
     const schema = z.object({ count: z.number().int().min(1) });
     const action = new ConfiguredAction({ name: "x", inputs: schema });

--- a/packages/keryx/actions/status.ts
+++ b/packages/keryx/actions/status.ts
@@ -10,6 +10,7 @@ export class Status implements Action {
     "Returns server health and runtime information including the server name, process ID, package version, uptime in milliseconds, memory consumption in MB, and dependency health checks for the database and Redis. Does not require authentication.";
   inputs = z.object({});
   web = { route: "/status", method: HTTP_METHOD.GET };
+  tracing = false;
 
   async run() {
     const consumedMemoryMB =

--- a/packages/keryx/classes/Action.ts
+++ b/packages/keryx/classes/Action.ts
@@ -189,6 +189,17 @@ export type ActionConstructorInputs = {
   /** Per-action timeout in ms (overrides global `config.actions.timeout`; 0 disables) */
   timeout?: number;
 
+  /**
+   * When `false`, tracing plugins (`@keryxjs/sentry`, `@keryxjs/tracing`) skip
+   * this action: no action span, and for HTTP / background tasks the whole
+   * request or job transaction is dropped. Error capture and metrics still
+   * run. Unset (the default) means the action is traced.
+   *
+   * Use this for high-frequency health checks so they don't flood the trace
+   * backend. The built-in `status` action sets `tracing = false`.
+   */
+  tracing?: boolean;
+
   /** Configure this action as a background task/job */
   task?: {
     /** Optional recurring frequency in milliseconds */
@@ -251,6 +262,11 @@ export abstract class Action {
     rawBody?: boolean;
   };
   timeout?: number;
+  /**
+   * When `false`, tracing plugins skip this action. Unset means traced.
+   * See {@link ActionConstructorInputs.tracing}.
+   */
+  tracing?: boolean;
   task?: {
     frequency?: number;
     queue: string;
@@ -261,6 +277,7 @@ export abstract class Action {
     this.inputs = args.inputs;
     this.middleware = args.middleware ?? [];
     this.timeout = args.timeout;
+    this.tracing = args.tracing;
     // MCP tools are opt-in — see the actions initializer for rationale. An action
     // becomes a tool only when it sets `mcp.tool = true` (or declares `mcp.ui`).
     this.mcp = { tool: false, ...args.mcp };

--- a/packages/keryx/package.json
+++ b/packages/keryx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keryx",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/plugins/sentry/__tests__/sentry.test.ts
+++ b/packages/plugins/sentry/__tests__/sentry.test.ts
@@ -266,7 +266,9 @@ describe("sentry plugin (enabled)", () => {
     const traced = new SentryTraced();
     api.actions.actions.push(traced);
     api.resque.jobs[traced.name] = api.resque.wrapActionAsJob(traced);
-    api.actions.actions.push(new SentryQuiet());
+    const quiet = new SentryQuiet();
+    api.actions.actions.push(quiet);
+    api.resque.jobs[quiet.name] = api.resque.wrapActionAsJob(quiet);
     const quietBoom = new SentryQuietBoom();
     api.actions.actions.push(quietBoom);
     api.resque.jobs[quietBoom.name] = api.resque.wrapActionAsJob(quietBoom);
@@ -288,6 +290,7 @@ describe("sentry plugin (enabled)", () => {
     delete api.resque.jobs["sentry:nest"];
     delete api.resque.jobs["sentry:recurring"];
     delete api.resque.jobs["sentry:traced"];
+    delete api.resque.jobs["sentry:quiet"];
     delete api.resque.jobs["sentry:quiet-boom"];
     await api.stop();
     config.plugins = [];
@@ -427,14 +430,15 @@ describe("sentry plugin (enabled)", () => {
   });
 
   test("actions with tracing = false emit no HTTP or action spans", async () => {
+    await api.sentry.flush(2000);
     spans.length = 0;
-    const res = await fetch(`${serverUrl()}/api/status`);
+    const res = await fetch(`${serverUrl()}/api/sentry-quiet`);
     expect(res.status).toBe(200);
     await api.sentry.flush(2000);
     await Bun.sleep(50);
 
     expect(spans.some((s) => s.op === "http.server")).toBe(false);
-    expect(spans.some((s) => s.name === "action:status")).toBe(false);
+    expect(spans.some((s) => s.name === "action:sentry:quiet")).toBe(false);
     expect(spans.some((s) => s.name.startsWith("redis."))).toBe(false);
     expect(spans.some((s) => s.name.startsWith("pg."))).toBe(false);
   });
@@ -470,13 +474,67 @@ describe("sentry plugin (enabled)", () => {
   });
 
   test("opted-out background tasks emit no queue.process span", async () => {
+    await api.sentry.flush(2000);
     spans.length = 0;
-    await performJob("status");
+    await performJob("sentry:quiet");
     await api.sentry.flush(2000);
     await Bun.sleep(50);
 
-    expect(spans.some((s) => s.name === "task:status")).toBe(false);
-    expect(spans.some((s) => s.name === "action:status")).toBe(false);
+    expect(spans.some((s) => s.name === "task:sentry:quiet")).toBe(false);
+    expect(spans.some((s) => s.name === "action:sentry:quiet")).toBe(false);
+    expect(spans.some((s) => s.name === "redis.ping")).toBe(false);
+  });
+
+  test("tracing suppress does not leak to the next job on the worker", async () => {
+    await api.sentry.flush(2000);
+    spans.length = 0;
+
+    const quietCtx = {
+      queue: "default",
+      metadata: {} as Record<string, unknown>,
+    };
+    const tracedCtx = {
+      queue: "default",
+      metadata: {} as Record<string, unknown>,
+    };
+    const quietOutcome = {
+      success: true as const,
+      result: null,
+      duration: 1,
+    };
+
+    for (const hook of api.hooks.resque.beforeJobHooks) {
+      await hook("sentry:quiet", {}, quietCtx);
+    }
+    for (const hook of api.hooks.resque.afterJobHooks) {
+      await hook("sentry:quiet", {}, quietCtx, quietOutcome);
+    }
+    for (const hook of api.hooks.resque.beforeJobHooks) {
+      await hook("sentry:traced", {}, tracedCtx);
+    }
+
+    await api.redis.redis.ping();
+
+    for (const hook of api.hooks.resque.afterJobHooks) {
+      await hook("sentry:traced", {}, tracedCtx, quietOutcome);
+    }
+
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    expect(quietCtx.metadata.sentryPrevSuppressed).toBe(false);
+    expect(tracedCtx.metadata.sentrySpan).toBeDefined();
+    expect(spans.some((s) => s.name === "redis.ping")).toBe(true);
+
+    await api.sentry.flush(2000);
+    spans.length = 0;
+    await performJob("sentry:quiet");
+    await performJob("sentry:traced");
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    expect(spans.some((s) => s.name === "task:sentry:traced")).toBe(true);
+    expect(spans.some((s) => s.name === "redis.ping")).toBe(true);
   });
 
   test("Redis commands create db spans", async () => {

--- a/packages/plugins/sentry/__tests__/sentry.test.ts
+++ b/packages/plugins/sentry/__tests__/sentry.test.ts
@@ -76,26 +76,67 @@ class SentryUserBoom implements Action {
 
 class SentryEnqueue implements Action {
   name = "sentry:enqueue";
-  description = "Enqueues status as a background task";
+  description = "Enqueues sentry:traced as a background task";
   inputs = z.object({});
   web = { route: "/sentry-enqueue", method: HTTP_METHOD.GET };
   mcp = { tool: false };
   async run() {
-    await api.actions.enqueue("status");
+    await api.actions.enqueue("sentry:traced");
     return { enqueued: true };
   }
 }
 
 class SentryNest implements Action {
   name = "sentry:nest";
-  description = "Calls status via connection.act()";
+  description = "Calls sentry:traced via connection.act()";
   inputs = z.object({});
   web = { route: "/sentry-nest", method: HTTP_METHOD.GET };
   mcp = { tool: false };
   async run(_params: Record<string, unknown>, connection?: Connection) {
-    const { error } = await connection!.act("status", {});
+    const { error } = await connection!.act("sentry:traced", {});
     if (error) throw error;
     return { nested: true };
+  }
+}
+
+class SentryTraced implements Action {
+  name = "sentry:traced";
+  description = "Pings Redis and Postgres so span tests have a traced action";
+  inputs = z.object({});
+  web = { route: "/sentry-traced", method: HTTP_METHOD.GET };
+  mcp = { tool: false };
+  async run() {
+    if (api.redis?.redis) await api.redis.redis.ping();
+    if (api.db?.pool) await api.db.pool.query("SELECT 1 AS one");
+    return { ok: true };
+  }
+}
+
+class SentryQuiet implements Action {
+  name = "sentry:quiet";
+  description = "Opts out of tracing";
+  tracing = false;
+  inputs = z.object({});
+  web = { route: "/sentry-quiet", method: HTTP_METHOD.GET };
+  mcp = { tool: false };
+  async run() {
+    if (api.redis?.redis) await api.redis.redis.ping();
+    return { ok: true };
+  }
+}
+
+class SentryQuietBoom implements Action {
+  name = "sentry:quiet-boom";
+  description = "Opts out of tracing but still throws a 500";
+  tracing = false;
+  inputs = z.object({});
+  web = { route: "/sentry-quiet-boom", method: HTTP_METHOD.GET };
+  mcp = { tool: false };
+  async run() {
+    throw new TypedError({
+      message: "quiet boom failure",
+      type: ErrorType.CONNECTION_ACTION_RUN,
+    });
   }
 }
 
@@ -222,6 +263,13 @@ describe("sentry plugin (enabled)", () => {
     const recurring = new SentryRecurring();
     api.actions.actions.push(recurring);
     api.resque.jobs[recurring.name] = api.resque.wrapActionAsJob(recurring);
+    const traced = new SentryTraced();
+    api.actions.actions.push(traced);
+    api.resque.jobs[traced.name] = api.resque.wrapActionAsJob(traced);
+    api.actions.actions.push(new SentryQuiet());
+    const quietBoom = new SentryQuietBoom();
+    api.actions.actions.push(quietBoom);
+    api.resque.jobs[quietBoom.name] = api.resque.wrapActionAsJob(quietBoom);
   }, HOOK_TIMEOUT);
 
   afterAll(async () => {
@@ -231,11 +279,16 @@ describe("sentry plugin (enabled)", () => {
         a.name !== "sentry:user-boom" &&
         a.name !== "sentry:enqueue" &&
         a.name !== "sentry:nest" &&
-        a.name !== "sentry:recurring",
+        a.name !== "sentry:recurring" &&
+        a.name !== "sentry:traced" &&
+        a.name !== "sentry:quiet" &&
+        a.name !== "sentry:quiet-boom",
     );
     delete api.resque.jobs["sentry:boom"];
     delete api.resque.jobs["sentry:nest"];
     delete api.resque.jobs["sentry:recurring"];
+    delete api.resque.jobs["sentry:traced"];
+    delete api.resque.jobs["sentry:quiet-boom"];
     await api.stop();
     config.plugins = [];
   }, HOOK_TIMEOUT);
@@ -338,7 +391,7 @@ describe("sentry plugin (enabled)", () => {
     config.sentry.enableMetrics = false;
     try {
       logger.warn("should not reach sentry while logs are off");
-      const res = await fetch(`${serverUrl()}/api/status`);
+      const res = await fetch(`${serverUrl()}/api/sentry-traced`);
       expect(res.status).toBe(200);
       await api.sentry.flush(2000);
       await Bun.sleep(50);
@@ -358,7 +411,7 @@ describe("sentry plugin (enabled)", () => {
 
   test("HTTP request creates a transport span and an action span", async () => {
     spans.length = 0;
-    const res = await fetch(`${serverUrl()}/api/status`);
+    const res = await fetch(`${serverUrl()}/api/sentry-traced`);
     expect(res.status).toBe(200);
     await api.sentry.flush(2000);
     await Bun.sleep(50);
@@ -366,16 +419,69 @@ describe("sentry plugin (enabled)", () => {
     const httpSpan = spans.find(
       (s) => s.op === "http.server" || s.name.startsWith("GET"),
     );
-    const actionSpan = spans.find((s) => s.name === "action:status");
+    const actionSpan = spans.find((s) => s.name === "action:sentry:traced");
     expect(httpSpan).toBeDefined();
     expect(actionSpan).toBeDefined();
-    expect(actionSpan!.data["keryx.action"]).toBe("status");
+    expect(actionSpan!.data["keryx.action"]).toBe("sentry:traced");
     expect(actionSpan!.data["keryx.connection.type"]).toBe("web");
+  });
+
+  test("actions with tracing = false emit no HTTP or action spans", async () => {
+    spans.length = 0;
+    const res = await fetch(`${serverUrl()}/api/status`);
+    expect(res.status).toBe(200);
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    expect(spans.some((s) => s.op === "http.server")).toBe(false);
+    expect(spans.some((s) => s.name === "action:status")).toBe(false);
+    expect(spans.some((s) => s.name.startsWith("redis."))).toBe(false);
+    expect(spans.some((s) => s.name.startsWith("pg."))).toBe(false);
+  });
+
+  test("tracing = false still records the per-action count metric", async () => {
+    metrics.length = 0;
+    const res = await fetch(`${serverUrl()}/api/sentry-quiet`);
+    expect(res.status).toBe(200);
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    const quietMetric = metrics.find(
+      (m) =>
+        m.name === "keryx.action.count" &&
+        m.attributes["keryx.action"] === "sentry:quiet",
+    );
+    expect(quietMetric).toBeDefined();
+  });
+
+  test("tracing = false still captures 5xx exceptions", async () => {
+    events.length = 0;
+    spans.length = 0;
+    const res = await fetch(`${serverUrl()}/api/sentry-quiet-boom`);
+    expect(res.status).toBe(500);
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    expect(spans.some((s) => s.name === "action:sentry:quiet-boom")).toBe(
+      false,
+    );
+    const messages = events.map((e) => eventMessage(e));
+    expect(messages.some((m) => m.includes("quiet boom failure"))).toBe(true);
+  });
+
+  test("opted-out background tasks emit no queue.process span", async () => {
+    spans.length = 0;
+    await performJob("status");
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    expect(spans.some((s) => s.name === "task:status")).toBe(false);
+    expect(spans.some((s) => s.name === "action:status")).toBe(false);
   });
 
   test("Redis commands create db spans", async () => {
     spans.length = 0;
-    const res = await fetch(`${serverUrl()}/api/status`);
+    const res = await fetch(`${serverUrl()}/api/sentry-traced`);
     expect(res.status).toBe(200);
     await api.sentry.flush(2000);
     await Bun.sleep(50);
@@ -393,7 +499,7 @@ describe("sentry plugin (enabled)", () => {
 
   test("Postgres commands create db spans", async () => {
     spans.length = 0;
-    const res = await fetch(`${serverUrl()}/api/status`);
+    const res = await fetch(`${serverUrl()}/api/sentry-traced`);
     expect(res.status).toBe(200);
     await api.sentry.flush(2000);
     await Bun.sleep(50);
@@ -422,7 +528,7 @@ describe("sentry plugin (enabled)", () => {
     socket.send(
       JSON.stringify({
         messageType: "action",
-        action: "status",
+        action: "sentry:traced",
         messageId: 1,
         params: {},
       }),
@@ -441,7 +547,7 @@ describe("sentry plugin (enabled)", () => {
     expect(
       spans.some(
         (s) =>
-          s.name === "action:status" &&
+          s.name === "action:sentry:traced" &&
           s.data["keryx.connection.type"] === "websocket",
       ),
     ).toBe(true);
@@ -714,19 +820,19 @@ describe("sentry plugin (enabled)", () => {
 
   test("background tasks create a root queue.process span and a child action span", async () => {
     spans.length = 0;
-    await performJob("status");
+    await performJob("sentry:traced");
     await api.sentry.flush(2000);
     await Bun.sleep(50);
 
-    const taskSpan = spans.find((s) => s.name === "task:status");
+    const taskSpan = spans.find((s) => s.name === "task:sentry:traced");
     const actionSpan = spans.find(
       (s) =>
-        s.name === "action:status" &&
+        s.name === "action:sentry:traced" &&
         s.data["keryx.connection.type"] === "task",
     );
     expect(taskSpan).toBeDefined();
     expect(taskSpan!.op).toBe("queue.process");
-    expect(taskSpan!.data["keryx.action"]).toBe("status");
+    expect(taskSpan!.data["keryx.action"]).toBe("sentry:traced");
     expect(taskSpan!.data["keryx.connection.type"]).toBe("task");
     expect(taskSpan!.data["messaging.destination.name"]).toBe("default");
     expect(actionSpan).toBeDefined();
@@ -742,19 +848,19 @@ describe("sentry plugin (enabled)", () => {
     expect(res.status).toBe(200);
 
     const queued = await api.actions.queued();
-    const statusJob = queued.find((j) => j.class === "status");
-    expect(statusJob).toBeDefined();
-    const payload = statusJob!.args[0] as Record<string, unknown>;
+    const tracedJob = queued.find((j) => j.class === "sentry:traced");
+    expect(tracedJob).toBeDefined();
+    const payload = tracedJob!.args[0] as Record<string, unknown>;
     expect(typeof payload._sentryTrace).toBe("string");
 
-    await performJob("status", payload);
+    await performJob("sentry:traced", payload);
     await api.sentry.flush(2000);
     await Bun.sleep(50);
 
     const httpSpan = spans.find(
       (s) => s.op === "http.server" && s.name.includes("sentry:enqueue"),
     );
-    const taskSpan = spans.find((s) => s.name === "task:status");
+    const taskSpan = spans.find((s) => s.name === "task:sentry:traced");
     expect(httpSpan).toBeDefined();
     expect(taskSpan).toBeDefined();
     expect(taskSpan!.traceId).toBe(httpSpan!.traceId);
@@ -773,7 +879,8 @@ describe("sentry plugin (enabled)", () => {
     const outer = spans.find((s) => s.name === "action:sentry:nest");
     const inner = spans.find(
       (s) =>
-        s.name === "action:status" && s.data["keryx.connection.type"] === "web",
+        s.name === "action:sentry:traced" &&
+        s.data["keryx.connection.type"] === "web",
     );
     expect(httpSpan).toBeDefined();
     expect(outer).toBeDefined();
@@ -792,12 +899,12 @@ describe("sentry plugin (enabled)", () => {
     const taskRoots = spans.filter((s) => s.op === "queue.process");
     expect(taskRoots).toHaveLength(1);
     expect(taskRoots[0]!.name).toBe("task:sentry:nest");
-    expect(spans.some((s) => s.name === "task:status")).toBe(false);
+    expect(spans.some((s) => s.name === "task:sentry:traced")).toBe(false);
 
     const outer = spans.find((s) => s.name === "action:sentry:nest");
     const inner = spans.find(
       (s) =>
-        s.name === "action:status" &&
+        s.name === "action:sentry:traced" &&
         s.data["keryx.connection.type"] === "task",
     );
     expect(outer).toBeDefined();

--- a/packages/plugins/sentry/__tests__/sentry.test.ts
+++ b/packages/plugins/sentry/__tests__/sentry.test.ts
@@ -125,6 +125,20 @@ class SentryQuiet implements Action {
   }
 }
 
+class SentryQuietNest implements Action {
+  name = "sentry:quiet-nest";
+  description = "Opts out of tracing then calls sentry:traced via act()";
+  tracing = false;
+  inputs = z.object({});
+  web = { route: "/sentry-quiet-nest", method: HTTP_METHOD.GET };
+  mcp = { tool: false };
+  async run(_params: Record<string, unknown>, connection?: Connection) {
+    const { error } = await connection!.act("sentry:traced", {});
+    if (error) throw error;
+    return { nested: true };
+  }
+}
+
 class SentryQuietBoom implements Action {
   name = "sentry:quiet-boom";
   description = "Opts out of tracing but still throws a 500";
@@ -269,6 +283,7 @@ describe("sentry plugin (enabled)", () => {
     const quiet = new SentryQuiet();
     api.actions.actions.push(quiet);
     api.resque.jobs[quiet.name] = api.resque.wrapActionAsJob(quiet);
+    api.actions.actions.push(new SentryQuietNest());
     const quietBoom = new SentryQuietBoom();
     api.actions.actions.push(quietBoom);
     api.resque.jobs[quietBoom.name] = api.resque.wrapActionAsJob(quietBoom);
@@ -284,6 +299,7 @@ describe("sentry plugin (enabled)", () => {
         a.name !== "sentry:recurring" &&
         a.name !== "sentry:traced" &&
         a.name !== "sentry:quiet" &&
+        a.name !== "sentry:quiet-nest" &&
         a.name !== "sentry:quiet-boom",
     );
     delete api.resque.jobs["sentry:boom"];
@@ -443,6 +459,24 @@ describe("sentry plugin (enabled)", () => {
     expect(fresh.some((s) => s.name === "action:sentry:quiet")).toBe(false);
     expect(fresh.some((s) => s.name.startsWith("redis."))).toBe(false);
     expect(fresh.some((s) => s.name.startsWith("pg."))).toBe(false);
+  });
+
+  test("nested act() under tracing = false does not emit an inner action span", async () => {
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+    const prior = new Set(spans);
+    const res = await fetch(`${serverUrl()}/api/sentry-quiet-nest`);
+    expect(res.status).toBe(200);
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+
+    const fresh = spans.filter((s) => !prior.has(s));
+    expect(fresh.some((s) => s.op === "http.server")).toBe(false);
+    expect(fresh.some((s) => s.name === "action:sentry:quiet-nest")).toBe(
+      false,
+    );
+    expect(fresh.some((s) => s.name === "action:sentry:traced")).toBe(false);
+    expect(fresh.some((s) => s.name.startsWith("redis."))).toBe(false);
   });
 
   test("tracing = false still records the per-action count metric", async () => {

--- a/packages/plugins/sentry/__tests__/sentry.test.ts
+++ b/packages/plugins/sentry/__tests__/sentry.test.ts
@@ -431,16 +431,18 @@ describe("sentry plugin (enabled)", () => {
 
   test("actions with tracing = false emit no HTTP or action spans", async () => {
     await api.sentry.flush(2000);
-    spans.length = 0;
+    await Bun.sleep(50);
+    const prior = new Set(spans);
     const res = await fetch(`${serverUrl()}/api/sentry-quiet`);
     expect(res.status).toBe(200);
     await api.sentry.flush(2000);
     await Bun.sleep(50);
 
-    expect(spans.some((s) => s.op === "http.server")).toBe(false);
-    expect(spans.some((s) => s.name === "action:sentry:quiet")).toBe(false);
-    expect(spans.some((s) => s.name.startsWith("redis."))).toBe(false);
-    expect(spans.some((s) => s.name.startsWith("pg."))).toBe(false);
+    const fresh = spans.filter((s) => !prior.has(s));
+    expect(fresh.some((s) => s.op === "http.server")).toBe(false);
+    expect(fresh.some((s) => s.name === "action:sentry:quiet")).toBe(false);
+    expect(fresh.some((s) => s.name.startsWith("redis."))).toBe(false);
+    expect(fresh.some((s) => s.name.startsWith("pg."))).toBe(false);
   });
 
   test("tracing = false still records the per-action count metric", async () => {
@@ -666,14 +668,18 @@ describe("sentry plugin (enabled)", () => {
   });
 
   test("Postgres queries are not double-instrumented", async () => {
-    spans.length = 0;
-    await api.db.pool.query("SELECT 1 AS one");
-    await api.db.pool.query("SELECT 1 AS one");
+    await api.sentry.flush(2000);
+    await Bun.sleep(50);
+    const prior = new Set(spans);
+    const res1 = await fetch(`${serverUrl()}/api/sentry-traced`);
+    const res2 = await fetch(`${serverUrl()}/api/sentry-traced`);
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
     await api.sentry.flush(2000);
     await Bun.sleep(50);
 
     const selectSpans = spans.filter(
-      (s) => s.data["db.query.text"] === "SELECT 1 AS one",
+      (s) => !prior.has(s) && s.data["db.query.text"] === "SELECT 1 AS one",
     );
     // One span per query — no stacked pool.query + client.query duplicate.
     expect(selectSpans.length).toBe(2);

--- a/packages/plugins/sentry/dbInstrumentation.ts
+++ b/packages/plugins/sentry/dbInstrumentation.ts
@@ -23,7 +23,9 @@ type SpanStore = AsyncLocalStorage<SentrySpan | undefined>;
  * @param spanALS - Async store holding the active parent span so each Redis
  *   span nests under the current request / action span.
  * @param isSuppressed - When this returns true (an action set `tracing = false`),
- *   the original command runs with no span.
+ *   the original command runs with no span. Commands with no active parent span
+ *   are also skipped so opted-out requests and worker polling do not emit
+ *   orphan Redis traces.
  */
 export function instrumentRedis(
   spanALS: SpanStore,
@@ -38,13 +40,17 @@ export function instrumentRedis(
     if (isSuppressed()) {
       return originalSendCommand(...args);
     }
+    const parent = spanALS.getStore();
+    if (!parent) {
+      return originalSendCommand(...args);
+    }
     const [command] = args;
     const commandName = (command as { name?: string }).name ?? "unknown";
     const queryText = buildRedisQueryText(command, commandName);
     const span = Sentry.startInactiveSpan({
       name: `redis.${commandName}`,
       op: "db",
-      parentSpan: spanALS.getStore(),
+      parentSpan: parent,
       attributes: {
         "db.system": "redis",
         "db.operation.name": commandName,
@@ -73,7 +79,8 @@ export function instrumentRedis(
  * @param spanALS - Async store holding the active parent span so each Postgres
  *   span nests under the current request / action span.
  * @param isSuppressed - When this returns true (an action set `tracing = false`),
- *   the original query runs with no span.
+ *   the original query runs with no span. Queries with no active parent span
+ *   are also skipped so opted-out requests do not emit orphan Postgres traces.
  */
 export function instrumentPostgres(
   spanALS: SpanStore,
@@ -99,11 +106,15 @@ export function instrumentPostgres(
       if (isSuppressed()) {
         return originalClientQuery(...args);
       }
+      const parent = spanALS.getStore();
+      if (!parent) {
+        return originalClientQuery(...args);
+      }
       const sqlText = queryTextFromArgs(args);
       const span = Sentry.startInactiveSpan({
         name: `pg.${pgOperation(sqlText)}`,
         op: "db",
-        parentSpan: spanALS.getStore(),
+        parentSpan: parent,
         attributes: {
           "db.system": "postgresql",
           "db.operation.name": pgOperation(sqlText),

--- a/packages/plugins/sentry/dbInstrumentation.ts
+++ b/packages/plugins/sentry/dbInstrumentation.ts
@@ -22,14 +22,22 @@ type SpanStore = AsyncLocalStorage<SentrySpan | undefined>;
  *
  * @param spanALS - Async store holding the active parent span so each Redis
  *   span nests under the current request / action span.
+ * @param isSuppressed - When this returns true (an action set `tracing = false`),
+ *   the original command runs with no span.
  */
-export function instrumentRedis(spanALS: SpanStore) {
+export function instrumentRedis(
+  spanALS: SpanStore,
+  isSuppressed: () => boolean = () => false,
+) {
   const client = api.redis?.redis;
   if (!client) return;
   const originalSendCommand = client.sendCommand.bind(client);
   client.sendCommand = function (
     ...args: Parameters<typeof originalSendCommand>
   ) {
+    if (isSuppressed()) {
+      return originalSendCommand(...args);
+    }
     const [command] = args;
     const commandName = (command as { name?: string }).name ?? "unknown";
     const queryText = buildRedisQueryText(command, commandName);
@@ -64,8 +72,13 @@ export function instrumentRedis(spanALS: SpanStore) {
  *
  * @param spanALS - Async store holding the active parent span so each Postgres
  *   span nests under the current request / action span.
+ * @param isSuppressed - When this returns true (an action set `tracing = false`),
+ *   the original query runs with no span.
  */
-export function instrumentPostgres(spanALS: SpanStore) {
+export function instrumentPostgres(
+  spanALS: SpanStore,
+  isSuppressed: () => boolean = () => false,
+) {
   const pool = (
     api as {
       db?: {
@@ -83,6 +96,9 @@ export function instrumentPostgres(spanALS: SpanStore) {
     wrappedClients.add(client);
     const originalClientQuery = client.query.bind(client);
     client.query = (...args: unknown[]) => {
+      if (isSuppressed()) {
+        return originalClientQuery(...args);
+      }
       const sqlText = queryTextFromArgs(args);
       const span = Sentry.startInactiveSpan({
         name: `pg.${pgOperation(sqlText)}`,

--- a/packages/plugins/sentry/initializer.ts
+++ b/packages/plugins/sentry/initializer.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/bun";
 import { api, config, Initializer, logger } from "keryx";
 import { instrumentPostgres, instrumentRedis } from "./dbInstrumentation";
 import { createNoopNamespace } from "./namespace";
+import { TRACING_SKIP_ATTR } from "./spanHelpers";
 import { SentryRequestState } from "./state";
 import { instrumentLogger } from "./telemetry";
 import { registerTracingHooks } from "./tracingHooks";
@@ -89,6 +90,7 @@ export class SentryPlugin extends Initializer {
       enableMetrics: config.sentry.enableMetrics,
       beforeSend: config.sentry.beforeSend,
       beforeSendSpan: config.sentry.beforeSendSpan,
+      ignoreSpans: [{ attributes: { [TRACING_SKIP_ATTR]: true } }],
       beforeSendLog: config.sentry.beforeSendLog,
       beforeSendMetric: config.sentry.beforeSendMetric,
       transport: config.sentry.transport,
@@ -129,8 +131,14 @@ export class SentryPlugin extends Initializer {
     ns.flush = (timeoutMs) => Sentry.flush(timeoutMs);
 
     registerTracingHooks(this.state);
-    instrumentRedis(this.state.spanALS);
-    instrumentPostgres(this.state.spanALS);
+    instrumentRedis(
+      this.state.spanALS,
+      () => this.state.tracingSuppressedALS.getStore() === true,
+    );
+    instrumentPostgres(
+      this.state.spanALS,
+      () => this.state.tracingSuppressedALS.getStore() === true,
+    );
     if (config.sentry.enableLogs) {
       // `instrumentLogger` returns `undefined` if the logger is already
       // wrapped; only overwrite the restorer when we actually wrapped it, so a

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keryxjs/sentry",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/plugins/sentry/spanHelpers.ts
+++ b/packages/plugins/sentry/spanHelpers.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/bun";
-import { ErrorStatusCodes, TypedError } from "keryx";
+import { api, config, ErrorStatusCodes, HTTP_METHOD, TypedError } from "keryx";
 
 /**
  * A lazily-started, inactive Sentry span. The plugin creates spans this way
@@ -7,6 +7,89 @@ import { ErrorStatusCodes, TypedError } from "keryx";
  * hand across the framework's async hooks.
  */
 export type SentrySpan = ReturnType<typeof Sentry.startInactiveSpan>;
+
+/**
+ * Attribute written onto a transport span that should not be sent. The plugin
+ * registers this key with Sentry's `ignoreSpans` so marked spans are dropped
+ * even if they are ended.
+ */
+export const TRACING_SKIP_ATTR = "keryx.tracing.skip";
+
+/**
+ * True unless the named action set `tracing = false`. Unknown or unresolved
+ * names stay traced — opt-out is explicit.
+ *
+ * @param actionName - Action name from routing / `beforeAct`, or `undefined`
+ *   when the request did not resolve to an action.
+ */
+export function isActionTraced(actionName: string | undefined): boolean {
+  if (!actionName) return true;
+  const action = api.actions.actions.find((a) => a.name === actionName);
+  return action?.tracing !== false;
+}
+
+/**
+ * Best-effort action name from an incoming HTTP request, used to skip the
+ * HTTP span *before* session/DB work runs. Returns `undefined` when the path
+ * does not match a web route.
+ *
+ * @param req - The incoming request. Only `url` and `method` are read.
+ */
+export function matchWebActionName(req: Request): string | undefined {
+  try {
+    const pathname = new URL(req.url).pathname;
+    const pathToMatch = pathname.replace(
+      new RegExp(config.server.web.apiRoute),
+      "",
+    );
+    if (!pathToMatch) return undefined;
+    const method = (req.method?.toUpperCase() ?? "GET") as HTTP_METHOD;
+    return api.actions.router.match(pathToMatch, method)?.actionName;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read a WebSocket frame's `action` field without throwing on non-JSON.
+ *
+ * @param message - Raw WebSocket payload.
+ */
+export function peekWsActionName(message: string | Buffer): string | undefined {
+  try {
+    const parsed = JSON.parse(message.toString()) as { action?: unknown };
+    return typeof parsed.action === "string" ? parsed.action : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Mark a span so Sentry's `ignoreSpans` filter drops it on send.
+ *
+ * @param span - Live Sentry span to suppress.
+ */
+export function markSpanSkipped(span: SentrySpan): void {
+  span.setAttribute(TRACING_SKIP_ATTR, true);
+}
+
+/**
+ * True when this parent is a per-request / per-message / per-job transport
+ * span that should be dropped along with an opted-out action — not a
+ * long-lived connection/session span.
+ *
+ * @param span - Parent span from `spanALS` at `beforeAct` time.
+ */
+export function isDroppableTransportSpan(span: SentrySpan): boolean {
+  const json = Sentry.spanToJSON(span);
+  const op = json.op;
+  const name = String(json.description ?? "");
+  if (op === "http.server") return true;
+  if (op === "queue.process") return true;
+  if (name === "mcp.message") return true;
+  if (name.startsWith("ws.message")) return true;
+  return false;
+}
 
 /**
  * Build the `db.query.text` attribute for a Redis span: `"<command> <key>..."`

--- a/packages/plugins/sentry/state.ts
+++ b/packages/plugins/sentry/state.ts
@@ -34,8 +34,10 @@ export class SentryRequestState {
    */
   requestScopeALS = new AsyncLocalStorage<RequestScopeData | undefined>();
   /**
-   * When true, Redis / Postgres instrumentation skips creating spans. Set for
-   * the duration of an action that opted out via `tracing = false`.
+   * When true, Redis / Postgres instrumentation skips creating spans. Set at
+   * the request or job boundary for `tracing = false` and restored when that
+   * request / job finishes so the next traced work on the same async
+   * context is not left suppressed.
    */
   tracingSuppressedALS = new AsyncLocalStorage<boolean>();
   wsConnections = new WeakMap<object, SentrySpan>();

--- a/packages/plugins/sentry/state.ts
+++ b/packages/plugins/sentry/state.ts
@@ -33,6 +33,11 @@ export class SentryRequestState {
    * current request instead of leaking through a shared global scope.
    */
   requestScopeALS = new AsyncLocalStorage<RequestScopeData | undefined>();
+  /**
+   * When true, Redis / Postgres instrumentation skips creating spans. Set for
+   * the duration of an action that opted out via `tracing = false`.
+   */
+  tracingSuppressedALS = new AsyncLocalStorage<boolean>();
   wsConnections = new WeakMap<object, SentrySpan>();
   wsMessageSpans = new WeakMap<object, SentrySpan>();
   mcpSessions = new Map<string, SentrySpan>();

--- a/packages/plugins/sentry/tracingHooks.ts
+++ b/packages/plugins/sentry/tracingHooks.ts
@@ -234,9 +234,13 @@ export function registerTracingHooks(state: SentryRequestState) {
     const prevSuppressed = state.tracingSuppressedALS.getStore() === true;
     actCtx.metadata.sentryPrevSuppressed = prevSuppressed;
 
-    if (!isActionTraced(actionName)) {
+    if (!isActionTraced(actionName) || prevSuppressed) {
       const parent = state.spanALS.getStore();
-      if (parent && isDroppableTransportSpan(parent)) {
+      if (
+        !isActionTraced(actionName) &&
+        parent &&
+        isDroppableTransportSpan(parent)
+      ) {
         markSpanSkipped(parent);
       }
       state.tracingSuppressedALS.enterWith(true);

--- a/packages/plugins/sentry/tracingHooks.ts
+++ b/packages/plugins/sentry/tracingHooks.ts
@@ -28,12 +28,19 @@ import { recordActionMetric } from "./telemetry";
  */
 export function registerTracingHooks(state: SentryRequestState) {
   api.hooks.web.beforeRequest((req, ctx) => {
+    ctx.metadata.sentryPrevSuppressed =
+      state.tracingSuppressedALS.getStore() === true;
     const actionName = matchWebActionName(req);
     if (!isActionTraced(actionName)) {
       ctx.metadata.sentryTracingSuppressed = true;
       state.tracingSuppressedALS.enterWith(true);
       return;
     }
+    // Jobs/requests are top-level: clear a flag left by a previous opted-out
+    // job on this async context (node-resque workers reuse one). Nested
+    // `connection.act()` still goes through beforeAct, which preserves
+    // an outer request's suppress.
+    state.tracingSuppressedALS.enterWith(false);
 
     const method = req.method?.toUpperCase() ?? "";
     const sentryTrace = req.headers.get("sentry-trace") ?? undefined;
@@ -57,28 +64,34 @@ export function registerTracingHooks(state: SentryRequestState) {
   });
 
   api.hooks.web.afterRequest((_req, _res, ctx, outcome) => {
-    if (ctx.metadata.sentryTracingSuppressed) return;
-    const httpSpan = ctx.metadata.sentrySpan as SentrySpan | undefined;
-    if (!httpSpan) return;
-    if (!isActionTraced(outcome.actionName)) {
-      markSpanSkipped(httpSpan);
+    try {
+      if (ctx.metadata.sentryTracingSuppressed) return;
+      const httpSpan = ctx.metadata.sentrySpan as SentrySpan | undefined;
+      if (!httpSpan) return;
+      if (!isActionTraced(outcome.actionName)) {
+        markSpanSkipped(httpSpan);
+        httpSpan.end();
+        return;
+      }
+      httpSpan.setAttribute("http.response.status_code", outcome.status);
+      if (outcome.actionName) {
+        httpSpan.setAttribute("http.route", outcome.actionName);
+        Sentry.updateSpanName(
+          httpSpan,
+          `${outcome.method} ${outcome.actionName}`,
+        );
+      }
+      if (outcome.status >= 400) {
+        httpSpan.setStatus({ code: 2 });
+      } else {
+        httpSpan.setStatus({ code: 1 });
+      }
       httpSpan.end();
-      return;
-    }
-    httpSpan.setAttribute("http.response.status_code", outcome.status);
-    if (outcome.actionName) {
-      httpSpan.setAttribute("http.route", outcome.actionName);
-      Sentry.updateSpanName(
-        httpSpan,
-        `${outcome.method} ${outcome.actionName}`,
+    } finally {
+      state.tracingSuppressedALS.enterWith(
+        ctx.metadata.sentryPrevSuppressed === true,
       );
     }
-    if (outcome.status >= 400) {
-      httpSpan.setStatus({ code: 2 });
-    } else {
-      httpSpan.setStatus({ code: 1 });
-    }
-    httpSpan.end();
   });
 
   api.hooks.ws.onConnect((connection) => {
@@ -103,7 +116,8 @@ export function registerTracingHooks(state: SentryRequestState) {
       messageType === "action" &&
       !isActionTraced(peekWsActionName(message))
     ) {
-      state.tracingSuppressedALS.enterWith(true);
+      // Skip the per-message span; `beforeAct` / `afterAct` own the
+      // suppress flag so it cannot stick to this long-lived connection.
       if (parent) state.spanALS.enterWith(parent);
       return;
     }
@@ -336,6 +350,8 @@ export function registerTracingHooks(state: SentryRequestState) {
   });
 
   api.hooks.resque.beforeJob((actionName, params, jobCtx) => {
+    jobCtx.metadata.sentryPrevSuppressed =
+      state.tracingSuppressedALS.getStore() === true;
     const p = params as Record<string, unknown>;
     const sentryTrace = p._sentryTrace as string | undefined;
     const baggage = p._sentryBaggage as string | undefined;
@@ -348,6 +364,8 @@ export function registerTracingHooks(state: SentryRequestState) {
       state.tracingSuppressedALS.enterWith(true);
       return;
     }
+    // See beforeRequest: traced jobs must not inherit a leaked suppress flag.
+    state.tracingSuppressedALS.enterWith(false);
 
     const start = () =>
       Sentry.startInactiveSpan({
@@ -369,19 +387,25 @@ export function registerTracingHooks(state: SentryRequestState) {
   });
 
   api.hooks.resque.afterJob((_actionName, _params, jobCtx, outcome) => {
-    const jobSpan = jobCtx.metadata.sentrySpan as SentrySpan | undefined;
-    if (!jobSpan) return;
-    if (outcome.success) {
-      jobSpan.setStatus({ code: 1 });
-    } else {
-      jobSpan.setStatus({
-        code: 2,
-        message:
-          outcome.error instanceof Error
-            ? outcome.error.message
-            : String(outcome.error),
-      });
+    try {
+      const jobSpan = jobCtx.metadata.sentrySpan as SentrySpan | undefined;
+      if (!jobSpan) return;
+      if (outcome.success) {
+        jobSpan.setStatus({ code: 1 });
+      } else {
+        jobSpan.setStatus({
+          code: 2,
+          message:
+            outcome.error instanceof Error
+              ? outcome.error.message
+              : String(outcome.error),
+        });
+      }
+      jobSpan.end();
+    } finally {
+      state.tracingSuppressedALS.enterWith(
+        jobCtx.metadata.sentryPrevSuppressed === true,
+      );
     }
-    jobSpan.end();
   });
 }

--- a/packages/plugins/sentry/tracingHooks.ts
+++ b/packages/plugins/sentry/tracingHooks.ts
@@ -1,6 +1,11 @@
 import * as Sentry from "@sentry/bun";
 import { api, CONNECTION_TYPE, config } from "keryx";
 import {
+  isActionTraced,
+  isDroppableTransportSpan,
+  markSpanSkipped,
+  matchWebActionName,
+  peekWsActionName,
   peekWsMessageType,
   type SentrySpan,
   shouldCapture,
@@ -23,6 +28,13 @@ import { recordActionMetric } from "./telemetry";
  */
 export function registerTracingHooks(state: SentryRequestState) {
   api.hooks.web.beforeRequest((req, ctx) => {
+    const actionName = matchWebActionName(req);
+    if (!isActionTraced(actionName)) {
+      ctx.metadata.sentryTracingSuppressed = true;
+      state.tracingSuppressedALS.enterWith(true);
+      return;
+    }
+
     const method = req.method?.toUpperCase() ?? "";
     const sentryTrace = req.headers.get("sentry-trace") ?? undefined;
     const baggage = req.headers.get("baggage") ?? undefined;
@@ -45,8 +57,14 @@ export function registerTracingHooks(state: SentryRequestState) {
   });
 
   api.hooks.web.afterRequest((_req, _res, ctx, outcome) => {
+    if (ctx.metadata.sentryTracingSuppressed) return;
     const httpSpan = ctx.metadata.sentrySpan as SentrySpan | undefined;
     if (!httpSpan) return;
+    if (!isActionTraced(outcome.actionName)) {
+      markSpanSkipped(httpSpan);
+      httpSpan.end();
+      return;
+    }
     httpSpan.setAttribute("http.response.status_code", outcome.status);
     if (outcome.actionName) {
       httpSpan.setAttribute("http.route", outcome.actionName);
@@ -80,6 +98,16 @@ export function registerTracingHooks(state: SentryRequestState) {
   api.hooks.ws.onMessage((connection, message) => {
     const messageType = peekWsMessageType(message);
     const parent = state.wsConnections.get(connection);
+
+    if (
+      messageType === "action" &&
+      !isActionTraced(peekWsActionName(message))
+    ) {
+      state.tracingSuppressedALS.enterWith(true);
+      if (parent) state.spanALS.enterWith(parent);
+      return;
+    }
+
     const span = Sentry.startInactiveSpan({
       name: `ws.message ${messageType}`,
       op: "ws.server",
@@ -183,6 +211,20 @@ export function registerTracingHooks(state: SentryRequestState) {
         ? { user: prevScope.user, tags: { ...prevScope.tags } }
         : { tags: {} },
     );
+
+    const prevSuppressed = state.tracingSuppressedALS.getStore() === true;
+    actCtx.metadata.sentryPrevSuppressed = prevSuppressed;
+
+    if (!isActionTraced(actionName)) {
+      const parent = state.spanALS.getStore();
+      if (parent && isDroppableTransportSpan(parent)) {
+        markSpanSkipped(parent);
+      }
+      state.tracingSuppressedALS.enterWith(true);
+      actCtx.metadata.sentryParentSpan = parent;
+      return;
+    }
+
     const parent = state.spanALS.getStore();
     const actionSpan = Sentry.startInactiveSpan({
       name: `action:${actionName ?? "unknown"}`,
@@ -214,18 +256,22 @@ export function registerTracingHooks(state: SentryRequestState) {
                 ? outcome.error.message
                 : String(outcome.error),
           });
-          if (shouldCapture(outcome.error, config.sentry.captureClientErrors)) {
-            Sentry.withScope((scope) => {
-              state.applyRequestScope(scope);
-              scope.setTag("keryx.action", actionName);
-              scope.setTag("keryx.connection.type", connection.type);
-              Sentry.captureException(outcome.error);
-            });
-          }
         } else {
           span.setStatus({ code: 1 });
         }
         span.end();
+      }
+
+      if (
+        !outcome.success &&
+        shouldCapture(outcome.error, config.sentry.captureClientErrors)
+      ) {
+        Sentry.withScope((scope) => {
+          state.applyRequestScope(scope);
+          scope.setTag("keryx.action", actionName);
+          scope.setTag("keryx.connection.type", connection.type);
+          Sentry.captureException(outcome.error);
+        });
       }
 
       // Nested connection.act() must not close the transport span — only the
@@ -262,11 +308,15 @@ export function registerTracingHooks(state: SentryRequestState) {
       state.requestScopeALS.enterWith(
         actCtx.metadata.sentryPrevScope as RequestScopeData | undefined,
       );
+      state.tracingSuppressedALS.enterWith(
+        actCtx.metadata.sentryPrevSuppressed === true,
+      );
     },
   );
 
   api.hooks.actions.onEnqueue((_actionName, inputs) => {
     if (!api.sentry.enabled) return;
+    if (state.tracingSuppressedALS.getStore()) return;
     const parent = state.spanALS.getStore();
     if (!parent) return;
     // Ended spans (afterJob has already closed the job root) must not
@@ -293,6 +343,11 @@ export function registerTracingHooks(state: SentryRequestState) {
     // action's validated params.
     delete p._sentryTrace;
     delete p._sentryBaggage;
+
+    if (!isActionTraced(actionName)) {
+      state.tracingSuppressedALS.enterWith(true);
+      return;
+    }
 
     const start = () =>
       Sentry.startInactiveSpan({

--- a/packages/plugins/sentry/tracingHooks.ts
+++ b/packages/plugins/sentry/tracingHooks.ts
@@ -30,10 +30,12 @@ export function registerTracingHooks(state: SentryRequestState) {
   api.hooks.web.beforeRequest((req, ctx) => {
     ctx.metadata.sentryPrevSuppressed =
       state.tracingSuppressedALS.getStore() === true;
+    ctx.metadata.sentryPrevSpan = state.spanALS.getStore();
     const actionName = matchWebActionName(req);
     if (!isActionTraced(actionName)) {
       ctx.metadata.sentryTracingSuppressed = true;
       state.tracingSuppressedALS.enterWith(true);
+      state.spanALS.enterWith(undefined);
       return;
     }
     // Jobs/requests are top-level: clear a flag left by a previous opted-out
@@ -88,6 +90,9 @@ export function registerTracingHooks(state: SentryRequestState) {
       }
       httpSpan.end();
     } finally {
+      state.spanALS.enterWith(
+        ctx.metadata.sentryPrevSpan as SentrySpan | undefined,
+      );
       state.tracingSuppressedALS.enterWith(
         ctx.metadata.sentryPrevSuppressed === true,
       );
@@ -352,6 +357,7 @@ export function registerTracingHooks(state: SentryRequestState) {
   api.hooks.resque.beforeJob((actionName, params, jobCtx) => {
     jobCtx.metadata.sentryPrevSuppressed =
       state.tracingSuppressedALS.getStore() === true;
+    jobCtx.metadata.sentryPrevSpan = state.spanALS.getStore();
     const p = params as Record<string, unknown>;
     const sentryTrace = p._sentryTrace as string | undefined;
     const baggage = p._sentryBaggage as string | undefined;
@@ -362,6 +368,7 @@ export function registerTracingHooks(state: SentryRequestState) {
 
     if (!isActionTraced(actionName)) {
       state.tracingSuppressedALS.enterWith(true);
+      state.spanALS.enterWith(undefined);
       return;
     }
     // See beforeRequest: traced jobs must not inherit a leaked suppress flag.
@@ -403,6 +410,9 @@ export function registerTracingHooks(state: SentryRequestState) {
       }
       jobSpan.end();
     } finally {
+      state.spanALS.enterWith(
+        jobCtx.metadata.sentryPrevSpan as SentrySpan | undefined,
+      );
       state.tracingSuppressedALS.enterWith(
         jobCtx.metadata.sentryPrevSuppressed === true,
       );

--- a/packages/plugins/tracing/initializer.ts
+++ b/packages/plugins/tracing/initializer.ts
@@ -207,7 +207,8 @@ export class TracingPlugin extends Initializer {
   private requestALS = new AsyncLocalStorage<RequestState>();
   /**
    * When true, new spans (Redis, Drizzle, nested work) are not recorded.
-   * Set for the duration of an action that opted out via `tracing = false`.
+   * Set at the request or job boundary for `tracing = false` and restored
+   * when that request / job finishes.
    */
   private tracingSuppressedALS = new AsyncLocalStorage<boolean>();
 
@@ -327,12 +328,17 @@ export class TracingPlugin extends Initializer {
     const tracing = api.tracing;
 
     api.hooks.web.beforeRequest((req, ctx) => {
+      ctx.metadata.otelPrevSuppressed =
+        this.tracingSuppressedALS.getStore() === true;
       const actionName = matchWebActionName(req);
       if (!isActionTraced(actionName)) {
         ctx.metadata.otelTracingSuppressed = true;
         this.tracingSuppressedALS.enterWith(true);
         return;
       }
+      // Traced requests must not inherit a leaked flag from a previous
+      // opted-out request/job on this async context.
+      this.tracingSuppressedALS.enterWith(false);
 
       const method = req.method?.toUpperCase() ?? "";
       const parentCtx = tracing.extractContext(req.headers);
@@ -357,24 +363,30 @@ export class TracingPlugin extends Initializer {
     });
 
     api.hooks.web.afterRequest((_req, _res, ctx, outcome) => {
-      if (ctx.metadata.otelTracingSuppressed) return;
-      const httpSpan = ctx.metadata.otelSpan as Span | undefined;
-      if (!httpSpan) return;
-      if (!isActionTraced(outcome.actionName)) {
-        // Don't export a transaction for an opted-out action. Leaving the
-        // span un-ended means the processor never sees it.
-        return;
+      try {
+        if (ctx.metadata.otelTracingSuppressed) return;
+        const httpSpan = ctx.metadata.otelSpan as Span | undefined;
+        if (!httpSpan) return;
+        if (!isActionTraced(outcome.actionName)) {
+          // Don't export a transaction for an opted-out action. Leaving the
+          // span un-ended means the processor never sees it.
+          return;
+        }
+        httpSpan.setAttribute("http.response.status_code", outcome.status);
+        if (outcome.actionName) {
+          httpSpan.setAttribute("http.route", outcome.actionName);
+        }
+        if (outcome.status >= 400) {
+          httpSpan.setStatus({ code: SpanStatusCode.ERROR });
+        } else {
+          httpSpan.setStatus({ code: SpanStatusCode.OK });
+        }
+        httpSpan.end();
+      } finally {
+        this.tracingSuppressedALS.enterWith(
+          ctx.metadata.otelPrevSuppressed === true,
+        );
       }
-      httpSpan.setAttribute("http.response.status_code", outcome.status);
-      if (outcome.actionName) {
-        httpSpan.setAttribute("http.route", outcome.actionName);
-      }
-      if (outcome.status >= 400) {
-        httpSpan.setStatus({ code: SpanStatusCode.ERROR });
-      } else {
-        httpSpan.setStatus({ code: SpanStatusCode.OK });
-      }
-      httpSpan.end();
     });
 
     api.hooks.actions.beforeAct((actionName, _params, connection, actCtx) => {
@@ -451,7 +463,9 @@ export class TracingPlugin extends Initializer {
       return next;
     });
 
-    api.hooks.resque.beforeJob((actionName, params, _ctx) => {
+    api.hooks.resque.beforeJob((actionName, params, jobCtx) => {
+      jobCtx.metadata.otelPrevSuppressed =
+        this.tracingSuppressedALS.getStore() === true;
       const p = params as Record<string, unknown>;
       const traceParent = p._traceParent as string | undefined;
       const traceState = p._traceState as string | undefined;
@@ -463,12 +477,19 @@ export class TracingPlugin extends Initializer {
         this.tracingSuppressedALS.enterWith(true);
         return;
       }
+      this.tracingSuppressedALS.enterWith(false);
       if (!traceParent) return;
       const headers = new Headers();
       headers.set("traceparent", traceParent);
       if (traceState) headers.set("tracestate", traceState);
       const extractedCtx = tracing.extractContext(headers);
       this.contextManager.enterWith(extractedCtx);
+    });
+
+    api.hooks.resque.afterJob((_actionName, _params, jobCtx) => {
+      this.tracingSuppressedALS.enterWith(
+        jobCtx.metadata.otelPrevSuppressed === true,
+      );
     });
   }
 

--- a/packages/plugins/tracing/initializer.ts
+++ b/packages/plugins/tracing/initializer.ts
@@ -397,7 +397,7 @@ export class TracingPlugin extends Initializer {
       const prevSuppressed = this.tracingSuppressedALS.getStore() === true;
       actCtx.metadata.otelPrevSuppressed = prevSuppressed;
 
-      if (!isActionTraced(actionName)) {
+      if (!isActionTraced(actionName) || prevSuppressed) {
         this.tracingSuppressedALS.enterWith(true);
         return;
       }

--- a/packages/plugins/tracing/initializer.ts
+++ b/packages/plugins/tracing/initializer.ts
@@ -2,9 +2,11 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import path from "node:path";
 import { instrumentDrizzleClient } from "@kubiks/otel-drizzle";
 import {
+  type Attributes,
   type Context,
   type ContextManager,
   context,
+  type Link,
   propagation,
   ROOT_CONTEXT,
   type Span,
@@ -19,10 +21,13 @@ import { resourceFromAttributes } from "@opentelemetry/resources";
 import {
   BasicTracerProvider,
   BatchSpanProcessor,
+  type Sampler,
+  SamplingDecision,
+  type SamplingResult,
   TraceIdRatioBasedSampler,
 } from "@opentelemetry/sdk-trace-base";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
-import { api, config, Initializer, logger } from "keryx";
+import { api, config, HTTP_METHOD, Initializer, logger } from "keryx";
 
 const namespace = "tracing";
 
@@ -40,6 +45,71 @@ declare module "keryx" {
 interface RequestState {
   httpSpan: Span;
   method: string;
+}
+
+/**
+ * True unless the named action set `tracing = false`. Unknown names stay traced.
+ */
+function isActionTraced(actionName: string | undefined): boolean {
+  if (!actionName) return true;
+  const action = api.actions.actions.find((a) => a.name === actionName);
+  return action?.tracing !== false;
+}
+
+/**
+ * Best-effort action name from an incoming HTTP request, used to skip the
+ * HTTP span before session/DB work runs.
+ */
+function matchWebActionName(req: Request): string | undefined {
+  try {
+    const pathname = new URL(req.url).pathname;
+    const pathToMatch = pathname.replace(
+      new RegExp(config.server.web.apiRoute),
+      "",
+    );
+    if (!pathToMatch) return undefined;
+    const method = (req.method?.toUpperCase() ?? "GET") as HTTP_METHOD;
+    return api.actions.router.match(pathToMatch, method)?.actionName;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Sampler that records nothing while an action with `tracing = false` is
+ * running, so Redis / Drizzle child spans don't leak as their own traces.
+ * Delegates to an inner sampler the rest of the time.
+ */
+class SuppressibleSampler implements Sampler {
+  constructor(
+    private inner: Sampler,
+    private isSuppressed: () => boolean,
+  ) {}
+
+  shouldSample(
+    context: Context,
+    traceId: string,
+    spanName: string,
+    spanKind: SpanKind,
+    attributes: Attributes,
+    links: Link[],
+  ): SamplingResult {
+    if (this.isSuppressed()) {
+      return { decision: SamplingDecision.NOT_RECORD };
+    }
+    return this.inner.shouldSample(
+      context,
+      traceId,
+      spanName,
+      spanKind,
+      attributes,
+      links,
+    );
+  }
+
+  toString(): string {
+    return `SuppressibleSampler(${this.inner.toString()})`;
+  }
 }
 
 /**
@@ -135,6 +205,11 @@ export class TracingPlugin extends Initializer {
    * calls with `context.with`.
    */
   private requestALS = new AsyncLocalStorage<RequestState>();
+  /**
+   * When true, new spans (Redis, Drizzle, nested work) are not recorded.
+   * Set for the duration of an action that opted out via `tracing = false`.
+   */
+  private tracingSuppressedALS = new AsyncLocalStorage<boolean>();
 
   constructor() {
     super(namespace);
@@ -189,7 +264,10 @@ export class TracingPlugin extends Initializer {
       url: `${config.tracing.otlpEndpoint}/v1/traces`,
     });
 
-    const sampler = new TraceIdRatioBasedSampler(config.tracing.sampleRate);
+    const sampler = new SuppressibleSampler(
+      new TraceIdRatioBasedSampler(config.tracing.sampleRate),
+      () => this.tracingSuppressedALS.getStore() === true,
+    );
 
     this.tracerProvider = new BasicTracerProvider({
       resource,
@@ -249,6 +327,13 @@ export class TracingPlugin extends Initializer {
     const tracing = api.tracing;
 
     api.hooks.web.beforeRequest((req, ctx) => {
+      const actionName = matchWebActionName(req);
+      if (!isActionTraced(actionName)) {
+        ctx.metadata.otelTracingSuppressed = true;
+        this.tracingSuppressedALS.enterWith(true);
+        return;
+      }
+
       const method = req.method?.toUpperCase() ?? "";
       const parentCtx = tracing.extractContext(req.headers);
       const httpSpan = tracing.tracer.startSpan(
@@ -272,8 +357,14 @@ export class TracingPlugin extends Initializer {
     });
 
     api.hooks.web.afterRequest((_req, _res, ctx, outcome) => {
+      if (ctx.metadata.otelTracingSuppressed) return;
       const httpSpan = ctx.metadata.otelSpan as Span | undefined;
       if (!httpSpan) return;
+      if (!isActionTraced(outcome.actionName)) {
+        // Don't export a transaction for an opted-out action. Leaving the
+        // span un-ended means the processor never sees it.
+        return;
+      }
       httpSpan.setAttribute("http.response.status_code", outcome.status);
       if (outcome.actionName) {
         httpSpan.setAttribute("http.route", outcome.actionName);
@@ -287,6 +378,14 @@ export class TracingPlugin extends Initializer {
     });
 
     api.hooks.actions.beforeAct((actionName, _params, connection, actCtx) => {
+      const prevSuppressed = this.tracingSuppressedALS.getStore() === true;
+      actCtx.metadata.otelPrevSuppressed = prevSuppressed;
+
+      if (!isActionTraced(actionName)) {
+        this.tracingSuppressedALS.enterWith(true);
+        return;
+      }
+
       const parentCtx = context.active();
 
       // For web requests, update the HTTP span's name with the resolved route
@@ -320,6 +419,9 @@ export class TracingPlugin extends Initializer {
 
     api.hooks.actions.afterAct(
       (_actionName, _params, _connection, actCtx, outcome) => {
+        this.tracingSuppressedALS.enterWith(
+          actCtx.metadata.otelPrevSuppressed === true,
+        );
         const span = actCtx.metadata.otelSpan as Span | undefined;
         if (!span) return;
         span.setAttribute("keryx.action.duration_ms", outcome.duration);
@@ -339,6 +441,7 @@ export class TracingPlugin extends Initializer {
 
     api.hooks.actions.onEnqueue((_actionName, inputs) => {
       if (!tracing.enabled) return;
+      if (this.tracingSuppressedALS.getStore()) return;
       const carrier: Record<string, string> = {};
       tracing.injectContext(carrier);
       if (!carrier.traceparent) return;
@@ -348,19 +451,23 @@ export class TracingPlugin extends Initializer {
       return next;
     });
 
-    api.hooks.resque.beforeJob((_actionName, params, _ctx) => {
+    api.hooks.resque.beforeJob((actionName, params, _ctx) => {
       const p = params as Record<string, unknown>;
       const traceParent = p._traceParent as string | undefined;
-      if (!traceParent) return;
       const traceState = p._traceState as string | undefined;
-      const headers = new Headers();
-      headers.set("traceparent", traceParent);
-      if (traceState) headers.set("tracestate", traceState);
-      const extractedCtx = tracing.extractContext(headers);
       // Strip internal framework trace-propagation fields so they don't leak
       // into the action's validated params.
       delete p._traceParent;
       delete p._traceState;
+      if (!isActionTraced(actionName)) {
+        this.tracingSuppressedALS.enterWith(true);
+        return;
+      }
+      if (!traceParent) return;
+      const headers = new Headers();
+      headers.set("traceparent", traceParent);
+      if (traceState) headers.set("tracestate", traceState);
+      const extractedCtx = tracing.extractContext(headers);
       this.contextManager.enterWith(extractedCtx);
     });
   }
@@ -383,9 +490,13 @@ export class TracingPlugin extends Initializer {
     if (!client) return;
     const tracer = api.tracing.tracer;
     const originalSendCommand = client.sendCommand.bind(client);
+    const isSuppressed = () => this.tracingSuppressedALS.getStore() === true;
     client.sendCommand = function (
       ...args: Parameters<typeof originalSendCommand>
     ) {
+      if (isSuppressed()) {
+        return originalSendCommand(...args);
+      }
       const [command] = args;
       const commandName = (command as { name?: string }).name ?? "unknown";
       const queryText = buildRedisQueryText(command, commandName);

--- a/packages/plugins/tracing/initializer.ts
+++ b/packages/plugins/tracing/initializer.ts
@@ -330,10 +330,12 @@ export class TracingPlugin extends Initializer {
     api.hooks.web.beforeRequest((req, ctx) => {
       ctx.metadata.otelPrevSuppressed =
         this.tracingSuppressedALS.getStore() === true;
+      ctx.metadata.otelPrevContext = context.active();
       const actionName = matchWebActionName(req);
       if (!isActionTraced(actionName)) {
         ctx.metadata.otelTracingSuppressed = true;
         this.tracingSuppressedALS.enterWith(true);
+        this.contextManager.enterWith(ROOT_CONTEXT);
         return;
       }
       // Traced requests must not inherit a leaked flag from a previous
@@ -383,6 +385,8 @@ export class TracingPlugin extends Initializer {
         }
         httpSpan.end();
       } finally {
+        const prevCtx = ctx.metadata.otelPrevContext as Context | undefined;
+        this.contextManager.enterWith(prevCtx ?? ROOT_CONTEXT);
         this.tracingSuppressedALS.enterWith(
           ctx.metadata.otelPrevSuppressed === true,
         );
@@ -466,6 +470,7 @@ export class TracingPlugin extends Initializer {
     api.hooks.resque.beforeJob((actionName, params, jobCtx) => {
       jobCtx.metadata.otelPrevSuppressed =
         this.tracingSuppressedALS.getStore() === true;
+      jobCtx.metadata.otelPrevContext = context.active();
       const p = params as Record<string, unknown>;
       const traceParent = p._traceParent as string | undefined;
       const traceState = p._traceState as string | undefined;
@@ -475,6 +480,7 @@ export class TracingPlugin extends Initializer {
       delete p._traceState;
       if (!isActionTraced(actionName)) {
         this.tracingSuppressedALS.enterWith(true);
+        this.contextManager.enterWith(ROOT_CONTEXT);
         return;
       }
       this.tracingSuppressedALS.enterWith(false);
@@ -487,6 +493,8 @@ export class TracingPlugin extends Initializer {
     });
 
     api.hooks.resque.afterJob((_actionName, _params, jobCtx) => {
+      const prevCtx = jobCtx.metadata.otelPrevContext as Context | undefined;
+      this.contextManager.enterWith(prevCtx ?? ROOT_CONTEXT);
       this.tracingSuppressedALS.enterWith(
         jobCtx.metadata.otelPrevSuppressed === true,
       );
@@ -516,6 +524,9 @@ export class TracingPlugin extends Initializer {
       ...args: Parameters<typeof originalSendCommand>
     ) {
       if (isSuppressed()) {
+        return originalSendCommand(...args);
+      }
+      if (!trace.getSpan(context.active())) {
         return originalSendCommand(...args);
       }
       const [command] = args;

--- a/packages/plugins/tracing/package.json
+++ b/packages/plugins/tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keryxjs/tracing",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "module": "index.ts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add optional `Action.tracing` (`false` opts out; unset stays traced) so health checks and similar actions skip distributed traces.
- Honor the opt-out in `@keryxjs/sentry` and `@keryxjs/tracing`: no action/HTTP/task/Redis/Postgres spans, while metrics and error capture still run.
- Default `tracing = false` on the built-in and example `status` actions, with docs and tests.

## Test plan
- [ ] `bun test-package` (or `packages/keryx/__tests__/classes/Action.test.ts`) covers default vs `tracing: false`
- [ ] `bun test-plugin-sentry` — traced actions still emit HTTP/action/Redis spans; `/api/status` still records metrics without those spans
- [ ] `bun test-plugin-tracing` plus `example/backend/__tests__/initializers/tracing.test.ts` — `/api/status` has no `GET status` / `action:status` / `redis.ping`; `/api/tracing-ping` still traces
- [ ] Docs: `docs/guide/actions.md` “Opting Out of Tracing”, plus sentry/tracing plugin pages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ebe033f-fd68-4822-a5d4-7e8d66a100da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ebe033f-fd68-4822-a5d4-7e8d66a100da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

